### PR TITLE
Add emscripten vanilla configuration

### DIFF
--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -31,7 +31,7 @@ CFLAGS_EXTRA = {
     # There is also 'wasm-binary'; it uses binaryen's binary format, which
     # may not match v8's format exactly. So we just generate the wast with
     # emcc and use sexpr-wasm to generate the binary.
-    'asm2wasm': ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'],
+    'binaryen': ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'],
 }
 
 
@@ -90,7 +90,7 @@ def run(c, cxx, testsuite, fails, out, config='wasm'):
       inputs=c_test_files,
       fails=fails)
 
-  if config != 'asm2wasm':
+  if config != 'binaryen':
     return result
 
   # Encode Binaryen's wast using sexpr-wasm (this means that v8's binary format

--- a/src/emscripten_config_vanilla
+++ b/src/emscripten_config_vanilla
@@ -1,0 +1,64 @@
+
+# Note: If you put paths relative to the home directory, do not forget os.path.expanduser
+
+# Note: On Windows, remember to escape backslashes! I.e. EMSCRIPTEN_ROOT='c:\emscripten\' is not valid, but EMSCRIPTEN_ROOT='c:\\emscripten\\' and EMSCRIPTEN_ROOT='c:/emscripten/' are.
+
+import os
+
+# This file is loaded from emscripten/tools/shared.py. There seems to be no
+# reasonable way to get a hermetic relocatable setup, other than some kind of
+# hack like this.
+WASM_INSTALL = os.path.dirname(
+                 os.path.dirname(
+                   os.path.dirname(
+                     os.path.dirname(__file__))))
+
+# this helps projects using emscripten find it
+EMSCRIPTEN_ROOT = os.path.join(WASM_INSTALL, 'bin', 'emscripten') # directory
+LLVM_ROOT = os.path.join(WASM_INSTALL, 'bin') # directory
+BINARYEN_ROOT = os.path.join(WASM_INSTALL) # directory
+
+# If not specified, defaults to sys.executable.
+#PYTHON = 'python'
+
+# Add this if you have manually built the JS optimizer executable (in Emscripten/tools/optimizer) and want to run it from a custom location.
+# Alternatively, you can set this as the environment variable EMSCRIPTEN_NATIVE_OPTIMIZER.
+# EMSCRIPTEN_NATIVE_OPTIMIZER='/path/to/custom/optimizer(.exe)'
+
+# See below for notes on which JS engine(s) you need
+NODE_JS = os.path.expanduser(os.getenv('NODE') or '/usr/bin/nodejs') # executable
+SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY') or 'js')] # executable
+V8_ENGINE = os.path.join(WASM_INSTALL, 'bin', 'd8') # executable
+
+JAVA = 'java' # executable
+
+TEMP_DIR = '/tmp'
+
+CRUNCH = os.path.expanduser(os.getenv('CRUNCH') or 'crunch') # executable
+
+#CLOSURE_COMPILER = '..' # define this to not use the bundled version
+
+########################################################################################################
+
+
+# Pick the JS engine to use for running the compiler. This engine must exist, or
+# nothing can be compiled.
+#
+# Recommendation: If you already have node installed, use that. Otherwise, build v8 or
+#                 spidermonkey from source. Any of these three is fine, as long as it's
+#                 a recent version (especially for v8 and spidermonkey).
+
+#COMPILER_ENGINE = NODE_JS
+COMPILER_ENGINE = V8_ENGINE
+#COMPILER_ENGINE = SPIDERMONKEY_ENGINE
+
+
+# All JS engines to use when running the automatic tests. Not all the engines in this list
+# must exist (if they don't, they will be skipped in the test runner).
+#
+# Recommendation: If you already have node installed, use that. If you can, also build
+#                 spidermonkey from source as well to get more test coverage (node can't
+#                 run all the tests due to node issue 1669). v8 is currently not recommended
+#                 here because of v8 issue 1822.
+
+JS_ENGINES = [V8_ENGINE] # add this if you have spidermonkey installed too, SPIDERMONKEY_ENGINE]

