### PR TITLE
Copy libLLVM dylib for mac and windows too

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -710,7 +710,7 @@ def CopyLLVMTools(build_dir, prefix=''):
   # The following are useful, LLVM_INSTALL_TOOLCHAIN_ONLY did away with them.
   extra_bins = ['FileCheck', 'lli', 'llc', 'llvm-as', 'llvm-dis', 'llvm-link',
                 'llvm-mc', 'llvm-nm', 'llvm-objdump', 'llvm-readobj', 'opt']
-  extra_libs = ['libLLVM*.so']
+  extra_libs = ['libLLVM*.%s' % ext for ext in ['so', 'dylib', 'dll']]
   for p in [glob.glob(os.path.join(build_dir, 'bin', b)) for b in
             extra_bins]:
     for e in p:


### PR DESCRIPTION
This isn't needed for upstream LLVM since https://reviews.llvm.org/D24676 but is still needed for fastcomp until it updates to include that patch.