### PR TITLE
Use up-to-date build\{vs_toolchain.py,win_toolchain.json}

### DIFF
--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -31,6 +31,7 @@ WIN_TOOLCHAIN_JSON = os.path.join(CR_BUILD_DIR, 'win_toolchain.json')
 
 os.environ['GYP_MSVS_VERSION'] = '2015'
 
+
 def SyncPrebuiltClang(name, src_dir, git_repo):
   """Update the prebuilt clang toolchain used by chromium bots"""
   tools_clang = os.path.join(src_dir, 'tools', 'clang')

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -26,8 +26,8 @@ CR_BUILD_DIR = os.path.join(WORK_DIR, 'build')
 SETUP_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'toolchain', 'win',
                                'setup_toolchain.py')
 V8_SRC_DIR = os.path.join(WORK_DIR, 'v8', 'v8')
-VS_TOOLCHAIN = os.path.join(V8_SRC_DIR, 'gypfiles', 'vs_toolchain.py')
-WIN_TOOLCHAIN_JSON = os.path.join(V8_SRC_DIR, 'gypfiles', 'win_toolchain.json')
+VS_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'vs_toolchain.py')
+WIN_TOOLCHAIN_JSON = os.path.join(CR_BUILD_DIR, 'win_toolchain.json')
 
 os.environ['GYP_MSVS_VERSION'] = '2015'
 

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -25,7 +25,6 @@ WORK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'work')
 CR_BUILD_DIR = os.path.join(WORK_DIR, 'build')
 SETUP_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'toolchain', 'win',
                                'setup_toolchain.py')
-V8_SRC_DIR = os.path.join(WORK_DIR, 'v8', 'v8')
 VS_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'vs_toolchain.py')
 WIN_TOOLCHAIN_JSON = os.path.join(CR_BUILD_DIR, 'win_toolchain.json')
 

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -31,7 +31,6 @@ WIN_TOOLCHAIN_JSON = os.path.join(CR_BUILD_DIR, 'win_toolchain.json')
 
 os.environ['GYP_MSVS_VERSION'] = '2015'
 
-
 def SyncPrebuiltClang(name, src_dir, git_repo):
   """Update the prebuilt clang toolchain used by chromium bots"""
   tools_clang = os.path.join(src_dir, 'tools', 'clang')


### PR DESCRIPTION
`v8\gypfiles` is deprecated and will be removed completely end of 2017. Use updated scripts in `build` folder instead.