### PR TITLE
Switch asm2wasm torture tests back to native-wasm mode

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -999,7 +999,7 @@ def CompileLLVMTortureBinaryen(name, em_config, outdir, fails):
       sysroot_dir=INSTALL_SYSROOT,
       fails=fails,
       out=outdir,
-      config='binaryen-interpret')
+      config='binaryen-native' if name == 'asm2wasm' else 'binaryen-interpret')
   Archive('torture-' + name, Tar(outdir))
   if 0 != unexpected_result_count:
     buildbot.Fail()

--- a/src/test/asm2wasm_run_known_gcc_test_failures.txt
+++ b/src/test/asm2wasm_run_known_gcc_test_failures.txt
@@ -40,4 +40,3 @@ simd-4.c.js
 simd-5.c.js
 simd-6.c.js
 va-arg-pack-1.c.js
-nestfunc-4.c.js


### PR DESCRIPTION
They now work again with 0xc. emwasm still has failures to be investigated.