### PR TITLE
Triage asm2wasm known failures

### DIFF
--- a/src/test/asm2wasm_run_known_gcc_test_failures.txt
+++ b/src/test/asm2wasm_run_known_gcc_test_failures.txt
@@ -1,40 +1,49 @@
 # Expected failures from running torture tests from emcc/binaryen with asm2wasm
 # and binaryen interpret-binary mode
 
-20010122-1.c.js
-20030222-1.c.js
-20031003-1.c.js
-20050316-2.c.js
-20050604-1.c.js
-20050607-1.c.js
-20060420-1.c.js
-20071018-1.c.js
-20071120-1.c.js
-20071220-1.c.js
-20071220-2.c.js
-20101011-1.c.js
-alloca-1.c.js
-bitfld-3.c.js
-bitfld-5.c.js
-builtin-bitops-1.c.js
-eeprof-1.c.js
-frame-address.c.js
-pr17377.c.js
-pr32244-1.c.js
-pr34971.c.js
-pr36765.c.js
-pr38533.c.js
-pr39228.c.js
-pr41239.c.js
-pr43008.c.js
-pr47237.c.js
-pr49279.c.js
-pr53645-2.c.js
-pr53645.c.js
-pr60960.c.js
-simd-1.c.js
-simd-2.c.js
-simd-4.c.js
-simd-5.c.js
-simd-6.c.js
-va-arg-pack-1.c.js
+# no builtin returnaddress or frameaddress
+20010122-1.c
+frame-address.c
+pr17377.c
+
+# inline assembly tricks
+20030222-1.c
+20071220-1.c
+20071220-2.c
+pr38533.c
+pr41239.c
+pr49279.c
+
+# aborts in native clang
+20031003-1.c
+20071018-1.c
+20071120-1.c
+alloca-1.c
+bitfld-3.c
+bitfld-5.c
+builtin-bitops-1.c
+eeprof-1.c
+pr34971.c
+pr36765.c
+pr39228.c
+pr43008.c
+pr47237.c
+va-arg-pack-1.c
+
+# SIMD
+20050316-2.c
+20050604-1.c
+20050607-1.c
+20060420-1.c
+simd-1.c
+simd-2.c
+simd-4.c
+simd-5.c
+simd-6.c
+pr53645-2.c
+pr53645.c
+pr60960.c
+
+# signal()
+20101011-1.c
+


### PR DESCRIPTION
As suggested by @dschuff in #146.

Sadly (?) nothing interesting turned up, was hoping for another interesting bug like that float thing. But I guess it's good to know that nothing that should work is broken. In particular, no failure is wasm-specific, it all is stuff expected to fail in asm.js too:

 * The `returnaddress` and `frameaddress` builtins cannot be supported in asm.js or wasm.
 * Inline assembly stuff. (This is maybe the one thing we could make work, we could add some workaround to ignore them I guess, they seem like memory barriers, but that's not something we need to test yet anyhow.)
 * Stuff that aborts in native clang - things that only work in gcc, weird builtins and such, or undefined behavior that clang handles differently than gcc (e.g. the first in that category is a float to int rounding thing).
 * SIMD stuff (some might work in asm.js, actually, but not really supported).
 * One test uses `signal()`.