### PR TITLE
Make torture tests work from any working directory

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -913,8 +913,8 @@ def CompileLLVMTorture():
   Remove(TORTURE_S_OUT_DIR)
   Mkdir(TORTURE_S_OUT_DIR)
   unexpected_result_count = compile_torture_tests.run(
-      script_dir=SCRIPT_DIR,
       c=c, cxx=cxx, testsuite=GCC_TEST_DIR,
+      sysroot_dir=INSTALL_SYSROOT,
       fails=LLVM_KNOWN_TORTURE_FAILURES,
       out=TORTURE_S_OUT_DIR)
   Archive('torture-c', Tar(GCC_TEST_DIR))
@@ -931,8 +931,8 @@ def CompileLLVMTortureBinaryen(name, em_config, outdir, fails):
   Remove(outdir)
   Mkdir(outdir)
   unexpected_result_count = compile_torture_tests.run(
-      script_dir=SCRIPT_DIR,
       c=c, cxx=cxx, testsuite=GCC_TEST_DIR,
+      sysroot_dir=INSTALL_SYSROOT,
       fails=fails,
       out=outdir,
       config='binaryen-interpret')

--- a/src/build.py
+++ b/src/build.py
@@ -913,6 +913,7 @@ def CompileLLVMTorture():
   Remove(TORTURE_S_OUT_DIR)
   Mkdir(TORTURE_S_OUT_DIR)
   unexpected_result_count = compile_torture_tests.run(
+      script_dir=SCRIPT_DIR,
       c=c, cxx=cxx, testsuite=GCC_TEST_DIR,
       fails=LLVM_KNOWN_TORTURE_FAILURES,
       out=TORTURE_S_OUT_DIR)
@@ -930,6 +931,7 @@ def CompileLLVMTortureBinaryen(name, em_config, outdir, fails):
   Remove(outdir)
   Mkdir(outdir)
   unexpected_result_count = compile_torture_tests.run(
+      script_dir=SCRIPT_DIR,
       c=c, cxx=cxx, testsuite=GCC_TEST_DIR,
       fails=fails,
       out=outdir,

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -102,5 +102,9 @@ def getargs():
 
 if __name__ == '__main__':
   args = getargs()
-  sys.exit(run(args.c, args.cxx, args.testsuite,
-               args.sysroot, args.fails, args.out))
+  sys.exit(run(c=args.c,
+               cxx=args.cxx,
+               testsuite=args.testsuite,
+               sysroot_dir=args.sysroot,
+               fails=args.fails,
+               out=args.out))

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -41,10 +41,8 @@ class Outname:
     return os.path.join(outdir, outname)
 
 
-def run(script_dir, c, cxx, testsuite, fails, out, config='wasm'):
+def run(c, cxx, testsuite, sysroot_dir, fails, out, config='wasm'):
   """Compile all torture tests."""
-  sysroot_dir = os.path.join(script_dir,
-                             'work', 'wasm-install', 'sysroot')
   cflags_common = ['--std=gnu89', '-DSTACK_SIZE=1044480',
                    '-w', '-Wno-implicit-function-declaration']
   cflags_extra = {
@@ -93,6 +91,8 @@ def getargs():
                       help='C++ compiler path')
   parser.add_argument('--testsuite', type=str, required=True,
                       help='GCC testsuite tests path')
+  parser.add_argument('--sysroot', type=str, required=True,
+                      help='Sysroot directory')
   parser.add_argument('--fails', type=str, required=True,
                       help='Expected failures')
   parser.add_argument('--out', type=str, required=True,
@@ -102,6 +102,5 @@ def getargs():
 
 if __name__ == '__main__':
   args = getargs()
-  script_dir = os.path.dirname(os.path.abspath(__file__))
-  sys.exit(run(script_dir, args.c, args.cxx,
-               args.testsuite, args.fails, args.out))
+  sys.exit(run(args.c, args.cxx, args.testsuite,
+               args.sysroot, args.fails, args.out))


### PR DESCRIPTION
Torture tests wouldn't get the right system directory when built from
anywhere other than waterfall root, because it was calculated at import
time.