### PR TITLE
Build LLVM on windows

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -496,7 +496,6 @@ def SyncGNUWin32(name, src_dir, git_repo):
     return
   zipfile = os.path.join(GNUWIN32_DIR, GNUWIN32_ZIP)
   url = WASM_STORAGE_BASE + GNUWIN32_ZIP
-  print url
   return SyncArchive(GNUWIN32_DIR, name, '1', url)
 
 def NoSync(*args):

--- a/src/build.py
+++ b/src/build.py
@@ -725,12 +725,12 @@ def CopyLLVMTools(build_dir, prefix=''):
 
 
 def BuildEnv(build_dir, use_gnuwin32=False, bin_subdir=False,
-                runtime='Release'):
+             runtime='Release'):
   if not IsWindows():
     return None
   cc_env = host_toolchains.SetUpVSEnv(build_dir)
   if use_gnuwin32:
-    cc_env['PATH'] = cc_env['PATH'] + os.pathsep + os.path.join(GNUWIN32_DIR, 
+    cc_env['PATH'] = cc_env['PATH'] + os.pathsep + os.path.join(GNUWIN32_DIR,
                                                                 'bin')
   bin_dir = build_dir if not bin_subdir else os.path.join(build_dir, 'bin')
   Mkdir(bin_dir)

--- a/src/build.py
+++ b/src/build.py
@@ -724,7 +724,7 @@ def CopyLLVMTools(build_dir, prefix=''):
       CopyLibraryToArchive(os.path.join(build_dir, 'lib', e), prefix)
 
 
-def WinBuildEnv(build_dir, use_gnuwin32=False, bin_subdir=False,
+def BuildEnv(build_dir, use_gnuwin32=False, bin_subdir=False,
                 runtime='Release'):
   if not IsWindows():
     return None
@@ -742,7 +742,7 @@ def WinBuildEnv(build_dir, use_gnuwin32=False, bin_subdir=False,
 def LLVM():
   buildbot.Step('LLVM')
   Mkdir(LLVM_OUT_DIR)
-  cc_env = WinBuildEnv(LLVM_OUT_DIR, use_gnuwin32=True, bin_subdir=True)
+  cc_env = BuildEnv(LLVM_OUT_DIR, use_gnuwin32=True, bin_subdir=True)
   build_dylib = 'ON' if not IsWindows() else 'OFF'
   command = [PREBUILT_CMAKE_BIN, '-G', 'Ninja', LLVM_SRC_DIR,
              '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
@@ -806,7 +806,7 @@ def V8():
 def Wabt():
   buildbot.Step('WABT')
   Mkdir(WABT_OUT_DIR)
-  cc_env = WinBuildEnv(WABT_OUT_DIR)
+  cc_env = BuildEnv(WABT_OUT_DIR)
 
   proc.check_call([PREBUILT_CMAKE_BIN, '-G', 'Ninja', WABT_SRC_DIR,
                    '-DCMAKE_BUILD_TYPE=Release',
@@ -845,7 +845,7 @@ def Binaryen():
   buildbot.Step('binaryen')
   Mkdir(BINARYEN_OUT_DIR)
   # Currently it's a bad idea to do a non-asserts build of Binaryen
-  cc_env = WinBuildEnv(BINARYEN_OUT_DIR, bin_subdir=True, runtime='Debug')
+  cc_env = BuildEnv(BINARYEN_OUT_DIR, bin_subdir=True, runtime='Debug')
 
   proc.check_call(
       [PREBUILT_CMAKE_BIN, '-G', 'Ninja', BINARYEN_SRC_DIR,
@@ -860,7 +860,7 @@ def Fastcomp():
   Mkdir(FASTCOMP_OUT_DIR)
   install_dir = os.path.join(INSTALL_DIR, 'fastcomp')
   build_dylib = 'ON' if not IsWindows() else 'OFF'
-  cc_env = WinBuildEnv(FASTCOMP_OUT_DIR, use_gnuwin32=True, bin_subdir=True)
+  cc_env = BuildEnv(FASTCOMP_OUT_DIR, use_gnuwin32=True, bin_subdir=True)
   proc.check_call(
       [PREBUILT_CMAKE_BIN, '-G', 'Ninja', FASTCOMP_SRC_DIR,
        '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',

--- a/src/build.py
+++ b/src/build.py
@@ -444,6 +444,7 @@ def SyncArchive(out_dir, name, version, url):
     with tempfile.NamedTemporaryFile() as t:
       t.write(f.read())
       t.flush()
+      t.seek(0)
       print 'Extracting...'
       ext = os.path.splitext(url)[-1]
       if ext == '.zip':
@@ -452,7 +453,7 @@ def SyncArchive(out_dir, name, version, url):
       elif ext == '.xz':
         proc.check_call(['tar', '-xvf', t.name], cwd=WORK_DIR)
       else:
-        tarfile.open(t).extractall(path=WORK_DIR)
+        tarfile.open(fileobj=t).extractall(path=WORK_DIR)
   except urllib2.URLError as e:
     print 'Error downloading %s: %s' % (url, e)
     raise

--- a/src/build.py
+++ b/src/build.py
@@ -122,6 +122,7 @@ OCAML_BIN_DIR = os.path.join(OCAML_OUT_DIR, 'bin')
 GNUWIN32_DIR = os.path.join(WORK_DIR, 'gnuwin32')
 GNUWIN32_ZIP = 'gnuwin32.zip'
 
+
 def IsWindows():
   return sys.platform == 'win32'
 
@@ -494,9 +495,9 @@ def SyncPrebuiltNodeJS(name, src_dir, git_repo):
 def SyncGNUWin32(name, src_dir, git_repo):
   if not IsWindows():
     return
-  zipfile = os.path.join(GNUWIN32_DIR, GNUWIN32_ZIP)
   url = WASM_STORAGE_BASE + GNUWIN32_ZIP
   return SyncArchive(GNUWIN32_DIR, name, '1', url)
+
 
 def NoSync(*args):
   pass
@@ -539,7 +540,7 @@ ALL_SOURCES = [
            custom_sync=SyncPrebuiltCMake),
     Source('nodejs', '', '',  # The source and git args are ignored.
            custom_sync=SyncPrebuiltNodeJS, no_windows=True),
-    Source('gnuwin32', '', '', # The source and git args are ignored.
+    Source('gnuwin32', '', '',  # The source and git args are ignored.
            custom_sync=SyncGNUWin32),
     Source('wabt', WABT_SRC_DIR,
            WASM_GIT_BASE + 'wabt.git'),
@@ -723,12 +724,14 @@ def CopyLLVMTools(build_dir, prefix=''):
       CopyLibraryToArchive(os.path.join(build_dir, 'lib', e), prefix)
 
 
-def WinBuildEnv(build_dir, use_gnuwin32=False, bin_subdir=False, runtime='Release'):
+def WinBuildEnv(build_dir, use_gnuwin32=False, bin_subdir=False,
+                runtime='Release'):
   if not IsWindows():
     return None
   cc_env = host_toolchains.SetUpVSEnv(build_dir)
   if use_gnuwin32:
-    cc_env['PATH'] = cc_env['PATH'] + os.pathsep + os.path.join(GNUWIN32_DIR, 'bin')
+    cc_env['PATH'] = cc_env['PATH'] + os.pathsep + os.path.join(GNUWIN32_DIR, 
+                                                                'bin')
   bin_dir = build_dir if not bin_subdir else os.path.join(build_dir, 'bin')
   Mkdir(bin_dir)
   assert runtime in ['Release', 'Debug']

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -58,7 +58,7 @@ def GetVSEnv(dir):
   """ Return the configured VS build environment block as a python dict."""
   # The format is a list of nul-terminated strings of the form var=val
   # where 'var' is the environment variable name, and 'val' is its value
-  env = {}
+  env = os.environ.copy()
   with open(os.path.join(dir, 'environment.x64'), 'rb') as f:
     entries = f.read().split('\0')
     for e in entries:
@@ -66,6 +66,7 @@ def GetVSEnv(dir):
         continue
       var, val = e.split('=', 1)
       env[var] = val
+
   return env
 
 


### PR DESCRIPTION
LLVM's tests require unix utilities from GNUWin32, so download a prebuilt
of that, and inject into the PATH when building and testing LLVM.
Also disable building the LLVM dylib, as that seems broken on windows
currently.