### PR TITLE
Update expected failures after LLVM r268679

### DIFF
--- a/src/test/d8_known_gcc_test_failures.txt
+++ b/src/test/d8_known_gcc_test_failures.txt
@@ -62,7 +62,6 @@ strncmp-1.c.s.wast.wasm # abort()
 20040709-1.c.s.wast.wasm # memory access out of bounds
 
 # The following failures go away when disabling backend optimizations, regardless of IR
-frame-address.c.s.wast.wasm # abort()
 pr47337.c.s.wast.wasm # memory access out of bounds
 
 # The following only fail when all optimizations are enabled

--- a/src/test/d8_musl_known_gcc_test_failures.txt
+++ b/src/test/d8_musl_known_gcc_test_failures.txt
@@ -40,7 +40,6 @@ va-arg-pack-1.c.s.wast.wasm
 bitfld-3.c.s.wast.wasm
 builtin-constant.c.s.wast.wasm
 eeprof-1.c.s.wast.wasm
-frame-address.c.s.wast.wasm # abort()
 pr22493-1.c.s.wast.wasm
 pr32244-1.c.s.wast.wasm
 pr34971.c.s.wast.wasm

--- a/src/test/emwasm_run_known_gcc_test_failures.txt
+++ b/src/test/emwasm_run_known_gcc_test_failures.txt
@@ -20,7 +20,6 @@ bitfld-5.c.js
 builtin-bitops-1.c.js
 conversion.c.js
 eeprof-1.c.js
-frame-address.c.js
 pr17377.c.js
 pr32244-1.c.js
 pr34971.c.js
@@ -59,17 +58,12 @@ va-arg-pack-1.c.js
 	struct-ret-1.c.js # missing __extenddftf2
 
 ## The following work using wasm-clang without emcc
-	20000717-5.c.js # abort() (also works without emcc)
 	20001203-2.c.js # assert fail (works without emcc)
 	20040811-1.c.js # OOB trap
 	20070824-1.c.js # abort() (also works without emcc)
 	arith-rand-ll.c.js # abort() (works without emcc)
 	arith-rand.c.js # abort() (works without emcc)
 	pr23135.c.js # OOB trap (works without emcc)
-	pr34415.c.js # (empty output?)
-	pr36339.c.js # abort() (works without emcc)
-	pr38048-2.c.js # abort() (works without emcc)
-	pr42691.c.js # abort() (works without emcc)
 	pr43220.c.js # OOB trap (works without emcc)
 	vla-dealloc-1.c.js # OOB trap (works without emcc)
 	20051012-1.c.js # error reading binary


### PR DESCRIPTION
This seems to match what the waterfall is seeing; although I'm actually getting more new passes locally...