### PR TITLE
Always include repo info in summary json

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -393,7 +393,7 @@ class Source:
     AddGithubRemote(self.src_dir)
 
   def CurrentGitInfo(self):
-    if not self.src_dir:
+    if not os.path.exists(self.src_dir):
       return None
 
     def pretty(fmt):
@@ -1261,9 +1261,7 @@ def run(sync_filter, build_filter, test_filter, options):
   Chdir(SCRIPT_DIR)
   Mkdir(WORK_DIR)
   SyncRepos(sync_filter, options.sync_lkgr)
-  repos = None
-  if sync_filter.Check(''):
-    repos = GetRepoInfo()
+  repos = GetRepoInfo()
   if build_filter.All():
     Remove(INSTALL_DIR)
     Mkdir(INSTALL_DIR)


### PR DESCRIPTION
Previously we were only including the info for the repos
that were sync'd.   Now the info is included even with
--no-sync.

This means that the buildinfo.json file will always
contain the git hashes of the sourece that were used
to build it.