### PR TITLE
Allow either clang or LLVM to trigger builds

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -14,10 +14,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import json
+import multiprocessing
 import os
 import shutil
 import sys
-import multiprocessing
 import urllib2
 
 import assemble_files
@@ -94,14 +95,23 @@ OCAML_BIN_DIR = os.path.join(OCAML_OUT_DIR, 'bin')
 
 NPROC = multiprocessing.cpu_count()
 
-# Try to use the LLVM revision provided by buildbot.
-LLVM_REVISION = os.environ.get('BUILDBOT_REVISION', 'None')
-if LLVM_REVISION == 'None':
-  LLVM_REVISION = 'origin/master'
+# Schedulers which can kick off new builds, from:
+# https://chromium.googlesource.com/chromium/tools/build/+/master/masters/master.client.wasm.llvm/builders.pyl
+SCHEDULERS = {
+    'llvm_commits': 'llvm',
+    'clang_commits': 'clang'
+}
+
+# Buildbot-provided environment.
+BUILDBOT_SCHEDULER = os.environ.get('BUILDBOT_SCHEDULER', None)
+SCHEDULER = SCHEDULERS[BUILDBOT_SCHEDULER]
+BUILDBOT_REVISION = os.environ.get('BUILDBOT_REVISION', None)
+BUILDBOT_BUILDNUMBER = os.environ.get('BUILDBOT_BUILDNUMBER', None)
 
 # Pin the GCC revision so that new torture tests don't break the bot. This
 # should be manually updated when convenient.
 GCC_REVISION = 'b6125c702850488ac3bfb1079ae5c9db89989406'
+GCC_CLONE_DEPTH = 1000
 
 
 # Magic annotations:
@@ -160,7 +170,6 @@ def Tar(directory):
   (up_directory, basename) = os.path.split(directory)
   tar = os.path.join(up_directory, basename + '.tbz2')
   Remove(tar)
-  print 'Creating %s from %s/%s' % (tar, up_directory, basename)
   proc.check_call(['tar', 'cjf', tar, basename], cwd=up_directory)
   return tar
 
@@ -170,7 +179,6 @@ def UploadToCloud(local, remote, link_name):
   if not os.environ.get('BUILDBOT_BUILDERNAME'):
     return
   remote = CLOUD_STORAGE_PATH + remote
-  print 'Uploading %s to %s' % (local, remote)
   proc.check_call(
       ['gsutil', 'cp', '-a', 'public-read', local, 'gs://' + remote])
   StepLink(link_name, CLOUD_STORAGE_BASE_URL + remote)
@@ -182,7 +190,6 @@ def CopyCloudStorage(copy_from, copy_to, link_name):
     return
   copy_from = CLOUD_STORAGE_PATH + copy_from
   copy_to = CLOUD_STORAGE_PATH + copy_to
-  print 'Copying %s to %s' % (copy_from, copy_to)
   proc.check_call(
       ['gsutil', 'cp', '-a', 'public-read',
        'gs://' + copy_from, 'gs://' + copy_to])
@@ -193,8 +200,7 @@ def Archive(name, tar):
   """Archive the tar file with the given name, and with the LLVM git hash."""
   if not os.environ.get('BUILDBOT_BUILDERNAME'):
     return
-  print 'Archiving %s: %s' % (name, tar)
-  git_gs = 'git/wasm-%s-%s.tbz2' % (name, LLVM_REVISION)
+  git_gs = 'git/wasm-%s-%s-%s.tbz2' % (name, SCHEDULER, BUILDBOT_REVISION)
   UploadToCloud(tar, git_gs, 'download')
 
 
@@ -228,19 +234,38 @@ def AddGithubRemote(cwd):
                   cwd=cwd)
 
 
-def GitCloneFetchCheckout(name, work_dir, git_repo, checkout='origin/master'):
+def CurrentGitInfo(cwd):
+  def pretty(fmt):
+    return proc.check_output(
+        ['git', 'log', '-n1', '--pretty=format:%s' % fmt], cwd=cwd).strip()
+  remote = proc.check_output(['git', 'config', '--get', 'remote.origin.url'],
+                             cwd=cwd).strip()
+  return {
+      'hash': pretty('%H'),
+      'name': pretty('%aN'),
+      'email': pretty('%ae'),
+      'subject': pretty('%s'),
+      'remote': remote,
+  }
+
+
+def GitCloneFetchCheckout(name, work_dir, git_repo, rebase_master=False,
+                          checkout='origin/master', depth=None):
   """Clone a git repo if not already cloned, then fetch and checkout."""
   if os.path.isdir(work_dir):
     print '%s directory already exists' % name
   else:
