### PR TITLE
Print traceback when exceptions are thrown in build steps

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1177,7 +1177,8 @@ def run(sync_filter, build_filter, test_filter, options):
   except Exception as e:
     # If any exception reaches here, do not attempt to run the tests; just
     # log the error for buildbot and exit
-    print "Exception thrown: {}".format(e)
+    print "Exception thrown in build step."
+    traceback.print_exc()
     buildbot.Fail()
     Summary(repos)
     return 1

--- a/src/build.py
+++ b/src/build.py
@@ -1174,7 +1174,7 @@ def run(sync_filter, build_filter, test_filter, options):
 
   try:
     BuildRepos(build_filter, test_filter.Check('asm'))
-  except Exception as e:
+  except Exception:
     # If any exception reaches here, do not attempt to run the tests; just
     # log the error for buildbot and exit
     print "Exception thrown in build step."


### PR DESCRIPTION
Notes:
1) we already import the traceback module for the build.py as a whole.
2) `traceback.print_exc()` prints out the exception, so we don't need to explicitly print it.