### PR TITLE
Add support for Binaryen's wasm-as to assemble_files.py

### DIFF
--- a/src/assemble_files.py
+++ b/src/assemble_files.py
@@ -34,7 +34,8 @@ def assemble(infile, outfile, extras):
   assembler = extras['assembler']
   basename = os.path.basename(assembler)
   commands = {
-      'wast2wasm': [extras['assembler'], infile, '-o', outfile]
+      'wast2wasm': [extras['assembler'], infile, '-o', outfile],
+      'wasm-as': [extras['assembler'], infile, '-o', outfile]
   }
   return commands[basename]
 


### PR DESCRIPTION
Not used on the continuous build, but is useful for checking
compatibility between implementations.