### PR TITLE
Re-enable LLVM regression tests on mac

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -743,9 +743,7 @@ def LLVM():
 
   proc.check_call(command, cwd=LLVM_OUT_DIR)
   proc.check_call(['ninja', '-v'] + jobs, cwd=LLVM_OUT_DIR)
-  if sys.platform != 'darwin':
-    # TODO(dschuff): remove this when https://reviews.llvm.org/D25304 lands
-    proc.check_call(['ninja', 'check-all'], cwd=LLVM_OUT_DIR)
+  proc.check_call(['ninja', 'check-all'], cwd=LLVM_OUT_DIR)
   proc.check_call(['ninja', 'install'] + jobs, cwd=LLVM_OUT_DIR)
   CopyLLVMTools(LLVM_OUT_DIR)
 


### PR DESCRIPTION
The patch fixing LLVM_LINK_LLVM_DYLIB has landed upstream