### PR TITLE
Use vs_toolchain.py and win_toolchain.json in v8/build 

### DIFF
--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -25,8 +25,9 @@ WORK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'work')
 CR_BUILD_DIR = os.path.join(WORK_DIR, 'build')
 SETUP_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'toolchain', 'win',
                                'setup_toolchain.py')
-VS_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'vs_toolchain.py')
-WIN_TOOLCHAIN_JSON = os.path.join(CR_BUILD_DIR, 'win_toolchain.json')
+V8_SRC_DIR = os.path.join(WORK_DIR, 'v8', 'v8')
+VS_TOOLCHAIN = os.path.join(V8_SRC_DIR, 'build', 'vs_toolchain.py')
+WIN_TOOLCHAIN_JSON = os.path.join(V8_SRC_DIR, 'build', 'win_toolchain.json')
 
 os.environ['GYP_MSVS_VERSION'] = '2015'
 


### PR DESCRIPTION
#202 directly uses `<workspace>\build\vs_toolchain.py`. It assumes `<workspace>\build\..\tools\gyp\pylib` exists to `import gyp`, but `tools\gyp\pylib` is pulled by `gclient sync` and lives under `<workspace>\v8\v8` instead of under `<workspace>`.

See https://cs.chromium.org/chromium/src/build/vs_toolchain.py?type=cs&q=%22import+gyp%22&l=21

Depending on scripts in v8\build is fine since they are updated everyday.

Failure log: https://wasm-stat.us/builders/windows/builds/8788/steps/Sync%20Repos/logs/stdio/text