### PR TITLE
Use 'main' consistently for python entry point name

### DIFF
--- a/src/assemble_files.py
+++ b/src/assemble_files.py
@@ -14,6 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import argparse
 import glob
 import os
 import os.path
@@ -56,8 +57,7 @@ def run(assembler, files, fails, out):
       fails=fails)
 
 
-def getargs():
-  import argparse
+def main():
   parser = argparse.ArgumentParser(
       description='Assemble .wast files into .wasm.')
   parser.add_argument('--assembler', type=str, required=True,
@@ -68,9 +68,9 @@ def getargs():
                       help='Expected failures')
   parser.add_argument('--out', type=str, required=True,
                       help='Output directory')
-  return parser.parse_args()
+  args = parser.parse_args()
+  return run(args.assembler, args.files, args.fails, args.out)
 
 
 if __name__ == '__main__':
-  args = getargs()
-  sys.exit(run(args.assembler, args.files, args.fails, args.out))
+  sys.exit(main())

--- a/src/build.py
+++ b/src/build.py
@@ -15,6 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import argparse
 import glob
 import json
 import multiprocessing
@@ -23,6 +24,8 @@ import shutil
 import sys
 import tarfile
 import tempfile
+import textwrap
+import time
 import traceback
 import urllib2
 import zipfile
@@ -1393,7 +1396,6 @@ ALL_TESTS = [
 
 
 def TextWrapNameList(prefix, items):
-  import textwrap
   width = 80  # TODO(binji): better guess?
   names = sorted(item.name for item in items)
   return '%s%s' % (prefix, textwrap.fill(' '.join(names), width,
@@ -1402,8 +1404,6 @@ def TextWrapNameList(prefix, items):
 
 
 def ParseArgs():
-  import argparse
-
   def SplitComma(arg):
     if not arg:
       return None
@@ -1512,7 +1512,6 @@ def run(sync_filter, build_filter, test_filter, options):
 
 
 def main():
-  import time
   start = time.time()
   options = ParseArgs()
 

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -14,6 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import argparse
 import glob
 import os
 import os.path
@@ -82,8 +83,7 @@ def run(c, cxx, testsuite, sysroot_dir, fails, out, config='wasm'):
   return result
 
 
-def getargs():
-  import argparse
+def main():
   parser = argparse.ArgumentParser(description='Compile GCC torture tests.')
   parser.add_argument('--c', type=str, required=True,
                       help='C compiler path')
@@ -97,14 +97,14 @@ def getargs():
                       help='Expected failures')
   parser.add_argument('--out', type=str, required=True,
                       help='Output directory')
-  return parser.parse_args()
+  args = parser.parse_args()
+  return run(c=args.c,
+             cxx=args.cxx,
+             testsuite=args.testsuite,
+             sysroot_dir=args.sysroot,
+             fails=args.fails,
+             out=args.out)
 
 
 if __name__ == '__main__':
-  args = getargs()
-  sys.exit(run(c=args.c,
-               cxx=args.cxx,
-               testsuite=args.testsuite,
-               sysroot_dir=args.sysroot,
-               fails=args.fails,
-               out=args.out))
+  sys.exit(main())

--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -14,6 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import argparse
 import glob
 import os
 import os.path
@@ -77,8 +78,7 @@ def run(runner, files, fails, attributes, out, wasmjs='', extra_files=[]):
       attributes=attributes)
 
 
-def getargs():
-  import argparse
+def main():
   parser = argparse.ArgumentParser(description='Execute .wast or .wasm files.')
   parser.add_argument('--runner', type=str, required=True,
                       help='Runner path')
@@ -92,10 +92,10 @@ def getargs():
                       help='JavaScript support runtime for WebAssembly')
   parser.add_argument('--extra', type=str, required=False, action='append',
                       help='Extra files to pass to the runner')
-  return parser.parse_args()
+  args = parser.parse_args()
+  return run(args.runner, [args.files], args.fails, set(), args.out,
+             args.wasmjs, args.extra)
 
 
 if __name__ == '__main__':
-  args = getargs()
-  sys.exit(run(args.runner, [args.files], args.fails, set(), args.out,
-               args.wasmjs, args.extra))
+  sys.exit(main())

--- a/src/link_assembly_files.py
+++ b/src/link_assembly_files.py
@@ -14,6 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import argparse
 import glob
 import os
 import os.path
@@ -56,8 +57,7 @@ def run(linker, files, fails, out):
       fails=fails)
 
 
-def getargs():
-  import argparse
+def main():
   parser = argparse.ArgumentParser(description='Link .s files into .wast.')
   parser.add_argument('--linker', type=str, required=True,
                       help='Linker path')
@@ -67,9 +67,9 @@ def getargs():
                       help='Expected failures')
   parser.add_argument('--out', type=str, required=True,
                       help='Output directory')
-  return parser.parse_args()
+  args = parser.parse_args()
+  return run(args.linker, args.files, args.fails, args.out)
 
 
 if __name__ == '__main__':
-  args = getargs()
-  sys.exit(run(args.linker, args.files, args.fails, args.out))
+  sys.exit(main())


### PR DESCRIPTION
Also, don't import modules except at the top level.