### PR TITLE
Set spec branch back to master

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -525,8 +525,7 @@ ALL_SOURCES = [
     Source('wabt', WABT_SRC_DIR,
            WASM_GIT_BASE + 'wabt.git'),
     Source('spec', SPEC_SRC_DIR,
-           WASM_GIT_BASE + 'spec.git',
-           checkout=RemoteBranch('binary-0xc')),
+           WASM_GIT_BASE + 'spec.git'),
     Source('binaryen', BINARYEN_SRC_DIR,
            WASM_GIT_BASE + 'binaryen.git'),
     Source('musl', MUSL_SRC_DIR,
@@ -1169,7 +1168,6 @@ def TestBare():
       runner=os.path.join(INSTALL_BIN, 'wasm.opt'),
       indir=s2wasm_out,
       fails=SPEC_KNOWN_TORTURE_FAILURES,
-      warn_only=True,  # TODO https://github.com/WebAssembly/spec/issues/353
       extension='wast')
   ExecuteLLVMTorture(
       name='d8',

--- a/src/test/spec_known_gcc_test_failures.txt
+++ b/src/test/spec_known_gcc_test_failures.txt
@@ -58,7 +58,6 @@ pr44942.c.s.wast # arity mismatch: toolchain problem.
 920501-9.c.s.wast # env.sprintf
 920726-1.c.s.wast # env.sprintf
 920810-1.c.s.wast # env.malloc
-921110-1.c.s.wast # abort() is declared with the wrong type (returning i32)
 921117-1.c.s.wast # env.strcmp
 930513-1.c.s.wast # env.sprintf
 930622-2.c.s.wast # env.__floatditf


### PR DESCRIPTION
Also update expected failures, and change failure state back to error instead of warning, as the blocking bug has been fixed.