### PR TITLE
Move prebuilt clang checkout to root of working dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_script:
   - flake8 --version
 script:
   - flake8
-  - ./src/build.py --sync-include=host-toolchain,cmake,wabt --build-include=wabt,debian --no-test
+  - ./src/build.py --sync-include=cr-buildtools,host-toolchain,cmake,wabt --build-include=wabt,debian --no-test
 notifications:
   email: false

--- a/src/build.py
+++ b/src/build.py
@@ -63,7 +63,7 @@ MUSL_SRC_DIR = os.path.join(WORK_DIR, 'musl')
 
 FIND_SVN_REV = os.path.join(SCRIPT_DIR, 'find_svn_rev.py')
 
-PREBUILT_CLANG = os.path.join(WORK_DIR)
+PREBUILT_CLANG = WORK_DIR
 PREBUILT_CLANG_TOOLS_CLANG = os.path.join(PREBUILT_CLANG, 'tools', 'clang')
 PREBUILT_CLANG_BIN = os.path.join(
     PREBUILT_CLANG, 'third_party', 'llvm-build', 'Release+Asserts', 'bin')
@@ -561,11 +561,11 @@ ALL_SOURCES = [
     Source('v8', V8_SRC_DIR,
            GIT_MIRROR_BASE + 'v8/v8',
            custom_sync=ChromiumFetchSync),
+    Source('cr-buildtools', os.path.join(WORK_DIR, 'build'),
+           GIT_MIRROR_BASE + 'chromium/src/build'),
     Source('host-toolchain', PREBUILT_CLANG,
            GIT_MIRROR_BASE + 'chromium/src/tools/clang',
            custom_sync=SyncToolchain),
-    Source('cr-buildtools', os.path.join(WORK_DIR, 'build'),
-           GIT_MIRROR_BASE + 'chromium/src/build'),
     Source('cmake', '', '',  # The source and git args are ignored.
            custom_sync=SyncPrebuiltCMake),
     Source('nodejs', '', '',  # The source and git args are ignored.

--- a/src/build.py
+++ b/src/build.py
@@ -63,7 +63,7 @@ MUSL_SRC_DIR = os.path.join(WORK_DIR, 'musl')
 
 FIND_SVN_REV = os.path.join(SCRIPT_DIR, 'find_svn_rev.py')
 
-PREBUILT_CLANG = os.path.join(WORK_DIR, 'chromium-clang')
+PREBUILT_CLANG = os.path.join(WORK_DIR)
 PREBUILT_CLANG_TOOLS_CLANG = os.path.join(PREBUILT_CLANG, 'tools', 'clang')
 PREBUILT_CLANG_BIN = os.path.join(
     PREBUILT_CLANG, 'third_party', 'llvm-build', 'Release+Asserts', 'bin')


### PR DESCRIPTION
A recent change
(https://chromium.googlesource.com/chromium/src/tools/clang/+/49cece5b02431a848652c7f60dd7b06d94e8d625)
made the prebuilt gold plugin downloaded by default, and also made the
location of the checkout dependent on the location of the binaries. So
move the checkout out to the root of the working dir to make things line
up.