### PR TITLE
Make emscripten failures real and standalone failures warnings

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -752,8 +752,7 @@ def Emscripten(use_asm=True):
           '-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'])
 
   except proc.CalledProcessError:
-    # Don't make it fatal yet.
-    buildbot.Fail(True)
+    buildbot.Fail()
   finally:
     del os.environ['EMCC_DEBUG']
 
@@ -817,7 +816,7 @@ def CompileLLVMTortureBinaryen(name, em_config, outdir, fails):
       config='binaryen')
   Archive('torture-' + em_config, Tar(outdir))
   if 0 != unexpected_result_count:
-    buildbot.Fail(True)
+    buildbot.Fail()
   return outdir
 
 
@@ -855,7 +854,7 @@ def AssembleLLVMTorture(name, assembler, indir, fails):
 
 
 def ExecuteLLVMTorture(name, runner, indir, fails, extension, outdir='',
-                       wasmjs='', extra_files=[], is_flaky=False):
+                       wasmjs='', extra_files=[], warn_only=False):
   buildbot.Step('Execute LLVM Torture with %s' % name)
   if not indir:
     print 'Step skipped: no input'
@@ -871,7 +870,7 @@ def ExecuteLLVMTorture(name, runner, indir, fails, extension, outdir='',
       wasmjs=wasmjs,
       extra_files=extra_files)
   if 0 != unexpected_result_count:
-      buildbot.Fail(is_flaky)
+      buildbot.Fail(warn_only)
   return outdir
 
 
@@ -1022,7 +1021,7 @@ def main(sync_filter, build_filter, test_filter, options):
         indir=s2wasm_out,
         fails=BINARYEN_SHELL_KNOWN_TORTURE_FAILURES,
         extension='wast',
-        is_flaky=True)  # TODO wasm-shell is flaky when running tests.
+        warn_only=True)  # TODO wasm-shell is flaky when running tests.
     ExecuteLLVMTorture(
         name='spec',
         runner=os.path.join(INSTALL_BIN, 'wasm.opt'),
@@ -1035,6 +1034,7 @@ def main(sync_filter, build_filter, test_filter, options):
         indir=sexpr_wasm_out,
         fails=V8_KNOWN_TORTURE_FAILURES,
         extension='wasm',
+        warn_only=True,
         wasmjs=os.path.join(INSTALL_LIB, 'wasm.js'))
     ExecuteLLVMTorture(
         name='d8-musl',
@@ -1042,6 +1042,7 @@ def main(sync_filter, build_filter, test_filter, options):
         indir=sexpr_wasm_out,
         fails=V8_MUSL_KNOWN_TORTURE_FAILURES,
         extension='wasm',
+        warn_only=True,
         wasmjs=os.path.join(INSTALL_LIB, 'wasm.js'),
         extra_files=[os.path.join(INSTALL_LIB, 'musl.wasm')])
 

--- a/src/test/emwasm_compile_known_gcc_test_failures.txt
+++ b/src/test/emwasm_compile_known_gcc_test_failures.txt
@@ -79,3 +79,6 @@
         921208-2.c # call param number must match
         920501-1.c # call param number must match
         20051012-1.c # call param number must match
+
+# Crash (untriaged)
+        vla-dealloc-1.c


### PR DESCRIPTION
Previously failures in the standalone build (without emscripten) caused
the build to be red, whereas failures with emscripten were just warnings
because the support was more experimental. This PR reverses that,
because emscripten is what we expect users to be using, and the
standalone support is experimental. We keep the standalone builds
running because in the past they have sometimes been useful for catching
issues in implmentations (wasm-shell, v8, etc) and the maintenance cost
for keeping them running has been low.

Also update current failure state of tests