### PR TITLE
Fix upload of debian package

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -962,7 +962,7 @@ def DebianPackage():
       Git(['checkout', 'debian/changelog'], cwd=top_dir)
 
       debfile = os.path.join(os.path.dirname(top_dir),
-                             'wasm-toolchain_0.1_amd64.deb')
+                             'wasm-toolchain_%s_amd64.deb' % version)
       UploadFile(debfile, os.path.basename(debfile))
   except proc.CalledProcessError:
     # Note the failure but allow the build to continue.


### PR DESCRIPTION
The version number of the debian package is now dependent
of the build number.