### PR TITLE
Revert "Build V8"

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -563,7 +563,6 @@ def main():
   BuildLLVM()
   TestLLVM()
   InstallLLVM()
-  BuildV8()
   BuildSexpr()
   BuildOCaml()
   BuildSpec()


### PR DESCRIPTION
Reverts WebAssembly/waterfall#11

Gyp isn't available it looks like. I'll investigate and fix later.
```
Traceback (most recent call last):
  File "build/gyp_v8", line 35, in <module>
    import gyp_environment
  File "/b/build/slave/linux/build/src/src/work/v8/build/gyp_environment.py", line 13, in <module>
    import vs_toolchain
  File "/b/build/slave/linux/build/src/src/work/v8/build/vs_toolchain.py", line 24, in <module>
    import gyp
ImportError: No module named gyp
Traceback (most recent call last):
  File "/b/build/slave/linux/build/src/src/build.py", line 589, in <module>
    sys.exit(main())
  File "/b/build/slave/linux/build/src/src/build.py", line 566, in main
    BuildV8()
  File "/b/build/slave/linux/build/src/src/build.py", line 425, in BuildV8
    proc.check_call(['build/gyp_v8'], cwd=V8_SRC_DIR)
  File "/b/build/slave/linux/build/src/src/proc.py", line 34, in check_call
    return subprocess.check_call(cmd, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['build/gyp_v8']' returned non-zero exit status 1
```