### PR TITLE
Binaryen 0xb support

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -15,6 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import errno
 import glob
 import json
 import multiprocessing
@@ -228,15 +229,34 @@ def CopyTree(src, dst):
       shutil.copy2(os.path.join(root, f), dstfile)
 
 
+def CreateDirectoryAtPath(path):
+  """Create a directory at a specified path.
+
+  Creates all intermediate directories along the way.
+  e.g.: CreateDirectoryAtPath('a/b/c') when 'a/' is an empty directory will
+        cause the creation of directories 'a/b/' and 'a/b/c/'.
+
+  If the path already exists (and is already a directory), this does nothing.
+  """
+  try:
+    os.makedirs(path)
+  except OSError as e:
+    dir_exists = e.errno == errno.EEXIST and os.path.isdir(path)
+    if not dir_exists:
+      raise e
+
+
 def CopyBinaryToArchive(binary):
   """All binaries are archived in the same tar file."""
   print 'Copying binary %s to archive %s' % (binary, INSTALL_BIN)
+  CreateDirectoryAtPath(INSTALL_BIN)
   shutil.copy2(binary, INSTALL_BIN)
 
 
 def CopyLibraryToArchive(library):
   """All libraries are archived in the same tar file."""
   print 'Copying library %s to archive %s' % (library, INSTALL_LIB)
+  CreateDirectoryAtPath(INSTALL_LIB)
   shutil.copy2(library, INSTALL_LIB)
 
 

--- a/src/build.py
+++ b/src/build.py
@@ -239,11 +239,14 @@ def CopyTree(src, dst):
       shutil.copy2(os.path.join(root, f), dstfile)
 
 
-def CopyBinaryToArchive(binary):
+def CopyBinaryToArchive(binary, extra_dir=None):
   """All binaries are archived in the same tar file."""
-  print 'Copying binary %s to archive %s' % (binary, INSTALL_BIN)
-  Mkdir(INSTALL_BIN)
-  shutil.copy2(binary, INSTALL_BIN)
+  install_bin = INSTALL_BIN
+  if extra_dir is not None:
+    install_bin = os.path.join(INSTALL_BIN, extra_dir)
+  print 'Copying binary %s to archive %s' % (binary, install_bin)
+  Mkdir(install_bin)
+  shutil.copy2(binary, install_bin)
 
 
 def CopyLibraryToArchive(library):
@@ -724,7 +727,7 @@ def BinaryenBase(step_name, src_dir, out_dir, archive_dir=None):
     f = os.path.join(bin_dir, node)
     if os.path.isfile(f):
       CopyBinaryToArchive(f, archive_dir)
