### PR TITLE
Move special-casing of git from build.py to proc.py

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -770,7 +770,7 @@ def LLVM():
 
   def RunWithUnixUtils(cmd, **kwargs):
     if IsWindows():
-      return Git(['bash'] + cmd, **kwargs)
+      return proc.check_call(['git', 'bash'] + cmd, **kwargs)
     else:
       return proc.check_call(cmd, **kwargs)
 

--- a/src/build.py
+++ b/src/build.py
@@ -218,7 +218,6 @@ def CopyLibraryToArchive(library, prefix=''):
   shutil.copy2(library, install_lib)
 
 
-
 def Tar(directory, print_content=False):
   """Create a tar file from directory."""
   if not IsBuildbot():
@@ -254,7 +253,8 @@ def Archive(name, tar):
 
 def GitRemoteUrl(cwd, remote):
   """Get the URL of a remote."""
-  return proc.check_output(['git', 'config', '--get', 'remote.%s.url' % remote], cwd=cwd).strip()
+  return proc.check_output(
+      ['git', 'config', '--get', 'remote.%s.url' % remote], cwd=cwd).strip()
 
 
 def HasRemote(cwd, remote):
@@ -300,11 +300,13 @@ def IsBuildbot():
 
 def GitUpdateRemote(src_dir, git_repo, remote_name):
   try:
-    proc.check_call(['git', 'remote', 'set-url', remote_name, git_repo], cwd=src_dir)
+    proc.check_call(
+        ['git', 'remote', 'set-url', remote_name, git_repo], cwd=src_dir)
   except proc.CalledProcessError:
     # If proc.check_call fails it throws an exception. 'git remote set-url'
     # fails when the remote doesn't exist, so we should try to add it.
-    proc.check_call(['git', 'remote', 'add', remote_name, git_repo], cwd=src_dir)
+    proc.check_call(
+        ['git', 'remote', 'add', remote_name, git_repo], cwd=src_dir)
 
 
 class Source(object):

--- a/src/proc.py
+++ b/src/proc.py
@@ -36,7 +36,7 @@ def Which(filename, cwd, require_executable=True):
   to_search = [cwd] + os.environ.get('PATH', '').split(os.pathsep)
   exe_suffixes = ['']
   if sys.platform == 'win32':
-    exe_suffixes += ['.exe', '.bat']
+    exe_suffixes = ['.exe', '.bat'] + exe_suffixes
   for path in to_search:
     abs_path = os.path.abspath(os.path.join(path, filename))
     for suffix in exe_suffixes:

--- a/src/proc.py
+++ b/src/proc.py
@@ -48,32 +48,33 @@ def Which(filename, cwd, require_executable=True):
                   (filename, cwd, os.environ['PATH']))
 
 
-def FixPython(cmd, cwd):
-  script = cmd[0]
-  if script.endswith('.py'):
-    abs_script = Which(script, cwd, require_executable=False)
-    return [sys.executable, abs_script] + cmd[1:]
+def SpecialCases(cmd, cwd):
+  exe = cmd[0]
+  if exe.endswith('.py'):
+    script = Which(exe, cwd, require_executable=False)
+    return [sys.executable, script] + cmd[1:]
+  if exe == 'git' or exe == 'gclient':
+    return [Which(exe, cwd)] + cmd[1:]
   return cmd
 
 
 # Now we can override any parts of subprocess we want, while leaving the rest.
 def check_call(cmd, **kwargs):
   cwd = kwargs.get('cwd', os.getcwd())
-  cmd = FixPython(cmd, cwd)
+  cmd = SpecialCases(cmd, cwd)
   c = ' '.join('"' + c + '"' if ' ' in c else c for c in cmd)
   print 'subprocess.check_call(`%s`, cwd=`%s`)' % (c, cwd)
   sys.stdout.flush()
-  subprocess.check_call(cmd, **kwargs)
-  sys.stdout.flush()
+  try:
+    subprocess.check_call(cmd, **kwargs)
+  finally:
+    sys.stdout.flush()
 
 
 def check_output(cmd, **kwargs):
   cwd = kwargs.get('cwd', os.getcwd())
-  cmd = FixPython(cmd, cwd)
+  cmd = SpecialCases(cmd, cwd)
   c = ' '.join('"' + c + '"' if ' ' in c else c for c in cmd)
   print 'subprocess.check_output(`%s`, cwd=`%s`)' % (c, cwd)
   sys.stdout.flush()
-  try:
-    return subprocess.check_output(cmd, **kwargs)
-  finally:
-    sys.stdout.flush()
+  return subprocess.check_output(cmd, **kwargs)


### PR DESCRIPTION
Everywhere that we aren't actually using the output of the git command, use `proc.check_call()` instead of `proc.check_output()` so the output is shown in the build log.