### PR TITLE
Tell CMake the version of MSVC compilers we want to use

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -751,7 +751,10 @@ def GetRepoInfo():
 
 def OverrideCMakeCompiler():
   if IsWindows():
-    return []
+    MSVC_COMPILER = os.path.join(os.environ['GYP_MSVS_OVERRIDE_PATH'],
+                                 'VC', 'bin', 'amd64', 'cl.exe')
+    return ['-DCMAKE_C_COMPILER=' + MSVC_COMPILER,
+            '-DCMAKE_CXX_COMPILER=' + MSVC_COMPILER]
   return ['-DCMAKE_C_COMPILER=' + CC,
           '-DCMAKE_CXX_COMPILER=' + CXX]
 

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -25,8 +25,9 @@ WORK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'work')
 CR_BUILD_DIR = os.path.join(WORK_DIR, 'build')
 SETUP_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'toolchain', 'win',
                                'setup_toolchain.py')
-VS_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'vs_toolchain.py')
-WIN_TOOLCHAIN_JSON = os.path.join(CR_BUILD_DIR, 'win_toolchain.json')
+V8_SRC_DIR = os.path.join(WORK_DIR, 'v8', 'v8')
+VS_TOOLCHAIN = os.path.join(V8_SRC_DIR, 'build', 'vs_toolchain.py')
+WIN_TOOLCHAIN_JSON = os.path.join(V8_SRC_DIR, 'build', 'win_toolchain.json')
 
 os.environ['GYP_MSVS_VERSION'] = '2015'
 


### PR DESCRIPTION
In [LLVM build failure log](https://wasm-stat.us/builders/windows/builds/8807/steps/LLVM/logs/stdio/text), `vs_toolchain.py get_toolchain_dir` selected Visual Studio 2015 Update 3 (`E:\b\depot_tools\win_toolchain\vs_files\d3cb0e37bdd120ad0ac4650b674b09e81be45616`), but CMake picked up the older version of Visual Studio 2015 (`E:\b\depot_tools\win_toolchain\vs_files\95ddda401ec5678f15eeed01d2bee08fcbc5ee97\VC\bin\amd64\cl.exe`),

Workaround: explicitly setting `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER`.

`GYP_MSVS_OVERRIDE_PATH` is already set after running `vs_toolchain.py update`.