### PR TITLE
Make sure the we only append "python" to python scripts that aren't i…

### DIFF
--- a/src/proc.py
+++ b/src/proc.py
@@ -30,7 +30,8 @@ from subprocess import * # flake8: noqa
 
 
 def FixPython(cmd):
-  if cmd[0].endswith('.py'):
+  script = cmd[0]
+  if script.endswith('.py') and os.path.exists(script):
     return [sys.executable] + cmd
   return cmd
 


### PR DESCRIPTION
…n PATH

gsutil.py is in PATH, so `python gsutil.py` doesn't work.
This won't fix Windows, but should fix the Mac and Linux bots.