### PR TITLE
Use git bash from depot_tools for LLVM regression tests

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -767,12 +767,14 @@ def LLVM():
 
   proc.check_call(command, cwd=LLVM_OUT_DIR, env=cc_env)
   proc.check_call(['ninja', '-v'] + jobs, cwd=LLVM_OUT_DIR, env=cc_env)
+
   def RunWithUnixUtils(cmd, **kwargs):
-    if IsWindows:
+    if IsWindows():
       return Git(['bash'] + cmd, **kwargs)
     else:
       return proc.check_call(cmd, **kwargs)
-  RunWithUnixUtils('ninja', 'check-all'], cwd=LLVM_OUT_DIR, env=cc_env)
+
+  RunWithUnixUtils(['ninja', 'check-all'], cwd=LLVM_OUT_DIR, env=cc_env)
   proc.check_call(['ninja', 'install'] + jobs, cwd=LLVM_OUT_DIR, env=cc_env)
 
   CopyLLVMTools(LLVM_OUT_DIR)

--- a/src/build.py
+++ b/src/build.py
@@ -119,9 +119,6 @@ OCAML_DIR = os.path.join(WORK_DIR, OCAML_VERSION)
 OCAML_OUT_DIR = os.path.join(WORK_DIR, 'ocaml-out')
 OCAML_BIN_DIR = os.path.join(OCAML_OUT_DIR, 'bin')
 
-GNUWIN32_DIR = os.path.join(WORK_DIR, 'gnuwin32')
-GNUWIN32_ZIP = 'gnuwin32.zip'
-
 
 def IsWindows():
   return sys.platform == 'win32'
@@ -492,14 +489,6 @@ def SyncPrebuiltNodeJS(name, src_dir, git_repo):
   return SyncArchive(out_dir, name, NODE_VERSION, node_url)
 
 
-# Utilities needed for running LLVM regression tests on Windows
-def SyncGNUWin32(name, src_dir, git_repo):
-  if not IsWindows():
-    return
-  url = WASM_STORAGE_BASE + GNUWIN32_ZIP
-  return SyncArchive(GNUWIN32_DIR, name, '1', url)
-
-
 def NoSync(*args):
   pass
 
@@ -541,8 +530,6 @@ ALL_SOURCES = [
            custom_sync=SyncPrebuiltCMake),
     Source('nodejs', '', '',  # The source and git args are ignored.
            custom_sync=SyncPrebuiltNodeJS, no_windows=True),
