### PR TITLE
Package emscripten in the root of the toolchain rather than under `bin`

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ override_dh_auto_install:
 	mkdir -p debian/wasm-toolchain/opt/wasm
 	cp -ar src/work/wasm-install/* $(DESTDIR)
 	find $(DESTDIR) -name "*.pyc" -exec rm "{}" \;
-	rm -rf $(DESTDIR)/bin/emscripten/tests
+	rm -rf $(DESTDIR)/emscripten/tests
 	cp src/emscripten_config* debian/wasm-toolchain/opt/wasm
 	rm -f debian/wasm-toolchain/opt/wasm/emscripten_config*sanity*
 	perl -pi -e 's/{{WASM_INSTALL}}/\/opt\/wasm/' debian/wasm-toolchain/opt/wasm/emscripten_config*

--- a/src/build.py
+++ b/src/build.py
@@ -842,7 +842,7 @@ def Emscripten(use_asm=True):
   # Remove cached library builds (e.g. libc, libc++) to force them to be
   # rebuilt in the step below.
   Remove(os.path.expanduser(os.path.join('~', '.emscripten_cache')))
-  emscripten_dir = os.path.join(INSTALL_DIR, 'bin', 'emscripten')
+  emscripten_dir = os.path.join(INSTALL_DIR, 'emscripten')
   Remove(emscripten_dir)
   print 'Copying directory %s to %s' % (EMSCRIPTEN_SRC_DIR, emscripten_dir)
   shutil.copytree(EMSCRIPTEN_SRC_DIR,
@@ -960,8 +960,8 @@ def CompileLLVMTorture():
 def CompileLLVMTortureBinaryen(name, em_config, outdir, fails):
   buildbot.Step('Compile LLVM Torture (%s)' % name)
   os.environ['EM_CONFIG'] = em_config
-  c = os.path.join(INSTALL_DIR, 'bin', 'emscripten', 'emcc')
-  cxx = os.path.join(INSTALL_DIR, 'bin', 'emscripten', 'em++')
+  c = os.path.join(INSTALL_DIR, 'emscripten', 'emcc')
+  cxx = os.path.join(INSTALL_DIR, 'emscripten', 'em++')
   Remove(outdir)
   Mkdir(outdir)
   unexpected_result_count = compile_torture_tests.run(
@@ -1038,7 +1038,7 @@ def ExecuteEmscriptenTestSuite(name, config, outdir):
   try:
     proc.check_call(
         [sys.executable,
-         os.path.join(INSTALL_BIN, 'emscripten', 'tests', 'runner.py'),
+         os.path.join(INSTALL_DIR, 'emscripten', 'tests', 'runner.py'),
          'binaryen2', '--em-config', config],
         cwd=outdir)
   except proc.CalledProcessError:

--- a/src/emcc_wrapper.sh
+++ b/src/emcc_wrapper.sh
@@ -2,8 +2,9 @@
 
 SCRIPT_FILE=$(readlink -f "${BASH_SOURCE}")
 SCRIPT_DIR=$(cd $(dirname "${SCRIPT_FILE}") && pwd)
+WASM_ROOT=$(dirname "${SCRIPT_DIR}")
 
 export EMCC_SKIP_SANITY_CHECK=1
-export EM_CONFIG=$(dirname "${SCRIPT_DIR}")/emscripten_config
+export EM_CONFIG="${WASM_ROOT}/emscripten_config"
 
-exec $SCRIPT_DIR/emscripten/$(basename $0) $*
+exec "${WASM_ROOT}/emscripten/$(basename $0)" $*

--- a/src/emscripten_config
+++ b/src/emscripten_config
@@ -8,7 +8,7 @@ import os
 WASM_INSTALL = '{{WASM_INSTALL}}'
 
 # this helps projects using emscripten find it
-EMSCRIPTEN_ROOT = os.path.join(WASM_INSTALL, 'bin', 'emscripten') # directory
+EMSCRIPTEN_ROOT = os.path.join(WASM_INSTALL, 'emscripten') # directory
 LLVM_ROOT = os.path.join(WASM_INSTALL, 'fastcomp', 'bin') # directory
 BINARYEN_ROOT = os.path.join(WASM_INSTALL) # directory
 

--- a/src/emscripten_config_vanilla
+++ b/src/emscripten_config_vanilla
@@ -8,7 +8,7 @@ import os
 WASM_INSTALL = '{{WASM_INSTALL}}'
 
 # this helps projects using emscripten find it
-EMSCRIPTEN_ROOT = os.path.join(WASM_INSTALL, 'bin', 'emscripten') # directory
+EMSCRIPTEN_ROOT = os.path.join(WASM_INSTALL, 'emscripten') # directory
 LLVM_ROOT = os.path.join(WASM_INSTALL, 'bin') # directory
 BINARYEN_ROOT = os.path.join(WASM_INSTALL) # directory
 


### PR DESCRIPTION
The bin directory is normally reserved for executable that
should be in the PATH, not entire subdirectoris.