### PR TITLE
Update Travis build to use Trusty for a newer C++ compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: trusty
 language: python
 addons:
   apt:


### PR DESCRIPTION
The WABT build uses C++11 now.