### PR TITLE
Archive emcc+wasm files

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -724,6 +724,7 @@ def CompileLLVMTortureBinaryen(name, em_config, outdir, fails):
       fails=fails,
       out=outdir,
       config='binaryen')
+  Archive('torture-' + em_config, Tar(outdir))
   if 0 != unexpected_result_count:
     buildbot.Fail(True)
   return outdir


### PR DESCRIPTION
It would be helpful to be able to download these files from each build. I'm using them for my own testing.