-    Source('gnuwin32', '', '',  # The source and git args are ignored.
-           custom_sync=SyncGNUWin32),
     Source('wabt', WABT_SRC_DIR,
            WASM_GIT_BASE + 'wabt.git'),
     Source('spec', SPEC_SRC_DIR,
@@ -725,14 +712,11 @@ def CopyLLVMTools(build_dir, prefix=''):
       CopyLibraryToArchive(os.path.join(build_dir, 'lib', e), prefix)
 
 
-def BuildEnv(build_dir, use_gnuwin32=False, bin_subdir=False,
-             runtime='Release'):
+def BuildEnv(build_dir, bin_subdir=False, runtime='Release'):
   if not IsWindows():
     return None
   cc_env = host_toolchains.SetUpVSEnv(build_dir)
-  if use_gnuwin32:
-    cc_env['PATH'] = cc_env['PATH'] + os.pathsep + os.path.join(GNUWIN32_DIR,
-                                                                'bin')
+
   bin_dir = build_dir if not bin_subdir else os.path.join(build_dir, 'bin')
   Mkdir(bin_dir)
   assert runtime in ['Release', 'Debug']
@@ -743,7 +727,7 @@ def BuildEnv(build_dir, use_gnuwin32=False, bin_subdir=False,
 def LLVM():
   buildbot.Step('LLVM')
   Mkdir(LLVM_OUT_DIR)
-  cc_env = BuildEnv(LLVM_OUT_DIR, use_gnuwin32=True, bin_subdir=True)
+  cc_env = BuildEnv(LLVM_OUT_DIR, bin_subdir=True)
   build_dylib = 'ON' if not IsWindows() else 'OFF'
   command = [PREBUILT_CMAKE_BIN, '-G', 'Ninja', LLVM_SRC_DIR,
              '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
@@ -783,7 +767,12 @@ def LLVM():
 
   proc.check_call(command, cwd=LLVM_OUT_DIR, env=cc_env)
   proc.check_call(['ninja', '-v'] + jobs, cwd=LLVM_OUT_DIR, env=cc_env)
-  proc.check_call(['ninja', 'check-all'], cwd=LLVM_OUT_DIR, env=cc_env)
+  def RunWithUnixUtils(cmd, **kwargs):
+    if IsWindows:
+      return Git(['bash'] + cmd, **kwargs)
+    else:
+      return proc.check_call(cmd, **kwargs)
+  RunWithUnixUtils('ninja', 'check-all'], cwd=LLVM_OUT_DIR, env=cc_env)
   proc.check_call(['ninja', 'install'] + jobs, cwd=LLVM_OUT_DIR, env=cc_env)
 
   CopyLLVMTools(LLVM_OUT_DIR)
@@ -864,7 +853,7 @@ def Fastcomp():
   Mkdir(FASTCOMP_OUT_DIR)
   install_dir = os.path.join(INSTALL_DIR, 'fastcomp')
   build_dylib = 'ON' if not IsWindows() else 'OFF'
-  cc_env = BuildEnv(FASTCOMP_OUT_DIR, use_gnuwin32=True, bin_subdir=True)
+  cc_env = BuildEnv(FASTCOMP_OUT_DIR, bin_subdir=True)
   proc.check_call(
       [PREBUILT_CMAKE_BIN, '-G', 'Ninja', FASTCOMP_SRC_DIR,
        '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -26,10 +26,11 @@ CR_BUILD_DIR = os.path.join(WORK_DIR, 'build')
 SETUP_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'toolchain', 'win',
                                'setup_toolchain.py')
 V8_SRC_DIR = os.path.join(WORK_DIR, 'v8', 'v8')
-VS_TOOLCHAIN = os.path.join(V8_SRC_DIR, 'gypfiles', 'vs_toolchain.py')
-WIN_TOOLCHAIN_JSON = os.path.join(V8_SRC_DIR, 'gypfiles', 'win_toolchain.json')
+VS_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'vs_toolchain.py')
+WIN_TOOLCHAIN_JSON = os.path.join(CR_BUILD_DIR, 'win_toolchain.json')
 
 os.environ['GYP_MSVS_VERSION'] = '2015'
+os.environ['PYTHONPATH'] = os.path.join(V8_SRC_DIR, 'tools', 'gyp', 'pylib')
 
 
 def SyncPrebuiltClang(name, src_dir, git_repo):
@@ -51,6 +52,8 @@ def SyncPrebuiltClang(name, src_dir, git_repo):
 
 def SyncWinToolchain():
   """Update the VS toolchain used by Chromium bots"""
+  e = os.environ.copy()
+
   proc.check_call([VS_TOOLCHAIN, 'update'])
 
 

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -26,11 +26,10 @@ CR_BUILD_DIR = os.path.join(WORK_DIR, 'build')
 SETUP_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'toolchain', 'win',
                                'setup_toolchain.py')
 V8_SRC_DIR = os.path.join(WORK_DIR, 'v8', 'v8')
-VS_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'vs_toolchain.py')
-WIN_TOOLCHAIN_JSON = os.path.join(CR_BUILD_DIR, 'win_toolchain.json')
+VS_TOOLCHAIN = os.path.join(V8_SRC_DIR, 'gypfiles', 'vs_toolchain.py')
+WIN_TOOLCHAIN_JSON = os.path.join(V8_SRC_DIR, 'gypfiles', 'win_toolchain.json')
 
 os.environ['GYP_MSVS_VERSION'] = '2015'
-os.environ['PYTHONPATH'] = os.path.join(V8_SRC_DIR, 'tools', 'gyp', 'pylib')
 
 
 def SyncPrebuiltClang(name, src_dir, git_repo):
@@ -52,8 +51,6 @@ def SyncPrebuiltClang(name, src_dir, git_repo):
 
 def SyncWinToolchain():
   """Update the VS toolchain used by Chromium bots"""
-  e = os.environ.copy()
-
   proc.check_call([VS_TOOLCHAIN, 'update'])
 
 


### PR DESCRIPTION
Several of clang's regression tests use some nontrivial unix utilities
and/or bash features. We've been using the gnuwin32 ports of these
utilities, but for reasons I don't fully understand yet, this
reliably causes some issues with temp files created by tests on
windows 7 (windows 10 seems fine). The git that comes with
depot_tools has an msys bash with msys versions of these utilities
that are sufficient for running the LLVM tests, so switch to that
for now.