--- a/src/test/emwasm_compile_known_gcc_test_failures.txt
+++ b/src/test/emwasm_compile_known_gcc_test_failures.txt
@@ -1,0 +1,74 @@
+# Fails with direct LLVM wasm backend (no emcc)
+	20000822-1.c
+	20010209-1.c
+	20010605-1.c
+	20020412-1.c
+	20030501-1.c
+	20040308-1.c
+	20040423-1.c
+	20040520-1.c
+	20041218-2.c
+	20061220-1.c
+	20070919-1.c
+	20090219-1.c
+	920302-1.c
+	920415-1.c
+	920428-2.c
+	920501-3.c
+	920501-7.c
+	920612-2.c
+	920721-4.c
+	920728-1.c
+	921017-1.c
+	921215-1.c
+	931002-1.c
+	990413-2.c
+	align-nest.c
+	built-in-setjmp.c
+	comp-goto-2.c
+	nest-align-1.c
+	nest-stdar-1.c
+	nestfunc-1.c
+	nestfunc-2.c
+	nestfunc-3.c
+	nestfunc-5.c
+	nestfunc-6.c
+	nestfunc-7.c
+	pr22061-3.c
+	pr22061-4.c
+	pr24135.c
+	pr28865.c
+	pr41935.c
+	pr51447.c
+	pr60003.c
+	scal-to-vec1.c
+	scal-to-vec2.c
+	scal-to-vec3.c
+
+
+# Works with LLVM wasm backend (but fails with emcc)
+	20021127-1.c
+	20030125-1.c
+	20090711-1.c
+	960909-1.c
+	980701-1.c
+	cbrt.c
+
+# Additional failures with BINARYEN=1
+	20071220-1.c
+	20071220-2.c
+
+# Works with asm2wasm
+	20010122-1.c
+	20030913-1.c
+	20040302-1.c
+	20041214-1.c
+	20071210-1.c
+	920501-4.c
+	920501-5.c
+	941014-1.c
+	960218-1.c
+	980526-1.c
+	comp-goto-1.c
+	pr17377.c
+	pr54937.c

--- a/src/test/emwasm_run_known_gcc_test_failures.txt
+++ b/src/test/emwasm_run_known_gcc_test_failures.txt
@@ -1,0 +1,87 @@
+# Expected failures from running torture tests from emcc/binaryen with wasm backend
+# and native Wasm support in v8
+
+20010122-1.c.js
+20031003-1.c.js
+20071018-1.c.js
+20071120-1.c.js
+20071220-1.c.js
+20071220-2.c.js
+20101011-1.c.js
+alloca-1.c.js
+bitfld-3.c.js
+bitfld-5.c.js
+builtin-bitops-1.c.js
+conversion.c.js
+eeprof-1.c.js
+frame-address.c.js
+pr17377.c.js
+pr32244-1.c.js
+pr34971.c.js
+pr36765.c.js
+pr39228.c.js
+pr43008.c.js
+pr47237.c.js
+pr60960.c.js
+va-arg-pack-1.c.js
+
+# Works with asm2wasm
+	20000717-5.c.js
+	20001203-2.c.js
+	20010605-2.c.js
+	20020413-1.c.js
+	20030914-1.c.js
+	20040709-1.c.js
+	20040709-2.c.js
+	20040811-1.c.js
+	20050121-1.c.js
+	20051012-1.c.js
+	20070824-1.c.js
+	20080502-1.c.js
+	920501-1.c.js
+	920501-8.c.js
+	920625-1.c.js
+	921208-2.c.js
+	930513-1.c.js
+	930622-2.c.js
+	931004-10.c.js
+	931004-12.c.js
+	931004-14.c.js
+	931004-6.c.js
+	960215-1.c.js
+	960405-1.c.js
+	960513-1.c.js
+	align-2.c.js
+	arith-rand-ll.c.js
+	arith-rand.c.js
+	call-trap-1.c.js
+	complex-6.c.js
+	complex-7.c.js
+	loop-2f.c.js
+	loop-2g.c.js
+	pr23135.c.js
+	pr23467.c.js
+	pr34415.c.js
+	pr36339.c.js
+	pr38048-2.c.js
+	pr38051.c.js
+	pr38151.c.js
+	pr42691.c.js
+	pr43220.c.js
+	pr43269.c.js
+	pr44575.c.js
+	pr44942.c.js
+	pr49218.c.js
+	pr54471.c.js
+	pr56982.c.js
+	regstack-1.c.js
+	stdarg-1.c.js
+	stdarg-2.c.js
+	stdarg-3.c.js
+	strct-stdarg-1.c.js
+	strct-varg-1.c.js
+	struct-ret-1.c.js
+	va-arg-22.c.js
+	va-arg-5.c.js
+	va-arg-6.c.js
+	vla-dealloc-1.c.js


### PR DESCRIPTION
This change adds the 'vanilla' (aka wasm-backend) emscripten
configuration to the waterfall, and compiles and runs the torture tests
with it (in addition to asm2wasm).