### PR TITLE
Display the list of sync and build targets in help

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -829,14 +829,28 @@ def BuildRepos(filter=None):
 
 def ParseArgs():
   import argparse
+  import textwrap
 
   def SplitComma(arg):
     if not arg:
       return None
     return arg.split(',')
 
+  def TextWrapNameList(prefix, items):
+    width = 80  # TODO(binji): better guess?
+    names = sorted(item.name for item in items)
+    return '%s%s' % (prefix, textwrap.fill(' '.join(names), width,
+                                           initial_indent='  ',
+                                           subsequent_indent='  '))
+
+  epilog = (
+      TextWrapNameList('sync targets:\n', ALL_SOURCES) + '\n\n' +
+      TextWrapNameList('build targets:\n', ALL_BUILDS))
+
   parser = argparse.ArgumentParser(
-      description='Wasm waterfall top-level CI script')
+      description='Wasm waterfall top-level CI script',
+      formatter_class=argparse.RawDescriptionHelpFormatter,
+      epilog=epilog)
   sync_grp = parser.add_mutually_exclusive_group()
   sync_grp.add_argument('--no-sync', dest='sync',
                         default=True, action='store_false',


### PR DESCRIPTION
This looks like:
```
sync targets:
  binaryen chromium-clang clang emscripten fastcomp fastcomp-clang gcc llvm
  llvm-test-suite musl sexpr spec v8 waterfall

build targets:
  archive binaryen emscripten fastcomp llvm musl ocaml sexpr spec v8
```