### PR TITLE
Run the bare tests on Windows

### DIFF
--- a/src/assemble_files.py
+++ b/src/assemble_files.py
@@ -34,8 +34,8 @@ def assemble(infile, outfile, extras):
   assembler = extras['assembler']
   basename = os.path.splitext(os.path.basename(assembler))[0]
   commands = {
-      'wast2wasm': [extras['assembler'], infile, '-o', outfile],
-      'wasm-as': [extras['assembler'], infile, '-o', outfile]
+      'wast2wasm': [assembler, infile, '-o', outfile],
+      'wasm-as': [assembler, infile, '-o', outfile]
   }
   return commands[basename]
 

--- a/src/assemble_files.py
+++ b/src/assemble_files.py
@@ -32,7 +32,7 @@ def create_outname(outdir, infile):
 def assemble(infile, outfile, extras):
   """Create the command-line for an assembler invocation."""
   assembler = extras['assembler']
-  basename = os.path.basename(assembler)
+  basename = os.path.splitext(os.path.basename(assembler))[0]
   commands = {
       'wast2wasm': [extras['assembler'], infile, '-o', outfile],
       'wasm-as': [extras['assembler'], infile, '-o', outfile]

--- a/src/build.py
+++ b/src/build.py
@@ -997,8 +997,8 @@ def DebianPackage():
 def CompileLLVMTorture():
   name = 'Compile LLVM Torture'
   buildbot.Step(name)
-  c = os.path.join(INSTALL_BIN, 'clang')
-  cxx = os.path.join(INSTALL_BIN, 'clang++')
+  c = Executable(os.path.join(INSTALL_BIN, 'clang'))
+  cxx = Executable(os.path.join(INSTALL_BIN, 'clang++'))
   Remove(TORTURE_S_OUT_DIR)
   Mkdir(TORTURE_S_OUT_DIR)
   unexpected_result_count = compile_torture_tests.run(

--- a/src/build.py
+++ b/src/build.py
@@ -691,8 +691,9 @@ def CopyLLVMTools(build_dir, prefix=''):
   Remove(os.path.join(INSTALL_DIR, prefix, 'bin', 'clang-check'))
   # The following are useful, LLVM_INSTALL_TOOLCHAIN_ONLY did away with them.
   extra_bins = map(Executable,
-                   ['FileCheck', 'lli', 'llc', 'llvm-as', 'llvm-dis', 'llvm-link',
-                    'llvm-mc', 'llvm-nm', 'llvm-objdump', 'llvm-readobj', 'opt'])
+                   ['FileCheck', 'lli', 'llc', 'llvm-as', 'llvm-dis',
+                    'llvm-link', 'llvm-mc', 'llvm-nm', 'llvm-objdump',
+                    'llvm-readobj', 'opt'])
   extra_libs = ['libLLVM*.%s' % ext for ext in ['so', 'dylib', 'dll']]
   for p in [glob.glob(os.path.join(build_dir, 'bin', b)) for b in
             extra_bins]:
@@ -937,7 +938,7 @@ def Musl():
       # for LLVM.
       os.environ['PATH'] = (path + os.pathsep +
                             os.path.join(
-                              V8_SRC_DIR, 'third_party', 'cygwin', 'bin'))
+                                V8_SRC_DIR, 'third_party', 'cygwin', 'bin'))
     proc.check_call([
         os.path.join(MUSL_SRC_DIR, 'libc.py'),
         '--clang_dir', INSTALL_BIN,
@@ -1191,11 +1192,11 @@ def TestBare():
       warn_only=True)  # TODO wasm-shell is flaky when running tests.
   if not IsWindows():
     ExecuteLLVMTorture(
-      name='spec',
-      runner=Executable(os.path.join(INSTALL_BIN, 'wasm.opt')),
-      indir=s2wasm_out,
-      fails=SPEC_KNOWN_TORTURE_FAILURES,
-      extension='wast')
+        name='spec',
+        runner=Executable(os.path.join(INSTALL_BIN, 'wasm.opt')),
+        indir=s2wasm_out,
+        fails=SPEC_KNOWN_TORTURE_FAILURES,
+        extension='wast')
   ExecuteLLVMTorture(
       name='d8',
       runner=Executable(os.path.join(INSTALL_BIN, 'd8')),

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -58,6 +58,8 @@ def run(c, cxx, testsuite, sysroot_dir, fails, out, config='wasm'):
                              'BINARYEN_METHOD="interpret-binary"'],
   }
 
+  assert os.path.isfile(c), 'Cannot find C compiler at %s' % c
+  assert os.path.isfile(cxx), 'Cannot find C++ compiler at %s' % cxx
   assert os.path.isdir(testsuite), 'Cannot find testsuite at %s' % testsuite
   # TODO(jfb) Also compile other C tests, as well as C++ tests under g++.dg.
   c_torture = os.path.join(testsuite, 'gcc.c-torture', 'execute')

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -58,8 +58,6 @@ def run(c, cxx, testsuite, sysroot_dir, fails, out, config='wasm'):
                              'BINARYEN_METHOD="interpret-binary"'],
   }
 
-  assert os.path.isfile(c), 'Cannot find C compiler at %s' % c
-  assert os.path.isfile(cxx), 'Cannot find C++ compiler at %s' % cxx
   assert os.path.isdir(testsuite), 'Cannot find testsuite at %s' % testsuite
   # TODO(jfb) Also compile other C tests, as well as C++ tests under g++.dg.
   c_torture = os.path.join(testsuite, 'gcc.c-torture', 'execute')

--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -32,7 +32,7 @@ def create_outname(outdir, infile):
 def execute(infile, outfile, extras):
   """Create the command-line for an execution."""
   runner = extras['runner']
-  basename = os.path.basename(runner)
+  basename = os.path.splitext(os.path.basename(runner))[0]
   out_opt = ['-o', outfile] if outfile else []
   extra_files = extras['extra_files']
   config = basename

--- a/src/link_assembly_files.py
+++ b/src/link_assembly_files.py
@@ -32,7 +32,7 @@ def create_outname(outdir, infile):
 def link(infile, outfile, extras):
   """Create the command-line for a linker invocation."""
   linker = extras['linker']
-  basename = os.path.basename(linker)
+  basename = os.path.splitext(os.path.basename(linker))[0]
   commands = {
       's2wasm': [linker, '--allocate-stack', '1048576', '-o', outfile, infile],
       'wasm-as': [linker, '-o', outfile, infile],

--- a/src/testing.py
+++ b/src/testing.py
@@ -80,7 +80,8 @@ class Tester(object):
       output = proc.check_output(
           self.command_ctor(test_file, outfile, self.extras),
           stderr=proc.STDOUT, cwd=self.outdir or os.getcwd(),
-          preexec_fn=Tester.setlimits)
+          # preexec_fn is not supported on Windows
+          preexec_fn=Tester.setlimits if sys.platform != 'win32' else None)
       # Flush the logged command so buildbots don't think the script is dead.
       sys.stdout.flush()
       return Result(test=basename, success=True, output=output)


### PR DESCRIPTION
Several changes:
* Add a no_windows suppression to Test (like for Build)
* Invert the no_windows default for Build since most of the builds work now.
* Support windows in the Musl build
* Support windows in the bare test runners.