-  CopyBinaryToArchive(os.path.join(src_dir, 'bin', 'wasm.js'))
+  CopyBinaryToArchive(os.path.join(src_dir, 'bin', 'wasm.js'), archive_dir)
   Mkdir(os.path.join(INSTALL_DIR, 'src'))
   Mkdir(os.path.join(INSTALL_DIR, 'src', 'js'))
   shutil.copy2(os.path.join(src_dir, 'src', 'js', 'wasm.js-post.js'),

--- a/src/build.py
+++ b/src/build.py
@@ -1042,9 +1042,10 @@ def main(sync_filter, build_filter, test_filter, options):
 
   try:
     BuildRepos(build_filter, test_filter.Check('asm'))
-  except:
+  except Exception as e:
     # If any exception reaches here, do not attempt to run the tests; just
     # log the error for buildbot and exit
+    print "Exception thrown: {}".format(e)
     buildbot.Fail()
     Summary(repos)
     return 1

--- a/src/build.py
+++ b/src/build.py
@@ -478,6 +478,9 @@ ALL_SOURCES = [
            WASM_GIT_BASE + 'binaryen.git'),
     Source('binaryen-0xb', BINARYEN_0xB_SRC_DIR,
            WASM_GIT_BASE + 'binaryen.git',
+           # This is the commit hash for the last 0xb-compatible binaryen
+           # version. This is hardcoded because we shouldn't keep this after
+           # the rest of the toolchain is 0xc-compatible.
            checkout='79029eb346b721eacdaa28326fe8e7b50042611c'),
     Source('musl', MUSL_SRC_DIR,
            WASM_GIT_BASE + 'musl.git',

--- a/src/build.py
+++ b/src/build.py
@@ -181,12 +181,21 @@ def Chdir(path):
 
 
 def Mkdir(path):
-  if os.path.exists(path):
+  """Create a directory at a specified path.
+
+  Creates all intermediate directories along the way.
+  e.g.: Mkdir('a/b/c') when 'a/' is an empty directory will
+        cause the creation of directories 'a/b/' and 'a/b/c/'.
+
+  If the path already exists (and is already a directory), this does nothing.
+  """
+  try:
+    os.makedirs(path)
+  except OSError as e:
     if not os.path.isdir(path):
       raise Exception('Path %s is not a directory!' % path)
-    print 'Directory %s already exists' % path
-  else:
-    os.mkdir(path)
+    if not e.errno == errno.EEXIST:
+      raise e
 
 
 def Remove(path):
@@ -229,34 +238,17 @@ def CopyTree(src, dst):
       shutil.copy2(os.path.join(root, f), dstfile)
 
 
-def CreateDirectoryAtPath(path):
-  """Create a directory at a specified path.
-
-  Creates all intermediate directories along the way.
-  e.g.: CreateDirectoryAtPath('a/b/c') when 'a/' is an empty directory will
-        cause the creation of directories 'a/b/' and 'a/b/c/'.
-
-  If the path already exists (and is already a directory), this does nothing.
-  """
-  try:
-    os.makedirs(path)
-  except OSError as e:
-    dir_exists = e.errno == errno.EEXIST and os.path.isdir(path)
-    if not dir_exists:
-      raise e
-
-
 def CopyBinaryToArchive(binary):
   """All binaries are archived in the same tar file."""
   print 'Copying binary %s to archive %s' % (binary, INSTALL_BIN)
-  CreateDirectoryAtPath(INSTALL_BIN)
+  Mkdir(INSTALL_BIN)
   shutil.copy2(binary, INSTALL_BIN)
 
 
 def CopyLibraryToArchive(library):
   """All libraries are archived in the same tar file."""
   print 'Copying library %s to archive %s' % (library, INSTALL_LIB)
-  CreateDirectoryAtPath(INSTALL_LIB)
+  Mkdir(INSTALL_LIB)
   shutil.copy2(library, INSTALL_LIB)
 
 

--- a/src/build.py
+++ b/src/build.py
@@ -77,7 +77,6 @@ LLVM_OUT_DIR = os.path.join(WORK_DIR, 'llvm-out')
 V8_OUT_DIR = os.path.join(V8_SRC_DIR, 'out', 'Release')
 SEXPR_OUT_DIR = os.path.join(WORK_DIR, 'sexpr-out')
 BINARYEN_OUT_DIR = os.path.join(WORK_DIR, 'binaryen-out')
-BINARYEN_BIN_DIR = os.path.join(BINARYEN_OUT_DIR, 'bin')
 FASTCOMP_OUT_DIR = os.path.join(WORK_DIR, 'fastcomp-out')
 MUSL_OUT_DIR = os.path.join(WORK_DIR, 'musl-out')
 TORTURE_S_OUT_DIR = os.path.join(WORK_DIR, 'torture-s')
@@ -714,9 +713,10 @@ def Binaryen():
        '-DCMAKE_CXX_COMPILER=' + CXX],
       cwd=BINARYEN_OUT_DIR)
   proc.check_call(['ninja'], cwd=BINARYEN_OUT_DIR)
-  assert os.path.isdir(BINARYEN_BIN_DIR), 'Expected %s' % BINARYEN_BIN_DIR
-  for node in os.listdir(BINARYEN_BIN_DIR):
-    f = os.path.join(BINARYEN_BIN_DIR, node)
+  bin_dir = os.path.join(BINARYEN_OUT_DIR, 'bin')
+  assert os.path.isdir(bin_dir), 'Expected %s' % bin_dir
+  for node in os.listdir(bin_dir):
+    f = os.path.join(bin_dir, node)
     if os.path.isfile(f):
       CopyBinaryToArchive(f)
   CopyBinaryToArchive(os.path.join(BINARYEN_SRC_DIR, 'bin', 'wasm.js'))


### PR DESCRIPTION
Upstream binaryen has started using 0xc features. sexpr-wasm doesn't have support for that yet, so for now waterfall will sync and build both versions of binaryen.