-    print 'Cloning %s from %s into %s' % (name, git_repo, work_dir)
-    proc.check_call(['git', 'clone', git_repo, work_dir])
-  print 'Syncing %s' % name
+    clone = ['git', 'clone', git_repo, work_dir]
+    if depth:
+      clone.append('--depth')
+      clone.append(str(depth))
+    proc.check_call(clone)
+    if rebase_master:
+      GitConfigRebaseMaster(work_dir)
   proc.check_call(['git', 'fetch'], cwd=work_dir)
-  print 'Checking out %s' % checkout
   proc.check_call(['git', 'checkout', checkout], cwd=work_dir)
-  PrintCurrentGitRev(work_dir)
   AddGithubRemote(work_dir)
+  return (name, work_dir)
 
 
 def GitConfigRebaseMaster(cwd):
@@ -253,16 +278,12 @@ def GitConfigRebaseMaster(cwd):
       ['git', 'config', 'branch.master.rebase', 'true'], cwd=cwd)
 
 
-def PrintCurrentGitRev(cwd):
-  log = proc.check_output(
-      ['git', 'log', '--oneline', '-n1'], cwd=cwd).strip()
-  remote = proc.check_output(
-      ['git', 'config', '--get', 'remote.origin.url'], cwd=cwd).strip()
-  sys.stdout.write('%s from remote %s is at revision %s\n' %
-                   (cwd, remote, log))
+def CurrentSvnRev(path):
+  return int(proc.check_output(
+      ['git', 'svn', 'find-rev', 'HEAD'], cwd=path).strip())
 
 
-def FindPriorRev(path, goal):
+def FindPriorSvnRev(path, goal):
   revs = proc.check_output(
       ['git', 'rev-list', 'origin/master'], cwd=path).splitlines()
   for rev in revs:
@@ -270,33 +291,31 @@ def FindPriorRev(path, goal):
         ['git', 'svn', 'find-rev', rev], cwd=path).strip()
     if int(num) <= goal:
       return rev
-  raise Exception('Cannot find clang rev at or before %d' % goal)
+  raise Exception('Cannot find svn rev at or before %d' % goal)
+
+
+def SyncToSameSvnRev(primary, secondary):
+    """Use primary's SVN rev to figure out which rev secondary goes to."""
+    primary_svn_rev = CurrentSvnRev(primary)
+    print 'SVN REV for %s: %d' % (primary, primary_svn_rev)
+    print 'Finding prior %s rev' % secondary
+    prior_rev = FindPriorSvnRev(secondary, primary_svn_rev)
+    print 'Checking out %s rev: %s' % (secondary, prior_rev)
+    proc.check_call(['git', 'checkout', prior_rev], cwd=secondary)
 
 
 def SyncLLVMClang():
-  if os.path.isdir(LLVM_SRC_DIR):
-    assert os.path.isdir(CLANG_SRC_DIR), 'Assuming LLVM implies Clang'
-    print 'LLVM and Clang directories already exist'
-  else:
-    print 'Cloning LLVM and Clang'
-    proc.check_call(['git', 'clone', LLVM_GIT, LLVM_SRC_DIR])
-    GitConfigRebaseMaster(LLVM_SRC_DIR)
-    proc.check_call(['git', 'clone', CLANG_GIT, CLANG_SRC_DIR])
-    GitConfigRebaseMaster(CLANG_SRC_DIR)
-  print 'Syncing LLVM'
-  proc.check_call(['git', 'fetch'], cwd=LLVM_SRC_DIR)
-  proc.check_call(['git', 'checkout', LLVM_REVISION], cwd=LLVM_SRC_DIR)
-  print 'Getting SVN rev'
-  llvm_svn_rev = int(proc.check_output(
-      ['git', 'svn', 'find-rev', 'HEAD'], cwd=LLVM_SRC_DIR).strip())
-  print 'SVN REV: %d' % llvm_svn_rev
-  print 'Finding prior Clang rev'
-  proc.check_call(['git', 'fetch'], cwd=CLANG_SRC_DIR)
-  prior_rev = FindPriorRev(CLANG_SRC_DIR, llvm_svn_rev)
-  print 'Checking out Clang rev: %s' % prior_rev
-  proc.check_call(['git', 'checkout', prior_rev], cwd=CLANG_SRC_DIR)
-  PrintCurrentGitRev(LLVM_SRC_DIR)
-  PrintCurrentGitRev(CLANG_SRC_DIR)
+  llvm_rev = BUILDBOT_REVISION if SCHEDULER == 'llvm' else 'origin/master'
+  clang_rev = BUILDBOT_REVISION if SCHEDULER == 'clang' else 'origin/master'
+  proc.check_call(['git', 'checkout', llvm_rev], cwd=LLVM_SRC_DIR)
+  proc.check_call(['git', 'checkout', clang_rev], cwd=CLANG_SRC_DIR)
+  # If LLVM didn't trigger the new build then sync LLVM to the corresponding
+  # clang revision, even if clang may not have triggered the build: usually
+  # LLVM provides APIs which clang uses, which means that most synchronized
+  # commits touch LLVM before clang. This should reduce the chance of breakage.
+  primary = LLVM_SRC_DIR if SCHEDULER == 'llvm' else CLANG_SRC_DIR
+  secondary = LLVM_SRC_DIR if primary == CLANG_SRC_DIR else CLANG_SRC_DIR
+  SyncToSameSvnRev(primary, secondary)
 
 
 def SyncPrebuiltClang():
