### PR TITLE
Group archived assets under <buildername>/<buildnumber>

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1268,10 +1268,10 @@ def main():
   test_filter = Filter(test_include, options.test_exclude)
 
   if IsBuildbot():
-    # Chrome's buildbot infra includes in its paths a module called 'tools' which
-    # conflicts with emscripten's own 'tools' module and overrides the emscripten
-    # test runner's import. We don't need that infra in this script, so we just
-    # scrub it from the environment.
+    # Chrome's buildbot infra includes in its paths a module called 'tools'
+    # which conflicts with emscripten's own 'tools' module and overrides the
+    # emscripten test runner's import. We don't need that infra in this script,
+    # so we just scrub it from the environment.
     del os.environ['PYTHONPATH']
 
   try:

--- a/src/build.py
+++ b/src/build.py
@@ -260,7 +260,7 @@ def CopyLibraryToArchive(library):
 
 def Tar(directory, print_content=False):
   """Create a tar file from directory."""
-  if not IsBuildBot():
+  if not IsBuildbot():
     return
   assert os.path.isdir(directory), 'Must tar a directory to avoid tarbombs'
   (up_directory, basename) = os.path.split(directory)
@@ -276,7 +276,7 @@ def Tar(directory, print_content=False):
 
 def UploadFile(local_name, remote_name):
   """Archive the file with the given name, and with the LLVM git hash."""
-  if not IsBuildBot():
+  if not IsBuildbot():
     return
   buildbot.Link('download', cloud.Upload(local_name, '%s/%s/%s' % (
       BUILDBOT_BUILDERNAME, BUILDBOT_BUILDNUMBER, remote_name)))
@@ -284,7 +284,7 @@ def UploadFile(local_name, remote_name):
 
 def Archive(name, tar):
   """Archive the tar file with the given name, and with the LLVM git hash."""
-  if not IsBuildBot():
+  if not IsBuildbot():
     return
   UploadFile(tar, 'wasm-%s-%s.tbz2' % (name, BUILDBOT_BUILDNUMBER))
 
@@ -336,7 +336,7 @@ def RemoteBranch(branch):
   return WATERFALL_REMOTE + '/' + branch
 
 
-def IsBuildBot():
+def IsBuildbot():
   """Return True if we are running on bot, False otherwise."""
   return BUILDBOT_BUILDNUMBER is not None
 
@@ -1267,7 +1267,7 @@ def main():
   test_include = options.test_include if options.test else []
   test_filter = Filter(test_include, options.test_exclude)
 
-  if IsBuildBot():
+  if IsBuildbot():
     # Chrome's buildbot infra includes in its paths a module called 'tools' which
     # conflicts with emscripten's own 'tools' module and overrides the emscripten
     # test runner's import. We don't need that infra in this script, so we just

--- a/src/build.py
+++ b/src/build.py
@@ -280,12 +280,19 @@ def Tar(directory, print_content=False):
   return tar
 
 
+def UploadFile(local_name, remote_name):
+  """Archive the file with the given name, and with the LLVM git hash."""
+  if not BUILDBOT_BUILDNUMBER:
+    return
+  buildbot.Link('download', cloud.Upload(local_name, '%s/%s/%s' % (
+      BUILDBOT_BUILDERNAME, BUILDBOT_BUILDNUMBER, remote_name)))
+
+
 def Archive(name, tar):
   """Archive the tar file with the given name, and with the LLVM git hash."""
-  if not BUILDBOT_BUILDERNAME:
+  if not BUILDBOT_BUILDNUMBER:
     return
-  git_gs = 'git/wasm-%s-%s.tbz2' % (name, BUILDBOT_BUILDNUMBER)
-  buildbot.Link('download', cloud.Upload(tar, git_gs))
+  UploadFile(tar, 'wasm-%s-%s.tbz2' % (name, BUILDBOT_BUILDNUMBER))
 
 
 # Repo and subproject utilities
@@ -636,7 +643,7 @@ def SyncRepos(filter=None, sync_lkgr=False):
   good_hashes = None
   if sync_lkgr:
     lkgr_file = os.path.join(WORK_DIR, 'lkgr')
-    cloud.Download('git/lkgr', lkgr_file)
+    cloud.Download('lkgr', lkgr_file)
     lkgr = json.loads(open(lkgr_file).read())
     good_hashes = {}
     for k, v in lkgr['repositories'].iteritems():
@@ -1040,14 +1047,14 @@ def Summary(repos):
   latest_file = os.path.join(WORK_DIR, 'latest')
   with open(latest_file, 'w+') as f:
     f.write(info_json)
-  buildbot.Link('latest', cloud.Upload(latest_file, 'git/latest'))
+  buildbot.Link('latest', cloud.Upload(latest_file, 'latest'))
   if buildbot.Failed():
     buildbot.Fail()
   else:
     lkgr_file = os.path.join(WORK_DIR, 'lkgr')
     with open(lkgr_file, 'w+') as f:
       f.write(info_json)
-    buildbot.Link('lkgr', cloud.Upload(lkgr_file, 'git/lkgr'))
+    buildbot.Link('lkgr', cloud.Upload(lkgr_file, 'lkgr'))
 
 
 def AllBuilds(use_asm=False):

--- a/src/build.py
+++ b/src/build.py
@@ -168,7 +168,6 @@ SCHEDULER = SCHEDULERS[BUILDBOT_SCHEDULER]
 BUILDBOT_REVISION = os.environ.get('BUILDBOT_REVISION', None)
 BUILDBOT_BUILDNUMBER = os.environ.get('BUILDBOT_BUILDNUMBER', None)
 BUILDBOT_BUILDERNAME = os.environ.get('BUILDBOT_BUILDERNAME', None)
-IS_BUILDBOT = BUILDBOT_BUILDERNAME != None
 
 
 # Pin the GCC revision so that new torture tests don't break the bot. This

--- a/src/cloud.py
+++ b/src/cloud.py
@@ -15,7 +15,6 @@
 #   limitations under the License.
 
 import os
-
 import proc
 
 
@@ -33,19 +32,6 @@ def Upload(local, remote):
   return CLOUD_STORAGE_BASE_URL + remote
 
 
-def Copy(copy_from, copy_to):
-  """Copy from one Cloud Storage file to another."""
-  if not os.environ.get('BUILDBOT_BUILDERNAME'):
-    return
-  copy_from = CLOUD_STORAGE_PATH + copy_from
-  copy_to = CLOUD_STORAGE_PATH + copy_to
-  proc.check_call(
-      ['gsutil.py', 'cp', '-a', 'public-read',
-       'gs://' + copy_from, 'gs://' + copy_to])
-  return CLOUD_STORAGE_BASE_URL + copy_to
-
-
 def Download(remote, local):
   remote = CLOUD_STORAGE_PATH + remote
-  proc.check_call(
-      ['gsutil.py', 'cp', 'gs://' + remote, local])
+  proc.check_call(['gsutil.py', 'cp', 'gs://' + remote, local])


### PR DESCRIPTION
Now that we have multiple builders we should probably start
grouping assets rather than putting them all in single
directly.

For now, the build number is also included in the names
of the individual tar archives.

Also, drop the (now-redundant) `git/` and `svn/` distiction.
