### PR TITLE
Support building CMake projects on Windows with Chromium infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_script:
   - flake8 --version
 script:
   - flake8
-  - ./src/build.py --sync-include=chromium-clang,cmake,wabt --build-include=wabt,debian --no-test
+  - ./src/build.py --sync-include=host-toolchain,cmake,wabt --build-include=wabt,debian --no-test
 notifications:
   email: false

--- a/src/build.py
+++ b/src/build.py
@@ -485,6 +485,7 @@ def SyncToolchain(name, src_dir, git_repo):
   else:
     host_toolchains.SyncPrebuiltClang(name, src_dir, git_repo)
 
+
 def SyncArchive(out_dir, name, version, url):
   if os.path.isdir(out_dir):
     print '%s directory already exists' % name
@@ -576,7 +577,8 @@ ALL_SOURCES = [
     Source('host-toolchain', PREBUILT_CLANG,
            GIT_MIRROR_BASE + 'chromium/src/tools/clang',
            custom_sync=SyncToolchain),
-    Source('cr-buildtools', os.path.join(WORK_DIR, 'build'), GIT_MIRROR_BASE+'chromium/src/build'),
+    Source('cr-buildtools', os.path.join(WORK_DIR, 'build'),
+           GIT_MIRROR_BASE + 'chromium/src/build'),
     Source('cmake', '', '',  # The source and git args are ignored.
            custom_sync=SyncPrebuiltCMake),
     Source('nodejs', '', '',  # The source and git args are ignored.

--- a/src/build.py
+++ b/src/build.py
@@ -576,6 +576,7 @@ ALL_SOURCES = [
     Source('host-toolchain', PREBUILT_CLANG,
            GIT_MIRROR_BASE + 'chromium/src/tools/clang',
            custom_sync=SyncToolchain),
+    Source('cr-buildtools', os.path.join(WORK_DIR, 'build'), GIT_MIRROR_BASE+'chromium/src/build'),
     Source('cmake', '', '',  # The source and git args are ignored.
            custom_sync=SyncPrebuiltCMake),
     Source('nodejs', '', '',  # The source and git args are ignored.
@@ -830,12 +831,15 @@ def Wabt():
   cl = host_toolchains.GetToolchainPath('cc')
   buildbot.Step('WABT')
   Mkdir(WABT_OUT_DIR)
+  if IsWindows():
+    host_toolchains.CopyDlls(WABT_OUT_DIR, 'Release')
+    cc_env = host_toolchains.GetEnv(WABT_OUT_DIR)
   proc.check_call([PREBUILT_CMAKE_BIN, '-G', 'Ninja', WABT_SRC_DIR,
-                   '-DCMAKE_INSTALL_PREFIX=%s' % INSTALL_DIR,
+                   '-DCMAKE_INSTALL_PREFIX=%s' % INSTALL_DIR, '-DCMAKE_BUILD_TYPE=Release',
                    '-DBUILD_TESTS=OFF'] + OverrideCMakeCompiler(),
-                  cwd=WABT_OUT_DIR)
-  proc.check_call(['ninja'], cwd=WABT_OUT_DIR)
-  proc.check_call(['ninja', 'install'], cwd=WABT_OUT_DIR)
+                  cwd=WABT_OUT_DIR, env=cc_env)
+  proc.check_call(['ninja'], cwd=WABT_OUT_DIR, env=cc_env)
+  proc.check_call(['ninja', 'install'], cwd=WABT_OUT_DIR, env=cc_env)
 
 
 def OCaml():

--- a/src/build.py
+++ b/src/build.py
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import errno
 import glob
 import json
 import multiprocessing
@@ -33,6 +32,7 @@ import buildbot
 import cloud
 import compile_torture_tests
 import execute_files
+from file_util import Chdir, CopyTree, Mkdir, Remove
 import host_toolchains
 import link_assembly_files
 import proc
@@ -202,69 +202,6 @@ GCC_REVISION = 'b6125c702850488ac3bfb1079ae5c9db89989406'
 GCC_CLONE_DEPTH = 1000
 
 
-# Shell utilities
-
-def Chdir(path):
-  print 'Change directory to: %s' % path
-  os.chdir(path)
-
-
-def Mkdir(path):
-  """Create a directory at a specified path.
-
-  Creates all intermediate directories along the way.
-  e.g.: Mkdir('a/b/c') when 'a/' is an empty directory will
-        cause the creation of directories 'a/b/' and 'a/b/c/'.
-
-  If the path already exists (and is already a directory), this does nothing.
-  """
-  try:
-    os.makedirs(path)
-  except OSError as e:
-    if not os.path.isdir(path):
-      raise Exception('Path %s is not a directory!' % path)
-    if not e.errno == errno.EEXIST:
-      raise e
-
-
-def Remove(path):
-  """Remove file or directory if it exists, do nothing otherwise."""
-  if os.path.exists(path):
-    print 'Removing %s' % path
-    if os.path.isdir(path):
-      shutil.rmtree(path)
-    else:
-      os.remove(path)
-
-
-def CopyTree(src, dst):
-  """Recursively copy the items in the src directory to the dst directory.
-
-  Unlike shutil.copytree, the destination directory and any subdirectories and
-  files may exist. Existing directories are left untouched, and existing files
-  are removed and copied from the source using shutil.copy2. It is also not
-  symlink-aware.
-
-  Args:
-    src: Source. Must be an existing directory.
-    dst: Destination directory. If it exists, must be a directory. Otherwise it
-         will be created, along with parent directories.
-  """
-  print 'Copying directory %s to %s' % (src, dst)
-  if not os.path.isdir(dst):
-    os.makedirs(dst)
-  for root, dirs, files in os.walk(src):
-    relroot = os.path.relpath(root, src)
-    dstroot = os.path.join(dst, relroot)
-    for d in dirs:
-      dstdir = os.path.join(dstroot, d)
-      if not os.path.isdir(dstdir):
-        os.mkdir(dstdir)
-    for f in files:
-      dstfile = os.path.join(dstroot, f)
-      if os.path.isfile(dstfile):
-        os.remove(dstfile)
-      shutil.copy2(os.path.join(root, f), dstfile)
 
 
 def CopyBinaryToArchive(binary, prefix=''):
@@ -484,6 +421,8 @@ def SyncToolchain(name, src_dir, git_repo):
     host_toolchains.SyncWinToolchain()
   else:
     host_toolchains.SyncPrebuiltClang(name, src_dir, git_repo)
+    assert os.path.isfile(CC), 'Expect clang at %s' % CC
+    assert os.path.isfile(CXX), 'Expect clang++ at %s' % CXX
 
 
 def SyncArchive(out_dir, name, version, url):
@@ -835,7 +774,7 @@ def Wabt():
   if IsWindows():
     cc_env = host_toolchains.SetUpEnv(WABT_OUT_DIR)
     host_toolchains.CopyDlls(WABT_OUT_DIR, 'Release')
-    # TODO(dschuff): Figure out how to make thise statically linked?
+    # TODO(dschuff): Figure out how to make this statically linked?
     host_toolchains.CopyDlls(INSTALL_BIN, 'Release')
 
   proc.check_call([PREBUILT_CMAKE_BIN, '-G', 'Ninja', WABT_SRC_DIR,

--- a/src/build.py
+++ b/src/build.py
@@ -202,8 +202,6 @@ GCC_REVISION = 'b6125c702850488ac3bfb1079ae5c9db89989406'
 GCC_CLONE_DEPTH = 1000
 
 
-
-
 def CopyBinaryToArchive(binary, prefix=''):
   """All binaries are archived in the same tar file."""
   install_bin = os.path.join(INSTALL_DIR, prefix, 'bin')

--- a/src/build.py
+++ b/src/build.py
@@ -770,7 +770,7 @@ def Wabt():
   Mkdir(WABT_OUT_DIR)
   cc_env = None
   if IsWindows():
-    cc_env = host_toolchains.SetUpEnv(WABT_OUT_DIR)
+    cc_env = host_toolchains.SetUpVSEnv(WABT_OUT_DIR)
     host_toolchains.CopyDlls(WABT_OUT_DIR, 'Release')
     # TODO(dschuff): Figure out how to make this statically linked?
     host_toolchains.CopyDlls(INSTALL_BIN, 'Release')

--- a/src/file_util.py
+++ b/src/file_util.py
@@ -21,6 +21,7 @@ import errno
 import os
 import shutil
 
+
 def Chdir(path):
   print 'Change directory to: %s' % path
   os.chdir(path)

--- a/src/file_util.py
+++ b/src/file_util.py
@@ -1,0 +1,84 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#   Copyright 2015 WebAssembly Community Group participants
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Shell utilities
+
+import errno
+import os
+import shutil
+
+def Chdir(path):
+  print 'Change directory to: %s' % path
+  os.chdir(path)
+
+
+def Mkdir(path):
+  """Create a directory at a specified path.
+
+  Creates all intermediate directories along the way.
+  e.g.: Mkdir('a/b/c') when 'a/' is an empty directory will
+        cause the creation of directories 'a/b/' and 'a/b/c/'.
+
+  If the path already exists (and is already a directory), this does nothing.
+  """
+  try:
+    os.makedirs(path)
+  except OSError as e:
+    if not os.path.isdir(path):
+      raise Exception('Path %s is not a directory!' % path)
+    if not e.errno == errno.EEXIST:
+      raise e
+
+
+def Remove(path):
+  """Remove file or directory if it exists, do nothing otherwise."""
+  if os.path.exists(path):
+    print 'Removing %s' % path
+    if os.path.isdir(path):
+      shutil.rmtree(path)
+    else:
+      os.remove(path)
+
+
+def CopyTree(src, dst):
+  """Recursively copy the items in the src directory to the dst directory.
+
+  Unlike shutil.copytree, the destination directory and any subdirectories and
+  files may exist. Existing directories are left untouched, and existing files
+  are removed and copied from the source using shutil.copy2. It is also not
+  symlink-aware.
+
+  Args:
+    src: Source. Must be an existing directory.
+    dst: Destination directory. If it exists, must be a directory. Otherwise it
+         will be created, along with parent directories.
+  """
+  print 'Copying directory %s to %s' % (src, dst)
+  if not os.path.isdir(dst):
+    os.makedirs(dst)
+  for root, dirs, files in os.walk(src):
+    relroot = os.path.relpath(root, src)
+    dstroot = os.path.join(dst, relroot)
+    for d in dirs:
+      dstdir = os.path.join(dstroot, d)
+      if not os.path.isdir(dstdir):
+        os.mkdir(dstdir)
+    for f in files:
+      dstfile = os.path.join(dstroot, f)
+      if os.path.isfile(dstfile):
+        os.remove(dstfile)
+      shutil.copy2(os.path.join(root, f), dstfile)

--- a/src/gyp.py
+++ b/src/gyp.py
@@ -1,8 +1,0 @@
-# Dummy gyp.py because chromium/src/vs_toolchain.py depends on gyp, but it's in
-# another repo.
-
-def NameValueListToDict(foo):
-  return {}
-
-def ShlexEnv(foo):
-  return None

--- a/src/gyp.py
+++ b/src/gyp.py
@@ -1,0 +1,8 @@
+# Dummy gyp.py because chromium/src/vs_toolchain.py depends on gyp, but it's in
+# another repo.
+
+def NameValueListToDict(foo):
+  return {}
+
+def ShlexEnv(foo):
+  return None

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -23,13 +23,11 @@ import proc
 WORK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'work')
 CR_BUILD_DIR = os.path.join(WORK_DIR, 'build')
 SETUP_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'toolchain', 'win', 'setup_toolchain.py')
-VS_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'vs_toolchain.py')
-WIN_TOOLCHAIN_JSON = os.path.join(CR_BUILD_DIR, 'win_toolchain.json')
+V8_SRC_DIR = os.path.join(WORK_DIR, 'v8', 'v8')
+VS_TOOLCHAIN = os.path.join(V8_SRC_DIR, 'gypfiles', 'vs_toolchain.py')
+WIN_TOOLCHAIN_JSON = os.path.join(V8_SRC_DIR, 'gypfiles', 'win_toolchain.json')
 
-dummy_gyp_env = os.environ.copy()
-dummy_gyp_env['PYTHONPATH'] = os.path.dirname(os.path.abspath(__file__))
-dummy_gyp_env['GYP_MSVS_VERSION'] = '2015'
-
+os.environ['GYP_MSVS_VERSION'] = '2015'
 
 def SyncPrebuiltClang(name, src_dir, git_repo):
   """Update the prebuilt clang toolchain used by chromium bots"""
@@ -51,7 +49,7 @@ def SyncPrebuiltClang(name, src_dir, git_repo):
 
 def SyncWinToolchain():
   """Update the VS toolchain used by Chromium bots"""
-  proc.check_call([VS_TOOLCHAIN, 'update'], env=dummy_gyp_env)
+  proc.check_call([VS_TOOLCHAIN, 'update'])
 
 
 def GetEnv(dir):
@@ -70,7 +68,7 @@ def SetUpEnv(outdir):
   """Set up the VS build environment used by Chromium bots"""
 
   # Get the chromium-packaged toolchain directory info in a JSON file
-  proc.check_call([VS_TOOLCHAIN, 'get_toolchain_dir'], env=dummy_gyp_env)
+  proc.check_call([VS_TOOLCHAIN, 'get_toolchain_dir'])
   with open(WIN_TOOLCHAIN_JSON) as f:
     paths = json.load(f)
 
@@ -84,4 +82,4 @@ def SetUpEnv(outdir):
 
 def CopyDlls(dir, configuration):
   """ Copy MSVS Runtime dlls into a build directory"""
-  proc.check_call([VS_TOOLCHAIN, 'copy_dlls', dir, configuration, 'x64'], env=dummy_gyp_env)
+  proc.check_call([VS_TOOLCHAIN, 'copy_dlls', dir, configuration, 'x64'])

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -58,7 +58,8 @@ def GetEnv(dir):
   with open(os.path.join(dir, 'environment.x64'), 'rb') as f:
     entries = f.read().split('\0')
     for e in entries:
-      if not e: continue
+      if not e:
+        continue
       var, val = e.split('=', 1)
       env[var] = val
   return env
@@ -76,7 +77,8 @@ def SetUpEnv(outdir):
   # block
   runtime_dirs = os.pathsep.join(paths['runtime_dirs'])
   proc.check_call([SETUP_TOOLCHAIN,
-                   'foo', paths['win_sdk'], runtime_dirs, 'x64', ''], cwd=outdir)
+                   'foo', paths['win_sdk'], runtime_dirs, 'x64', ''],
+                  cwd=outdir)
   return GetEnv(outdir)
 
 

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -23,12 +23,14 @@ import proc
 
 WORK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'work')
 CR_BUILD_DIR = os.path.join(WORK_DIR, 'build')