@@ -308,14 +327,12 @@ def SyncPrebuiltClang():
     Mkdir(PREBUILT_CLANG_TOOLS)
     proc.check_call(
         ['git', 'clone', PREBUILT_CLANG_GIT, PREBUILT_CLANG_TOOLS_CLANG])
-  print 'Syncing Prebuilt Chromium Clang scripts'
   proc.check_call(['git', 'fetch'], cwd=PREBUILT_CLANG_TOOLS_CLANG)
-  print 'Syncing Prebuilt Chromium Clang'
   proc.check_call(
       [os.path.join(PREBUILT_CLANG_TOOLS_CLANG, 'scripts', 'update.py')])
   assert os.path.isfile(CC), 'Expect clang at %s' % CC
   assert os.path.isfile(CXX), 'Expect clang++ at %s' % CXX
-  PrintCurrentGitRev(PREBUILT_CLANG_TOOLS_CLANG)
+  return ('chromium-clang', PREBUILT_CLANG_TOOLS_CLANG)
 
 
 def SyncOCaml():
@@ -328,7 +345,6 @@ def SyncOCaml():
     print 'Info: %s' % f.info()
     with open(OCAML_TAR, 'wb') as out:
       out.write(f.read())
-    print 'Download done, untar %s' % OCAML_TAR
     proc.check_call(['tar', '-xvf', OCAML_TAR], cwd=WORK_DIR)
     assert os.path.isdir(OCAML_DIR), 'Untar should produce %s' % OCAML_DIR
 
@@ -337,28 +353,39 @@ def Clobber():
   if os.environ.get('BUILDBOT_CLOBBER'):
     BuildStep('Clobbering work dir')
     if os.path.isdir(WORK_DIR):
-      print 'Removing %s' % WORK_DIR
       shutil.rmtree(WORK_DIR)
 
 
 def SyncRepos():
   BuildStep('Sync Repos')
-  PrintCurrentGitRev(SCRIPT_DIR)
+  repos = [
+      ('waterfall', SCRIPT_DIR),
+      GitCloneFetchCheckout(name='llvm', work_dir=LLVM_SRC_DIR,
+                            git_repo=LLVM_GIT),
+      GitCloneFetchCheckout(name='clang', work_dir=CLANG_SRC_DIR,
+                            git_repo=CLANG_GIT),
+      GitCloneFetchCheckout(name='gcc', work_dir=GCC_SRC_DIR, git_repo=GCC_GIT,
+                            checkout=GCC_REVISION, depth=GCC_CLONE_DEPTH),
+      SyncPrebuiltClang(),
+      GitCloneFetchCheckout(name='sexpr', work_dir=SEXPR_SRC_DIR,
+                            git_repo=SEXPR_GIT),
+      GitCloneFetchCheckout(name='spec', work_dir=SPEC_SRC_DIR,
+                            git_repo=SPEC_GIT),
+      GitCloneFetchCheckout(name='binaryen', work_dir=BINARYEN_SRC_DIR,
+                            git_repo=BINARYEN_GIT)
+  ]
   SyncLLVMClang()
-  GitCloneFetchCheckout(name='GCC', work_dir=GCC_SRC_DIR, git_repo=GCC_GIT,
-                        checkout=GCC_REVISION)
-  SyncPrebuiltClang()
-  GitCloneFetchCheckout(name='sexpr', work_dir=SEXPR_SRC_DIR,
-                        git_repo=SEXPR_GIT)
   SyncOCaml()
