### PR TITLE
Run jsc tests with --fast

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -884,7 +884,7 @@ def Jsc():
   proc.check_call(['../Tools/Scripts/run-javascriptcore-tests',
                    '--root=bin',
                    '--filter', 'wasm',
-                   '--no-build', '--no-testapi'],
+                   '--no-build', '--no-testapi', '--fast'],
                   cwd=JSC_OUT_DIR)
   to_archive = [Executable(os.path.join('bin', 'jsc'))]
   for a in to_archive:


### PR DESCRIPTION
For some reason the waterfall seems to dislike the wasm-no-cjit-yes-tls-context tests. They work on the JSC infra, and I'm not sure it's useful to run all tests 5-ways for the waterfall anyways. --fast will only run with the basic command-line setup, not the extra 4 variants we otherwise have.