### PR TITLE
Support emscripten on Windows

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -132,6 +132,10 @@ def Executable(name, extension='.exe'):
   return name + extension if IsWindows() else name
 
 
+def WindowsFSEscape(path):
+  return os.path.normpath(path).replace('\\', '/')
+
+
 # Use prebuilt Node.js because the buildbots don't have node preinstalled
 NODE_VERSION = '7.0.0'
 NODE_BASE_NAME = 'node-v' + NODE_VERSION + '-'
@@ -927,8 +931,9 @@ def Emscripten(use_asm=True):
 
   def WriteEmscriptenConfig(infile, outfile):
     with open(infile) as config:
-      text = config.read().replace('{{WASM_INSTALL}}', INSTALL_DIR)
-      text = text.replace('{{PREBUILT_NODE}}', NODE_BIN)
+      text = config.read().replace('{{WASM_INSTALL}}',
+                                   WindowsFSEscape(INSTALL_DIR))
+      text = text.replace('{{PREBUILT_NODE}}', WindowsFSEscape(NODE_BIN))
     with open(outfile, 'w') as config:
       config.write(text)
 

--- a/src/build.py
+++ b/src/build.py
@@ -569,7 +569,7 @@ ALL_SOURCES = [
     Source('cmake', '', '',  # The source and git args are ignored.
            custom_sync=SyncPrebuiltCMake),
     Source('nodejs', '', '',  # The source and git args are ignored.
-           custom_sync=SyncPrebuiltNodeJS, no_windows=False),
+           custom_sync=SyncPrebuiltNodeJS),
     Source('wabt', WABT_SRC_DIR,
            WASM_GIT_BASE + 'wabt.git'),
     Source('spec', SPEC_SRC_DIR,
@@ -1195,7 +1195,7 @@ def AllBuilds(use_asm=False):
       Build('spec', Spec, no_windows=True),
       Build('binaryen', Binaryen),
       Build('fastcomp', Fastcomp),
-      Build('emscripten', Emscripten, False, use_asm),
+      Build('emscripten', Emscripten, use_asm=use_asm),
       # Target libs
       Build('musl', Musl),
       # Archive

--- a/src/build.py
+++ b/src/build.py
@@ -144,7 +144,7 @@ NODE_BASE_NAME = 'node-v' + NODE_VERSION + '-'
 def NodePlatformName():
   return {'darwin': 'darwin-x64',
           'linux2': 'linux-x64',
-          'win32':'win32'}[sys.platform]
+          'win32': 'win32'}[sys.platform]
 
 
 NODE_BIN = Executable(os.path.join(WORK_DIR,
@@ -514,7 +514,7 @@ def SyncWindowsNode():
     with open(NODE_BIN, 'wb') as n:
       n.write(f.read())
   except urllib2.URLError as e:
-    print 'Error downloading %s: %s' % (url, e)
+    print 'Error downloading %s: %s' % (node_url, e)
     raise
   return
 
@@ -1431,7 +1431,8 @@ def run(sync_filter, build_filter, test_filter, options):
   if IsWindows():
     host_toolchains.CopyDlls(INSTALL_BIN, 'Release')
     host_toolchains.CopyDlls(INSTALL_BIN, 'Debug')
-    host_toolchains.CopyDlls(os.path.join(INSTALL_DIR, 'fastcomp', 'bin'), 'Release')
+    host_toolchains.CopyDlls(
+        os.path.join(INSTALL_DIR, 'fastcomp', 'bin'), 'Release')
 
   try:
     BuildRepos(build_filter,

--- a/src/build.py
+++ b/src/build.py
@@ -1065,8 +1065,8 @@ def CompileLLVMTorture():
 def CompileLLVMTortureBinaryen(name, em_config, outdir, fails):
   buildbot.Step('Compile LLVM Torture (%s)' % name)
   os.environ['EM_CONFIG'] = em_config
-  c = os.path.join(INSTALL_DIR, 'emscripten', 'emcc')
-  cxx = os.path.join(INSTALL_DIR, 'emscripten', 'em++')
+  c = Executable(os.path.join(INSTALL_DIR, 'emscripten', 'emcc'), '.bat')
+  cxx = Executable(os.path.join(INSTALL_DIR, 'emscripten', 'em++'), '.bat')
   Remove(outdir)
   Mkdir(outdir)
   unexpected_result_count = compile_torture_tests.run(
@@ -1274,7 +1274,7 @@ def TestAsm():
       ASM2WASM_KNOWN_TORTURE_COMPILE_FAILURES)
   ExecuteLLVMTorture(
       name='asm2wasm',
-      runner=os.path.join(INSTALL_BIN, 'd8'),
+      runner=Executable(os.path.join(INSTALL_BIN, 'd8')),
       indir=asm2wasm_out,
       fails=ASM2WASM_KNOWN_TORTURE_FAILURES,
       extension='c.js',
@@ -1289,7 +1289,7 @@ def TestEmwasm():
       EMSCRIPTENWASM_KNOWN_TORTURE_COMPILE_FAILURES)
   ExecuteLLVMTorture(
       name='emwasm',
-      runner=os.path.join(INSTALL_BIN, 'd8'),
+      runner=Executable(os.path.join(INSTALL_BIN, 'd8')),
       indir=emscripten_wasm_out,
       fails=EMSCRIPTENWASM_KNOWN_TORTURE_FAILURES,
       extension='c.js',
@@ -1326,8 +1326,8 @@ def TestEmtestAsm2Wasm():
 
 ALL_TESTS = [
     Test('bare', TestBare),
-    Test('asm', TestAsm, no_windows=True),
-    Test('emwasm', TestEmwasm, no_windows=True),
+    Test('asm', TestAsm),
+    Test('emwasm', TestEmwasm),
     Test('emtest', TestEmtest, no_windows=True),
     Test('emtest-asm', TestEmtestAsm2Wasm, no_windows=True),
 ]
@@ -1431,6 +1431,7 @@ def run(sync_filter, build_filter, test_filter, options):
   if IsWindows():
     host_toolchains.CopyDlls(INSTALL_BIN, 'Release')
     host_toolchains.CopyDlls(INSTALL_BIN, 'Debug')
+    host_toolchains.CopyDlls(os.path.join(INSTALL_DIR, 'fastcomp', 'bin'), 'Release')
 
   try:
     BuildRepos(build_filter,


### PR DESCRIPTION
* Sync the windows node.js
* Build emscripten
* Fix test running and enable asm.js and emwasm tests
