### PR TITLE
Add support for running emscripten test suite

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -157,6 +157,14 @@ BUILDBOT_SCHEDULER = os.environ.get('BUILDBOT_SCHEDULER', None)
 SCHEDULER = SCHEDULERS[BUILDBOT_SCHEDULER]
 BUILDBOT_REVISION = os.environ.get('BUILDBOT_REVISION', None)
 BUILDBOT_BUILDNUMBER = os.environ.get('BUILDBOT_BUILDNUMBER', None)
+BUILDBOT_BUILDERNAME = os.environ.get('BUILDBOT_BUILDERNAME', None)
+if BUILDBOT_BUILDERNAME:
+  # Chrome's buildbot infra includes in its paths a module called 'tools' which
+  # conflicts with emscripten's own 'tools' module and overrides the emscripten
+  # test runner's import. We don't need that infra in this script, so we just
+  # scrub it from the environment.
+  del os.environ['PYTHONPATH']
+
 
 # Pin the GCC revision so that new torture tests don't break the bot. This
 # should be manually updated when convenient.
@@ -234,7 +242,7 @@ def CopyLibraryToArchive(library):
 
 def Tar(directory, print_content=False):
   """Create a tar file from directory."""
-  if not os.environ.get('BUILDBOT_BUILDERNAME'):
+  if not BUILDBOT_BUILDERNAME:
     return
   assert os.path.isdir(directory), 'Must tar a directory to avoid tarbombs'
   (up_directory, basename) = os.path.split(directory)
@@ -250,7 +258,7 @@ def Tar(directory, print_content=False):
 
 def Archive(name, tar):
   """Archive the tar file with the given name, and with the LLVM git hash."""
-  if not os.environ.get('BUILDBOT_BUILDERNAME'):
+  if not BUILDBOT_BUILDERNAME:
     return
   git_gs = 'git/wasm-%s-%s.tbz2' % (name, BUILDBOT_BUILDNUMBER)
   buildbot.Link('download', cloud.Upload(tar, git_gs))


### PR DESCRIPTION
Run the emscripten test suite with the wasm backend, using the
wasm-shell (as opposed to native wasm) for now.

Also remove the attempt to use a relative path in the emscripten config
file and instead generate one with an absolute path at install time.