### PR TITLE
Add prebuilt cmake to PATH

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -466,10 +466,6 @@ def SyncPrebuiltCMake(name, src_dir, git_repo):
       print 'Error downloading %s: %s' % (url, e)
       raise
 
-  # Add prebuilt cmake to PATH so any subprocesses use a consistent cmake.
-  os.environ['PATH'] = (os.path.join(PREBUILT_CMAKE_DIR, 'bin') +
-                        ':' + os.environ['PATH'])
-
 
 def NoSync(*args):
   pass
@@ -1115,6 +1111,10 @@ def main(sync_filter, build_filter, test_filter, options):
     Mkdir(INSTALL_DIR)
     Mkdir(INSTALL_BIN)
     Mkdir(INSTALL_LIB)
+
+  # Add prebuilt cmake to PATH so any subprocesses use a consistent cmake.
+  os.environ['PATH'] = (os.path.join(PREBUILT_CMAKE_DIR, 'bin') +
+                        os.pathsep + os.environ['PATH'])
 
   try:
     BuildRepos(build_filter, test_filter.Check('asm'))

--- a/src/build.py
+++ b/src/build.py
@@ -466,6 +466,10 @@ def SyncPrebuiltCMake(name, src_dir, git_repo):
       print 'Error downloading %s: %s' % (url, e)
       raise
 
+  # Add prebuilt cmake to PATH so any subprocesses use a consistent cmake.
+  os.environ['PATH'] = (os.path.join(PREBUILT_CMAKE_DIR, 'bin') +
+                        ':' + os.environ['PATH'])
+
 
 def NoSync(*args):
   pass


### PR DESCRIPTION
Some emscripten tests use the system's cmake, which doesn't work on the
build bots. Add our prebuilt version of cmake at the start of PATH to
guarantee consistency in any subprocesses that rely on cmake.