### PR TITLE
Revert "Error out if passed non-existent/mis-spelled steps"

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -617,11 +617,6 @@ class Filter:
 
   def Apply(self, targets):
     """ Return the filtered list of targets. """
-    all_names = [t.name for t in targets]
-    specified_names = self.include or self.exclude or []
-    missing_names = [i for i in specified_names if i not in all_names]
-    if missing_names:
-      raise Exception('Invalid step name(s): ' + str(missing_names))
     if self.include is not None:
       return [t for t in targets if t.name in self.include]
     if self.exclude:


### PR DESCRIPTION
Reverts WebAssembly/waterfall#80

This caused issues whenever filter.Check() was called.