### PR TITLE
Only strip off windows exe suffixes in execute_files

### DIFF
--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -32,7 +32,7 @@ def create_outname(outdir, infile):
 def execute(infile, outfile, extras):
   """Create the command-line for an execution."""
   runner = extras['runner']
-  # Only strip Windows suffxes because wasm.opt has one
+  # Strip only Windows suffxes (instead of all) because wasm.opt has a suffix
   basename = os.path.basename(runner).replace('.exe', '').replace('.bat', '')
   out_opt = ['-o', outfile] if outfile else []
   extra_files = extras['extra_files']

--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -32,7 +32,8 @@ def create_outname(outdir, infile):
 def execute(infile, outfile, extras):
   """Create the command-line for an execution."""
   runner = extras['runner']
-  basename = os.path.splitext(os.path.basename(runner))[0]
+  # Only strip Windows suffxes because wasm.opt has one
+  basename = os.path.basename(runner).replace('.exe', '').replace('.bat', '')
   out_opt = ['-o', outfile] if outfile else []
   extra_files = extras['extra_files']
   config = basename


### PR DESCRIPTION
`wasm.opt` is the filename of the spec interpreter, so don't strip off
all suffixes; just ones that correspond to Windows executables