-  GitCloneFetchCheckout(name='spec', work_dir=SPEC_SRC_DIR, git_repo=SPEC_GIT)
-  GitCloneFetchCheckout(name='binaryen', work_dir=BINARYEN_SRC_DIR,
-                        git_repo=BINARYEN_GIT)
+  # Keep track of all repo information here, preventing the summary from
+  # getting out of sync with the actual list of repos.
+  info = {}
+  for r in repos:
+    info[r[0]] = CurrentGitInfo(r[1])
+  return info
 
 
 def BuildLLVM():
   BuildStep('Build LLVM')
-  print 'Running cmake on llvm'
   Mkdir(LLVM_OUT_DIR)
   proc.check_call(
       ['cmake', '-G', 'Ninja', LLVM_SRC_DIR,
@@ -371,7 +398,6 @@ def BuildLLVM():
        '-DLLVM_ENABLE_ASSERTIONS=ON',
        '-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly',
        '-DLLVM_TARGETS_TO_BUILD=X86'], cwd=LLVM_OUT_DIR)
-  print 'Running ninja'
   proc.check_call(['ninja'], cwd=LLVM_OUT_DIR)
 
 
@@ -430,7 +456,6 @@ def BuildBinaryen():
        '-DCMAKE_C_COMPILER=' + CC,
        '-DCMAKE_CXX_COMPILER=' + CXX],
       cwd=BINARYEN_OUT_DIR)
-  print 'Running ninja'
   proc.check_call(['ninja'], cwd=BINARYEN_OUT_DIR)
   assert os.path.isdir(BINARYEN_BIN_DIR), 'Expected %s' % BINARYEN_BIN_DIR
   for node in os.listdir(BINARYEN_BIN_DIR):
@@ -440,8 +465,6 @@ def BuildBinaryen():
 
 
 def ArchiveBinaries():
-  if LLVM_REVISION == 'origin/master':
-    return
   BuildStep('Archive binaries')
   # All relevant binaries were copied to the LLVM directory.
   Archive('binaries', Tar(LLVM_INSTALL_DIR))
@@ -496,28 +519,29 @@ def AssembleLLVMTorture(name, assembler, indir, fails):
   return out
 
 
-def Summary():
+def Summary(repos):
   BuildStep('Summary')
   sys.stdout.write('Failed steps: %s.' % failed_steps)
+  info = {'repositories': repos}
+  info['build'] = BUILDBOT_BUILDNUMBER
+  info['scheduler'] = SCHEDULER
+  info_json = json.dumps(info)
   with open('latest', 'w+') as f:
-    f.write(str(LLVM_REVISION))
+    f.write(info_json)
   UploadToCloud('latest', 'git/latest', 'latest')
   if failed_steps:
     StepFail()
   else:
-    try:
-      with open('lkgr', 'w+') as f:
-        f.write(str(LLVM_REVISION))
-      UploadToCloud('lkgr', 'git/lkgr', 'lkgr')
-    finally:
-      Remove('lkgr')
+    with open('lkgr', 'w+') as f:
+      f.write(info_json)
+    UploadToCloud('lkgr', 'git/lkgr', 'lkgr')
 
 
 def main():
   Clobber()
   Chdir(SCRIPT_DIR)
   Mkdir(WORK_DIR)
-  SyncRepos()
+  repos = SyncRepos()
   BuildLLVM()
   TestLLVM()
   InstallLLVM()
@@ -538,7 +562,7 @@ def main():
       fails=SEXPR_S2WASM_KNOWN_TORTURE_FAILURES)
   # Keep the summary step last: it'll be marked as red if the return code is
   # non-zero. Individual steps are marked as red with StepFail().
-  Summary()
+  Summary(repos)
   return failed_steps
 
 


### PR DESCRIPTION
This is required to support: https://codereview.chromium.org/1577943002/

Eventually we'll want other repositories to also be able to trigger builds. Maybe the lastest and lkgr files should also contain all the hashes that they've checked out, not just the one from BUILDBOT_REVISION. With that the build could use lkgr to only trigger on one repository, and keep all other repositories at lkgr (so they don't all float).

The output is now json, and contains information on all the repos as well as the build number and what schedule triggered the build. The archives are now named based on build number.

The following binaryen patch teaches binaryen this new format:
  WebAssembly/binaryen@9a3a2cb