### PR TITLE
Use prebuilt binary node.js

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -122,7 +122,7 @@ OCAML_DIR = os.path.join(WORK_DIR, OCAML_VERSION)
 OCAML_OUT_DIR = os.path.join(WORK_DIR, 'ocaml-out')
 OCAML_BIN_DIR = os.path.join(OCAML_OUT_DIR, 'bin')
 
-# Use prebuilt Node.js binary because the buildbots don't have node preinstalled
+# Use prebuilt Node.js because the buildbots don't have node preinstalled
 NODE_VERSION = '7.0.0'
 NODE_BASE_NAME = 'node-v' + NODE_VERSION + '-'
 

--- a/src/build.py
+++ b/src/build.py
@@ -123,7 +123,11 @@ OCAML_BIN_DIR = os.path.join(OCAML_OUT_DIR, 'bin')
 
 # Sync Node.js binary
 NODE_VERSION = '7.0.0'
-NODE_TAR_BASE = 'node-v' + NODE_VERSION + '-'
+NODE_BASE_NAME = 'node-v' + NODE_VERSION + '-'
+def NodePlatformName():
+    return {'darwin': 'darwin-x64', 'linux2': 'linux-x64'}[sys.platform]
+NODE_BIN = os.path.join(WORK_DIR, NODE_BASE_NAME + NodePlatformName(),
+                           'bin', 'node')
 
 # Known failures.
 IT_IS_KNOWN = 'known_gcc_test_failures.txt'
@@ -509,11 +513,11 @@ def SyncTarball(out_dir, name, version, url, tar):
 def SyncOCaml(name, src_dir, git_repo):
   return SyncTarball(src_dir, 'OCaml', OCAML_VERSION, OCAML_URL, OCAML_TAR)
 
+
 def SyncPrebuiltNodeJS(name, src_dir, git_repo):
-  os_string = {'darwin': 'darwin-x64', 'linux2': 'linux-x64'}[sys.platform]
   extension = {'darwin': 'gz', 'linux2': 'xz'}[sys.platform]
-  out_dir = os.path.join(WORK_DIR, NODE_TAR_BASE + os_string)
-  tarball = NODE_TAR_BASE + os_string + '.tar.' + extension
+  out_dir = os.path.join(WORK_DIR, NODE_BASE_NAME + NodePlatformName())
+  tarball = NODE_BASE_NAME + NodePlatformName() + '.tar.' + extension
   print tarball
   node_url = WASM_STORAGE_BASE + tarball
   return SyncTarball(out_dir, name, NODE_VERSION, node_url,
@@ -895,6 +899,7 @@ def Emscripten(use_asm=True):
   def WriteEmscriptenConfig(infile, outfile):
     with open(infile) as config:
       text = config.read().replace('{{WASM_INSTALL}}', INSTALL_DIR)
+      text = text.replace('{{PREBUILT_NODE}}', NODE_BIN)
     with open(outfile, 'w') as config:
       config.write(text)
 

--- a/src/build.py
+++ b/src/build.py
@@ -110,9 +110,10 @@ MUSL_GIT_BASE = 'https://github.com/jfbastien/'
 # clobbering any local development.
 WATERFALL_REMOTE = '_waterfall'
 
+WASM_STORAGE_BASE = 'https://wasm.storage.googleapis.com/'
+
 # Sync OCaml from a cached tar file because the upstream repository is only
 # http. The file untars into a directory of the same name as the tar file.
-WASM_STORAGE_BASE = 'https://wasm.storage.googleapis.com/'
 OCAML_VERSION = 'ocaml-4.02.2'
 OCAML_TAR_NAME = OCAML_VERSION + '.tar.gz'
 OCAML_TAR = os.path.join(WORK_DIR, OCAML_TAR_NAME)
@@ -121,7 +122,7 @@ OCAML_DIR = os.path.join(WORK_DIR, OCAML_VERSION)
 OCAML_OUT_DIR = os.path.join(WORK_DIR, 'ocaml-out')
 OCAML_BIN_DIR = os.path.join(OCAML_OUT_DIR, 'bin')
 
-# Sync Node.js binary
+# Use prebuilt Node.js binary because the buildbots don't have node preinstalled
 NODE_VERSION = '7.0.0'
 NODE_BASE_NAME = 'node-v' + NODE_VERSION + '-'
 
@@ -520,7 +521,6 @@ def SyncPrebuiltNodeJS(name, src_dir, git_repo):
   extension = {'darwin': 'gz', 'linux2': 'xz'}[sys.platform]
   out_dir = os.path.join(WORK_DIR, NODE_BASE_NAME + NodePlatformName())
   tarball = NODE_BASE_NAME + NodePlatformName() + '.tar.' + extension
-  print tarball
   node_url = WASM_STORAGE_BASE + tarball
   return SyncTarball(out_dir, name, NODE_VERSION, node_url,
                      os.path.join(WORK_DIR, tarball))

--- a/src/build.py
+++ b/src/build.py
@@ -124,10 +124,12 @@ OCAML_BIN_DIR = os.path.join(OCAML_OUT_DIR, 'bin')
 # Sync Node.js binary
 NODE_VERSION = '7.0.0'
 NODE_BASE_NAME = 'node-v' + NODE_VERSION + '-'
+
+
 def NodePlatformName():
-    return {'darwin': 'darwin-x64', 'linux2': 'linux-x64'}[sys.platform]
+  return {'darwin': 'darwin-x64', 'linux2': 'linux-x64'}[sys.platform]
 NODE_BIN = os.path.join(WORK_DIR, NODE_BASE_NAME + NodePlatformName(),
-                           'bin', 'node')
+                        'bin', 'node')
 
 # Known failures.
 IT_IS_KNOWN = 'known_gcc_test_failures.txt'

