### PR TITLE
Update newly-passing tests

### DIFF
--- a/src/test/emwasm_compile_known_gcc_test_failures.txt
+++ b/src/test/emwasm_compile_known_gcc_test_failures.txt
@@ -49,9 +49,6 @@
 	pr41935.c
 	pr51447.c
 	pr60003.c
-	scal-to-vec1.c
-	scal-to-vec2.c
-	scal-to-vec3.c
 
 
 # Multiply-defined symbols because emcc doesn't link libc/libm as archives

--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -164,10 +164,6 @@ va-arg-22.c.s.wast.wasm # abort()
 va-arg-22.c.js emwasm # abort()
 va-arg-6.c.js emwasm # abort()
 
-# LLVM emits a divide by zero:
-#   https://llvm.org/bugs/show_bug.cgi?id=26452
-pr60960.c.s.wast.wasm bare # divide by zero
-
 
 ### Failures specific to hacky-linking musl (aka bare-musl)
 
@@ -185,7 +181,6 @@ pr60960.c.s.wast.wasm bare # divide by zero
 980605-1.c.s.wast.wasm bare-musl
 complex-5.c.s.wast.wasm bare-musl
 pr56982.c.s.wast.wasm bare-musl
-pr60960.c.s.wast.wasm bare-musl
 struct-ret-1.c.s.wast.wasm bare-musl
 
 # TypeError
@@ -250,5 +245,4 @@ pr53645.c.js asm2wasm
 pr60960.c.js asm2wasm # actually fails in asm2wasm, but JS file is still there
 
 ### Failures specific to emwasm
-pr60960.c.js emwasm # throws. SIMD, but see also https://llvm.org/bugs/show_bug.cgi?id=26452
 complex-5.c.js emwasm # missing fmaxf, presumably needed by compiler-rt


### PR DESCRIPTION
https://reviews.llvm.org/D32487 seems to have fixed some vector instruction compilation, and https://bugs.llvm.org//show_bug.cgi?id=26452 additionally seems resolved