### PR TITLE
Remove 9 expected failures from spec_known_gcc_test_failures.txt

### DIFF
--- a/src/test/spec_known_gcc_test_failures.txt
+++ b/src/test/spec_known_gcc_test_failures.txt
@@ -11,7 +11,6 @@ pr44942.c.s.wast # arity mismatch: toolchain problem.
 #
 # abort / exit are supported by the spec interpreter, the other will come by
 # linking in a libc and runtime.
-20000815-1.c.s.wast # env.memset
 20000910-2.c.s.wast # env.strchr
 20000914-1.c.s.wast # env.malloc
 20001011-1.c.s.wast # env.strcmp
@@ -28,9 +27,7 @@ pr44942.c.s.wast # arity mismatch: toolchain problem.
 20030914-1.c.s.wast # env.__floatsitf
 20031012-1.c.s.wast # env.memset
 20031204-1.c.s.wast # env.strcpy
-20041126-1.c.s.wast # env.memcpy
 20041214-1.c.s.wast # env.strcpy
-20041218-1.c.s.wast # env.memset
 20050121-1.c.s.wast # env.__floatsitf
 20050218-1.c.s.wast # env.strlen
 20050502-1.c.s.wast # env.strcmp
@@ -40,7 +37,6 @@ pr44942.c.s.wast # arity mismatch: toolchain problem.
 20060412-1.c.s.wast # env.memsets
 20070201-1.c.s.wast # env.sprintf
 20071018-1.c.s.wast # env.__builtin_malloc
-20071029-1.c.s.wast # env.memset
 20071030-1.c.s.wast # env.memset
 20071120-1.c.s.wast # env.__builtin_malloc
 20071202-1.c.s.wast # env.memcpy
@@ -81,16 +77,13 @@ memcpy-1.c.s.wast # env.memcpy
 memcpy-2.c.s.wast # env.memset
 memcpy-bi.c.s.wast # env.memcmp
 memset-1.c.s.wast # env.memset
-memset-2.c.s.wast # env.memset
 memset-3.c.s.wast # env.memset
 multi-ix.c.s.wast # env.memset
 p18298.c.s.wast # env.strcmp
-pr27260.c.s.wast # env.memset
 pr28982b.c.s.wast # env.memset
 pr33870-1.c.s.wast # env.memset
 pr33870.c.s.wast # env.memset
 pr34456.c.s.wast # env.qsort
-pr35472.c.s.wast # env.memset
 pr36038.c.s.wast # env.memcmp
 pr36093.c.s.wast # env.memset
 pr36765.c.s.wast # env.__builtin_malloc
@@ -107,8 +100,6 @@ pr44852.c.s.wast # env.strcmp
 pr47237.c.s.wast # env.__builtin_apply_args
 pr47337.c.s.wast # env.strcmp
 pr49218.c.s.wast # env.__fixsfti
-pr49419.c.s.wast # env.memset
-pr51877.c.s.wast # env.memset
 pr51933.c.s.wast # env.memcmp
 pr53688.c.s.wast # env.memset
 pr54471.c.s.wast # env.__multi3


### PR DESCRIPTION
These all seem to be related to calls to __builtin_memset
no longer being generated in the .s files.