### PR TITLE
Switch the asm2wasm tests to use V8's native wasm support

### DIFF
--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -26,7 +26,12 @@ CFLAGS_COMMON = ['--std=gnu89', '-DSTACK_SIZE=1044480',
                  '-w', '-Wno-implicit-function-declaration']
 CFLAGS_EXTRA = {
     'wasm': ['--target=wasm32-unknown-unknown', '-S', '-O2'],
-    'asm2wasm': ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="wasm-s-parser"'],
+    # Binaryen's native-wasm method uses the JS engine's native support for
+    # wasm rather than interpreting the wasm with wasm.js.
+    # There is also 'wasm-binary'; it uses binaryen's binary format, which
+    # may not match v8's format exactly. So we just generate the wast with
+    # emcc and use sexpr-wasm to generate the binary.
+    'asm2wasm': ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'],
 }
 
 
@@ -35,16 +40,29 @@ def c_compile(infile, outfile, extras):
   return [extras['c'], infile, '-o', outfile] + extras['cflags']
 
 
+def sexpr(infile, outfile, extras):
+  """Create the command line for a sexpr-wasm invocation."""
+  return [extras['sexpr'], infile, '-o', outfile]
+
+
+def mv(infile, outfile, extras):
+  return ['mv', infile, outfile]
+
+
 class Outname:
   """Create the output file's name. A local function passed to testing.execute
   would be simpler, but it fails to pickle when the test driver calls pool.map.
   So we manually package the suffix in a class.
   """
-  def __init__(self, suffix):
+  def __init__(self, suffix, strip_suffix=None):
     self.suffix = suffix
+    self.strip_suffix = strip_suffix
 
   def __call__(self, outdir, infile):
     basename = os.path.basename(infile)
+    if self.strip_suffix:
+      assert basename.endswith(self.strip_suffix)
+      basename = basename[:-len(self.strip_suffix)]
     outname = basename + self.suffix
     return os.path.join(outdir, outname)
 
@@ -63,7 +81,7 @@ def run(c, cxx, testsuite, fails, out, config='wasm'):
   cflags = CFLAGS_COMMON + CFLAGS_EXTRA[config]
   suffix = '.s' if config == 'wasm' else '.js'
 
-  return testing.execute(
+  result = testing.execute(
       tester=testing.Tester(
           command_ctor=c_compile,
           outname_ctor=Outname(suffix),
@@ -71,6 +89,36 @@ def run(c, cxx, testsuite, fails, out, config='wasm'):
           extras={'c': c, 'cflags': cflags}),
       inputs=c_test_files,
       fails=fails)
+
+  if config != 'asm2wasm':
+    return result
+
+  # Encode Binaryen's wast using sexpr-wasm (this means that v8's binary format
+  # doesn't have to exactly match SM/Binaryen)
+  testing.execute(
+      tester=testing.Tester(
+          command_ctor=sexpr,
+          outname_ctor=Outname('.wasm', strip_suffix='.wast'),
+          outdir=out,
+          extras={'sexpr': os.path.join(
+              os.path.dirname(os.path.dirname(c)), 'sexpr-wasm')}),
+      inputs=[Outname('.wast')(out, f) for f in c_test_files],
+      fails=None)
+
+  # If emcc doesn't generate a foo.wasm binary, it assumes the browser will
+  # consume the wast file and names the globals file accordingly. We manually
+  # encode the wasm file, so rename <test>.wast.mappedGlobals to
+  # <test>.wasm.mappedGlobals so the emscripten JS glue can find it.
+  testing.execute(
+      tester=testing.Tester(
+          command_ctor=mv,
+          outname_ctor=Outname('.wasm.mappedGlobals',
+                               strip_suffix='.wast.mappedGlobals'),
+          outdir=out,
+          extras=None),
+      inputs=[Outname('.wast.mappedGlobals')(out, f) for f in c_test_files],
+      fails=None)
+  return result
 
 
 def getargs():

--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -43,7 +43,7 @@ def execute(infile, outfile, extras):
       'binaryen-shell': [runner, '--entry=main', infile] + out_opt,
       'd8-wasm': [runner, '--expose-wasm'] + wasmjs + [
           '--', infile] + extra_files,
-      'd8-asm2wasm': [runner, infile],
+      'd8-asm2wasm': [runner, '--expose-wasm', infile],
       'wasm.opt': [runner, infile]
   }
   return commands[config]

--- a/src/test/asm2wasm_run_known_gcc_test_failures.txt
+++ b/src/test/asm2wasm_run_known_gcc_test_failures.txt
@@ -1,11 +1,9 @@
-# Expected failures from running torture tests from emcc/binaryen with wasm.js
-# (which currently interprets the wast rather than executing it in d8)
+# Expected failures from running torture tests from emcc/binaryen with asm2wasm
+# and native Wasm support in v8
 
 	20010122-1.c.js
-	20011008-3.c.js
 	20030222-1.c.js
 	20031003-1.c.js
-	20040811-1.c.js
 	20050316-2.c.js
 	20050604-1.c.js
 	20050607-1.c.js
@@ -16,16 +14,12 @@
 	20071220-2.c.js
 	20101011-1.c.js
 	alloca-1.c.js
-	arith-rand-ll.c.js
 	bitfld-3.c.js
 	bitfld-5.c.js
 	builtin-bitops-1.c.js
 	conversion.c.js
 	eeprof-1.c.js
 	frame-address.c.js
-	memcpy-1.c.js
-	memcpy-2.c.js
-	nestfunc-4.c.js
 	pr17377.c.js
 	pr32244-1.c.js
 	pr34971.c.js
@@ -34,7 +28,6 @@
 	pr39228.c.js
 	pr41239.c.js
 	pr43008.c.js
-	pr43220.c.js
 	pr47237.c.js
 	pr49279.c.js
 	pr53645-2.c.js
@@ -45,8 +38,4 @@
 	simd-4.c.js
 	simd-5.c.js
 	simd-6.c.js
-	strcmp-1.c.js
-	strcpy-1.c.js
-	strncmp-1.c.js
 	va-arg-pack-1.c.js
-	vla-dealloc-1.c.js

--- a/src/testing.py
+++ b/src/testing.py
@@ -182,7 +182,7 @@ def similarity(results, cutoff):
 
 def execute(tester, inputs, fails):
   """Execute tests in parallel, output results, return failure count."""
-  input_expected_failures = get_expected_failures(fails)
+  input_expected_failures = get_expected_failures(fails) if fails else []
   pool = multiprocessing.Pool()
   sys.stdout.write('Executing tests.')
   results = sorted(pool.map(tester, inputs))
@@ -191,6 +191,8 @@ def execute(tester, inputs, fails):
   sys.stdout.write('\nDone.')
   successes = [r for r in results if r]
   failures = [r for r in results if not r]
+  if not fails:
+    return failures
   expected_failures = [t for t in failures
                        if t.test in input_expected_failures]
   unexpected_failures = [t for t in failures


### PR DESCRIPTION
Previously the asm2wasm tests used the binaryen interpreter compiled
into wasm.js. Now we use Binaryen's native-wasm method to use V8
directly. However we still use sexpr-wasm to encode the binary, so that
Binaryen's binary format need not match V8's.