### PR TITLE
Add --no-wasm-async-compilation when running d8 tests

### DIFF
--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -41,11 +41,14 @@ def execute(infile, outfile, extras):
   wasmjs = [extras['wasmjs']] if extras['wasmjs'] else []
   if basename == 'd8' or basename == 'jsc':
     config = basename + ('-wasm' if wasmjs else '-asm2wasm')
+
+  # TODO(sbc): Remove --no-wasm-async-compilation below once this bug is fixed:
+  # https://bugs.chromium.org/p/v8/issues/detail?id=6263
   commands = {
       'wasm-shell': [runner, '--entry=main', infile] + out_opt,
-      'd8-wasm': [runner, '--expose-wasm'] + wasmjs + [
+      'd8-wasm': [runner, '--no-wasm-async-compilation'] + wasmjs + [
           '--', infile] + extra_files,
-      'd8-asm2wasm': [runner, '--expose-wasm', infile],
+      'd8-asm2wasm': [runner, '--no-wasm-async-compilation', infile],
       'jsc-wasm': [runner, '--useWebAssembly=1'] + wasmjs + [
           '--', infile] + extra_files,
       'jsc-asm2wasm': [runner, '--useWebAssembly=1', infile],


### PR DESCRIPTION
Async compilation is currently breaking the d8 tests
because its exiting before the promises resolve.

BUG=https://bugs.chromium.org/p/v8/issues/detail?id=6263