### PR TITLE
Fix download link for "Archive binaries" step

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -279,7 +279,7 @@ def UploadArchive(name, archive):
   if not IsBuildbot():
     return
   extension = os.path.splitext(archive)[1]
-  UploadFile(archive, 'wasm-%s-%s%s' % (name, BUILDBOT_BUILDNUMBER, extension))
+  UploadFile(archive, 'wasm-%s%s' % (name, extension))
 
 
 # Repo and subproject utilities
@@ -1052,8 +1052,8 @@ def Musl():
 def ArchiveBinaries():
   buildbot.Step('Archive binaries')
   # All relevant binaries were copied to the LLVM directory.
-  UploadArchive('binaries', Archive(INSTALL_DIR, print_content=True))
   UploadArchive('torture-c', Archive(GCC_TEST_DIR))
+  UploadArchive('binaries', Archive(INSTALL_DIR, print_content=True))
 
 
 def DebianPackage():


### PR DESCRIPTION
This is partial fix for #197.  For steps that upload
more than one archive only one link is shown in the
buildbot GUI.  This change makes uploads the binaries
last in the step which fixes the link.  Really we should
give them different link names so they both appear but
that is larger change.

Secondly, remove the build number from the filenames
since it is already present in the directory name.