-SETUP_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'toolchain', 'win', 'setup_toolchain.py')
+SETUP_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'toolchain', 'win',
+                               'setup_toolchain.py')
 V8_SRC_DIR = os.path.join(WORK_DIR, 'v8', 'v8')
 VS_TOOLCHAIN = os.path.join(V8_SRC_DIR, 'gypfiles', 'vs_toolchain.py')
 WIN_TOOLCHAIN_JSON = os.path.join(V8_SRC_DIR, 'gypfiles', 'win_toolchain.json')
 
 os.environ['GYP_MSVS_VERSION'] = '2015'
+
 
 def SyncPrebuiltClang(name, src_dir, git_repo):
   """Update the prebuilt clang toolchain used by chromium bots"""

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -1,0 +1,68 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#   Copyright 2015 WebAssembly Community Group participants
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import json
+import os
+
+import proc
+
+# Update 3 final with patches with 10.0.10586.0 SDK.
+# Taken from https://cs.chromium.org/chromium/src/build/vs_toolchain.py?rcl=0&l=304
+# and should periodically be updated as Chromium gets updated.
+WIN_TOOLCHAIN_HASH = 'd5dc33b15d1b2c086f2f6632e2fd15882f80dbd3'
+#PREBUILT_CLANG = os.path.join(WORK_DIR, 'chromium-clang')
+#PREBUILT_CLANG_TOOLS_CLANG = os.path.join(PREBUILT_CLANG, 'tools', 'clang')
+#PREBUILT_CLANG_BIN = os.path.join(
+#    PREBUILT_CLANG, 'third_party', 'llvm-build', 'Release+Asserts', 'bin')
+#CC = os.path.join(PREBUILT_CLANG_BIN, 'clang')
+#CXX = os.path.join(PREBUILT_CLANG_BIN, 'clang++')
+
+
+def SyncPrebuiltClang(name, src_dir, git_repo):
+  tools_clang = os.path.join(src_dir, 'tools', 'clang')
+  if os.path.isdir(tools_clang):
+    print 'Prebuilt Chromium Clang directory already exists'
+  else:
+    print 'Cloning Prebuilt Chromium Clang directory'
+    Mkdir(src_dir)
+    Mkdir(os.path.join(src_dir, 'tools'))
+    Git(['clone', git_repo, tools_clang])
+  Git(['fetch'], cwd=tools_clang)
+  proc.check_call(
+      [os.path.join(tools_clang, 'scripts', 'update.py')])
+  assert os.path.isfile(CC), 'Expect clang at %s' % CC
+  assert os.path.isfile(CXX), 'Expect clang++ at %s' % CXX
+  return ('chromium-clang', tools_clang)
+
+
+def SyncWinToolchain(v8_src_dir):
+  print v8_src_dir
+  os.environ['GYP_MSVS_VERSION'] = '2015'
+  proc.check_call([os.path.join(v8_src_dir, 'gypfiles', 'vs_toolchain.py'), 'update'])
+
+
+def GetToolchainPath(cc):
+  v8_src_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'work', 'v8', 'v8')
+  proc.check_call(
+    [os.path.join(v8_src_dir, 'gypfiles', 'vs_toolchain.py'),
+     'get_toolchain_dir'])
+  
+  with open(os.path.join(v8_src_dir, 'gypfiles', 'win_toolchain.json')) as f:
+    paths = json.load(f)
+  
+  toolbin = os.path.join(paths['path'], 'VC', 'bin', 'amd64')
+  return os.path.join(toolbin, 'cl.exe')


### PR DESCRIPTION
Chrome's buildbots are special in that they do not have toolchains installed on the system. Instead they use a toolchain packaged and managed by depot_tools. This PR adds support for that setup.

* Factor toolchain stuff into host_toolchains.py
* Use scripts from Chromium's build tools repo to locate and use depot_tools toolchain
* Inject an environment like what CMake expects (similar to vcvars.bat) into build steps.