--- a/src/emscripten_config
+++ b/src/emscripten_config
@@ -20,7 +20,11 @@ BINARYEN_ROOT = os.path.join(WASM_INSTALL) # directory
 # EMSCRIPTEN_NATIVE_OPTIMIZER='/path/to/custom/optimizer(.exe)'
 
 # See below for notes on which JS engine(s) you need
-NODE_JS = os.path.expanduser(os.getenv('NODE') or '/usr/bin/nodejs') # executable
+prebuilt_node = '{{PREBUILT_NODE}}'
+if not os.path.isfile(prebuilt_node):
+   prebuilt_node = None
+
+NODE_JS = os.path.expanduser(os.getenv('NODE') or prebuilt_node  or '/usr/bin/nodejs') # executable
 SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY') or 'js')] # executable
 V8_ENGINE = os.path.join(WASM_INSTALL, 'bin', 'd8') # executable
 
@@ -42,8 +46,8 @@ CRUNCH = os.path.expanduser(os.getenv('CRUNCH') or 'crunch') # executable
 #                 spidermonkey from source. Any of these three is fine, as long as it's
 #                 a recent version (especially for v8 and spidermonkey).
 
-#COMPILER_ENGINE = NODE_JS
-COMPILER_ENGINE = V8_ENGINE
+COMPILER_ENGINE = NODE_JS
+#COMPILER_ENGINE = V8_ENGINE
 #COMPILER_ENGINE = SPIDERMONKEY_ENGINE
 
 

--- a/src/emscripten_config_vanilla
+++ b/src/emscripten_config_vanilla
@@ -20,7 +20,11 @@ BINARYEN_ROOT = os.path.join(WASM_INSTALL) # directory
 # EMSCRIPTEN_NATIVE_OPTIMIZER='/path/to/custom/optimizer(.exe)'
 
 # See below for notes on which JS engine(s) you need
-NODE_JS = os.path.expanduser(os.getenv('NODE') or '/usr/bin/nodejs') # executable
+prebuilt_node = '{{PREBUILT_NODE}}'
+if not os.path.isfile(prebuilt_node):
+   prebuilt_node = None
+
+NODE_JS = os.path.expanduser(os.getenv('NODE') or prebuilt_node or '/usr/bin/nodejs') # executable
 SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY') or 'js')] # executable
 V8_ENGINE = os.path.join(WASM_INSTALL, 'bin', 'd8') # executable
 
@@ -42,8 +46,8 @@ CRUNCH = os.path.expanduser(os.getenv('CRUNCH') or 'crunch') # executable
 #                 spidermonkey from source. Any of these three is fine, as long as it's
 #                 a recent version (especially for v8 and spidermonkey).
 
-#COMPILER_ENGINE = NODE_JS
-COMPILER_ENGINE = V8_ENGINE
+COMPILER_ENGINE = NODE_JS
+#COMPILER_ENGINE = V8_ENGINE
 #COMPILER_ENGINE = SPIDERMONKEY_ENGINE
 
 


### PR DESCRIPTION
Node.js isn't part of the base image for our buildbots, so it disappears whenever they get swapped or wiped. Use a prebuilt from nodejs.org (mirrored locally) instead. Keep the config file's fallback to /usr/bin/node in case someone ends up using that config file. Also use node as the compiler engine, as that more closely reflects what users are likely to do.