### PR TITLE
Update name of spec interpreter wasm.opt -> wasm

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -2,6 +2,6 @@
 set -e
 
 for x in emcc em++ emconfigure emmake wasm2wast wast2wasm wasmdump wasm-interp \
-         s2wasm wasm-opt wasm-as wasm-dis wasm-shell wasm.opt d8; do
+         s2wasm wasm-opt wasm-as wasm-dis wasm-shell wasm d8; do
   update-alternatives --install /usr/bin/$x $x /opt/wasm/bin/$x 10
 done

--- a/debian/prerm
+++ b/debian/prerm
@@ -2,6 +2,6 @@
 set -e
 
 for x in emcc em++ emconfigure emmake wasm2wast wast2wasm wasmdump wasm-interp \
-         s2wasm wasm-opt wasm-as wasm-dis wasm-shell wasm.opt d8; do
+         s2wasm wasm-opt wasm-as wasm-dis wasm-shell wasm d8; do
   update-alternatives --remove $x /opt/wasm/bin/$x
 done

--- a/src/build.py
+++ b/src/build.py
@@ -907,7 +907,7 @@ def Spec():
   # Spec builds in-tree. Always clobber and run the tests.
   proc.check_call(['make', 'clean'], cwd=ML_DIR)
   proc.check_call(['make', 'all'], cwd=ML_DIR)
-  wasm = os.path.join(ML_DIR, 'wasm.opt')
+  wasm = os.path.join(ML_DIR, 'wasm')
   CopyBinaryToArchive(wasm)
 
 
@@ -1295,7 +1295,7 @@ def TestBare():
   if not IsWindows():
     ExecuteLLVMTorture(
         name='spec',
-        runner=Executable(os.path.join(INSTALL_BIN, 'wasm.opt')),
+        runner=Executable(os.path.join(INSTALL_BIN, 'wasm')),
         indir=s2wasm_out,
         fails=SPEC_KNOWN_TORTURE_FAILURES,
         attributes=common_attrs + ['spec'],

--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -33,8 +33,7 @@ def create_outname(outdir, infile):
 def execute(infile, outfile, extras):
   """Create the command-line for an execution."""
   runner = extras['runner']
-  # Strip only Windows suffxes (instead of all) because wasm.opt has a suffix
-  basename = os.path.basename(runner).replace('.exe', '').replace('.bat', '')
+  basename = os.path.splitext(os.path.basename(runner))[0]
   out_opt = ['-o', outfile] if outfile else []
   extra_files = extras['extra_files']
   config = basename
@@ -52,7 +51,7 @@ def execute(infile, outfile, extras):
       'jsc-wasm': [runner, '--useWebAssembly=1'] + wasmjs + [
           '--', infile] + extra_files,
       'jsc-asm2wasm': [runner, '--useWebAssembly=1', infile],
-      'wasm.opt': [runner, infile]
+      'wasm': [runner, infile]
   }
   return commands[config]
 

--- a/src/test/spec_known_gcc_test_failures.txt
+++ b/src/test/spec_known_gcc_test_failures.txt
@@ -2,7 +2,7 @@
 # interpreter.
 #
 # To run this test:
-# waterfall/src/execute_files.py --runner waterfall/src/work/wasm-install/bin/wasm.opt --files torture-s2wasm/\*.wast --fails waterfall/src/test/spec_known_gcc_test_failures.txt
+# waterfall/src/execute_files.py --runner waterfall/src/work/wasm-install/bin/wasm --files torture-s2wasm/\*.wast --fails waterfall/src/test/spec_known_gcc_test_failures.txt
 #
 # .wast files are available from wasm-stat.us as wasm-torture-s2wasm-$BUILD.tbz2
 pr44942.c.s.wast # arity mismatch: toolchain problem.


### PR DESCRIPTION
Upstream changed the optimised build to just 'wasm' and
the debug build to 'wasm.debug' in:
https://github.com/WebAssembly/spec/pull/475