### PR TITLE
Use 0xb version of wasm-shell for standalone tests and interpret-binary for emscripten tests

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1096,7 +1096,7 @@ def main(sync_filter, build_filter, test_filter, options):
         fails=SEXPR_S2WASM_KNOWN_TORTURE_FAILURES)
     ExecuteLLVMTorture(
         name='wasm-shell',
-        runner=os.path.join(INSTALL_BIN, 'wasm-shell'),
+        runner=os.path.join(INSTALL_BIN, '0xb', 'wasm-shell'),
         indir=s2wasm_out,
         fails=BINARYEN_SHELL_KNOWN_TORTURE_FAILURES,
         extension='wast',

--- a/src/build.py
+++ b/src/build.py
@@ -869,7 +869,7 @@ def CompileLLVMTortureBinaryen(name, em_config, outdir, fails):
       c=c, cxx=cxx, testsuite=GCC_TEST_DIR,
       fails=fails,
       out=outdir,
-      config='binaryen')
+      config='binaryen-interpret')
   Archive('torture-' + em_config, Tar(outdir))
   if 0 != unexpected_result_count:
     buildbot.Fail()

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -32,7 +32,11 @@ CFLAGS_EXTRA = {
              '--sysroot=%s' % INSTALL_DIR],
     # Binaryen's native-wasm method uses the JS engine's native support for
     # wasm rather than interpreting the wasm with wasm.js.
-    'binaryen': ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'],
+    'binaryen-native': ['-s', 'BINARYEN=1', '-s',
+                        'BINARYEN_METHOD="native-wasm"'],
+    # The interpret-binary method runs the wasm in an asmjs-compiled wasm-shell.
+    'binaryen-interpret': ['-s', 'BINARYEN=1', '-s',
+                           'BINARYEN_METHOD="interpret-binary"'],
 }
 
 

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -34,7 +34,7 @@ CFLAGS_EXTRA = {
     # wasm rather than interpreting the wasm with wasm.js.
     'binaryen-native': ['-s', 'BINARYEN=1', '-s',
                         'BINARYEN_METHOD="native-wasm"'],
-    # The interpret-binary method runs the wasm in an asmjs-compiled wasm-shell.
+    # The interpret-binary method runs the wasm in an asmjs-compiled wasm-shell
     'binaryen-interpret': ['-s', 'BINARYEN=1', '-s',
                            'BINARYEN_METHOD="interpret-binary"'],
 }


### PR DESCRIPTION
This test executes the code generated by 0xb s2wasm, so it should be the
0xb interpreter.