### PR TITLE
Create emcc/em++ wrappers in toolchain bin directory

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+for x in emcc em++ wasm2wast wast2wasm wasm-interp s2wasm wasm-opt wasm-as \
+         wasm-dis wasm-shell wasm.opt d8; do
+  update-alternatives --install /usr/bin/$x $x /opt/wasm/bin/$x 10
+done

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+for x in emcc em++ wasm2wast wast2wasm wasm-interp s2wasm wasm-opt wasm-as \
+         wasm-dis wasm-shell wasm.opt d8; do
+  update-alternatives --remove $x /opt/wasm/bin/$x
+done

--- a/debian/rules
+++ b/debian/rules
@@ -15,8 +15,8 @@ DESTDIR = $(TMP)$(PREFIX)
 override_dh_auto_install:
 	mkdir -p debian/wasm-toolchain/opt/wasm
 	cp -ar src/work/wasm-install/* $(DESTDIR)
-	find $(DESTDIR) -name "*.pyc" -exec "rm {}" \;
+	find $(DESTDIR) -name "*.pyc" -exec rm "{}" \;
 	rm -rf $(DESTDIR)/bin/emscripten/tests
-	rm -rf $(DESTDIR)/bin/emscripten/third_party
 	cp src/emscripten_config* debian/wasm-toolchain/opt/wasm
+	rm -f debian/wasm-toolchain/opt/wasm/emscripten_config*sanity*
 	perl -pi -e 's/{{WASM_INSTALL}}/\/opt\/wasm/' debian/wasm-toolchain/opt/wasm/emscripten_config*

--- a/src/build.py
+++ b/src/build.py
@@ -887,6 +887,10 @@ def Emscripten(use_asm=True):
       del os.environ['EMCC_DEBUG']
       del os.environ['EM_CONFIG']
 
+  wrapper = os.path.join(SCRIPT_DIR, 'emcc_wrapper.sh')
+  shutil.copy2(wrapper, os.path.join(INSTALL_BIN, 'emcc'))
+  shutil.copy2(wrapper, os.path.join(INSTALL_BIN, 'em++'))
+
 
 def Musl():
   buildbot.Step('musl')

--- a/src/emcc_wrapper.sh
+++ b/src/emcc_wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SCRIPT_FILE=$(readlink -f "$BASH_SOURCE")
+SCRIPT_DIR=$(cd $(dirname $SCRIPT_FILE) && pwd)
+
+export EMCC_SKIP_SANITY_CHECK=1
+export EM_CONFIG=$(dirname $SCRIPT_DIR)/emscripten_config
+
+exec $SCRIPT_DIR/emscripten/$(basename $0) $*

--- a/src/emcc_wrapper.sh
+++ b/src/emcc_wrapper.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-SCRIPT_FILE=$(readlink -f "$BASH_SOURCE")
-SCRIPT_DIR=$(cd $(dirname $SCRIPT_FILE) && pwd)
+SCRIPT_FILE=$(readlink -f "${BASH_SOURCE}")
+SCRIPT_DIR=$(cd $(dirname "${SCRIPT_FILE}") && pwd)
 
 export EMCC_SKIP_SANITY_CHECK=1
-export EM_CONFIG=$(dirname $SCRIPT_DIR)/emscripten_config
+export EM_CONFIG=$(dirname "${SCRIPT_DIR}")/emscripten_config
 
 exec $SCRIPT_DIR/emscripten/$(basename $0) $*


### PR DESCRIPTION
These wrappers set/override EM_CONFIG meaning that the user's emscripten config
won't interfere with the toolchain. They also set EMCC_SKIP_SANITY_CHECK so that
emscripten won't try to write to the toolchain directory (which is not writable
in the packaged version).

Also, add /etc/alternatives for the core set of binaries in the debian package
so they are accessible via /usr/bin.

Also, fix the pyc cleanup command, and don't remove the third_party directory
(it is needed for closure-compiler.jar at least).
