### PR TITLE
Unify CMake binary sync and support Windows

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -123,6 +123,9 @@ def IsWindows():
   return sys.platform == 'win32'
 
 
+def IsMac():
+  return sys.platform == 'darwin'
+
 def Executable(name):
   if IsWindows():
     return name + '.exe'
@@ -500,7 +503,8 @@ def SyncTarball(out_dir, name, version, url, tar):
     with open(tar, 'w+b') as out:
       out.write(f.read())
       out.seek(0)
-      tarfile.open(mode='r:gz', fileobj=out).extractall(path=WORK_DIR)
+      print 'Extracting %s' % tar
+      tarfile.open(mode='r', fileobj=out).extractall(path=WORK_DIR)
   except urllib2.URLError as e:
     print 'Error downloading %s: %s' % (url, e)
     raise
@@ -519,8 +523,12 @@ def SyncPrebuiltCMake(name, src_dir, git_repo):
     archive = os.path.join(WORK_DIR, file_name)
 
     SyncTarball(PREBUILT_CMAKE_DIR, 'CMake', '3.4.3', url, archive)
-  
-    os.rename(os.path.join(WORK_DIR, file_base), PREBUILT_CMAKE_DIR)
+
+    contents_dir = os.path.join(WORK_DIR, file_base)
+    if IsMac():
+      contents_dir = os.path.join(contents_dir, 'CMake.app', 'Contents')
+    os.rename(contents_dir, PREBUILT_CMAKE_DIR)
+
     assert os.path.isfile(PREBUILT_CMAKE_BIN)
 
 

--- a/src/build.py
+++ b/src/build.py
@@ -26,6 +26,7 @@ import tarfile
 import tempfile
 import traceback
 import urllib2
+import zipfile
 
 import assemble_files
 import buildbot
@@ -504,7 +505,11 @@ def SyncTarball(out_dir, name, version, url, tar):
       out.write(f.read())
       out.seek(0)
       print 'Extracting %s' % tar
-      tarfile.open(mode='r', fileobj=out).extractall(path=WORK_DIR)
+      if tar.endswith('.zip'):
+        with zipfile.ZipFile(out, 'r') as zip:
+          zip.extractall(path=WORK_DIR)
+      else:
+        tarfile.open(mode='r', fileobj=out).extractall(path=WORK_DIR)
   except urllib2.URLError as e:
     print 'Error downloading %s: %s' % (url, e)
     raise
@@ -527,9 +532,8 @@ def SyncPrebuiltCMake(name, src_dir, git_repo):
     contents_dir = os.path.join(WORK_DIR, file_base)
     if IsMac():
       contents_dir = os.path.join(contents_dir, 'CMake.app', 'Contents')
-    os.rename(contents_dir, PREBUILT_CMAKE_DIR)
 
-    assert os.path.isfile(PREBUILT_CMAKE_BIN)
+    os.rename(contents_dir, PREBUILT_CMAKE_DIR)
 
 
 def SyncOCaml(name, src_dir, git_repo):

--- a/src/build.py
+++ b/src/build.py
@@ -507,7 +507,7 @@ def SyncArchive(out_dir, name, version, url):
     with tempfile.TemporaryFile()as t:
       t.write(f.read())
       t.seek(0)
-      print 'Extracting %s' % tar
+      print 'Extracting...'
       if url.endswith('zip'):
         with zipfile.ZipFile(t, 'r') as zip:
           zip.extractall(path=WORK_DIR)

--- a/src/build.py
+++ b/src/build.py
@@ -497,7 +497,7 @@ def SyncTarball(out_dir, name, version, url, tar):
     f = urllib2.urlopen(url)
     print 'URL: %s' % f.geturl()
     print 'Info: %s' % f.info()
-    with open(tar, 'wb') as out:
+    with open(tar, 'w+b') as out:
       out.write(f.read())
       out.seek(0)
       tarfile.open(mode='r:gz', fileobj=out).extractall(path=WORK_DIR)


### PR DESCRIPTION
* Use the official CMake binary distribution for all platforms, including Windows
* Unify CMake download with SyncTarball, which does the same thing
* Enable WABT and Binaryen builds on Windows