### PR TITLE
Make running of llvm/v8/spec tests optional

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -133,6 +133,7 @@ GNUWIN32_ZIP = 'gnuwin32.zip'
 
 options = None
 
+
 def IsWindows():
   return sys.platform == 'win32'
 


### PR DESCRIPTION
These tests are normally run as part of the build but
it can be useful to run a build with no tests too.

Alternatively we could split out these tests into
thier own phases.