### PR TITLE
Make JSC build failure not abort the whole process

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -910,7 +910,7 @@ def Jsc():
   except proc.CalledProcessError:
     # JSC cmake build is flaky because it is not the official build. For the
     # moment make this not abort the whole process.
-    buildbot.Fail(True)
+    buildbot.Warn()
 
 
 def Wabt():
@@ -1219,7 +1219,10 @@ def ExecuteLLVMTorture(name, runner, indir, fails, attributes, extension,
       wasmjs=wasmjs,
       extra_files=extra_files)
   if 0 != unexpected_result_count:
-      buildbot.Fail(warn_only)
+      if warn_only:
+        buildbot.Warn()
+      else:
+        buildbot.Fail()
   return outdir
 
 
@@ -1469,7 +1472,10 @@ def ExecuteEmscriptenTestSuite(name, config, outdir, warn_only):
          'binaryen2', '--em-config', config],
         cwd=outdir)
   except proc.CalledProcessError:
-    buildbot.Fail(warn_only)
+    if warn_only:
+      buildbot.Warn()
+    else:
+      buildbot.Fail()
 
 
 def TestEmtest():

--- a/src/build.py
+++ b/src/build.py
@@ -1406,7 +1406,7 @@ def TestBare():
       wasmjs=os.path.join(INSTALL_LIB, 'wasm.js'),
       extra_files=[os.path.join(INSTALL_LIB, 'musl.wasm')])
 
-  if IsMac() and 'JSC' not in buildbot.WarnedList():
+  if IsMac() and not buildbot.DidStepFailOrWarn('JSC'):
     ExecuteLLVMTorture(
         name='jsc',
         runner=os.path.join(INSTALL_BIN, 'jsc'),

--- a/src/build.py
+++ b/src/build.py
@@ -1264,6 +1264,9 @@ def Summary(repos):
   print 'Failed steps: %s.' % buildbot.Failed()
   for step in buildbot.FailedList():
     print '    %s' % step
+  print 'Warned steps: %s.' % buildbot.Warned()
+  for step in buildbot.WarnedList():
+    print '    %s' % step
 
   if IsBuildbot():
     latest_file = '%s/%s' % (BUILDBOT_BUILDERNAME, 'latest.json')
@@ -1403,7 +1406,7 @@ def TestBare():
       wasmjs=os.path.join(INSTALL_LIB, 'wasm.js'),
       extra_files=[os.path.join(INSTALL_LIB, 'musl.wasm')])
 
-  if IsMac():
+  if IsMac() and 'JSC' not in buildbot.WarnedList():
     ExecuteLLVMTorture(
         name='jsc',
         runner=os.path.join(INSTALL_BIN, 'jsc'),

--- a/src/buildbot.py
+++ b/src/buildbot.py
@@ -18,6 +18,7 @@ import sys
 
 
 failed_steps = []
+warned_steps = []
 current_step = None
 
 
@@ -38,7 +39,7 @@ def Fail(warn_only=False):
   """Mark one step as failing, but keep going."""
   sys.stdout.flush()
   if warn_only:
-    sys.stdout.write('\n@@@STEP_WARNINGS@@@\n')
+    Warn()
     return
   sys.stdout.write('\n@@@STEP_FAILURE@@@\n')
   global failed_steps
@@ -51,3 +52,18 @@ def Failed():
 
 def FailedList():
   return list(failed_steps)
+
+
+def Warn():
+  sys.stdout.flush()
+  sys.stdout.write('\n@@@STEP_WARNINGS@@@\n')
+  global warned_steps
+  warned_steps.append(current_step)
+
+
+def Warned():
+  return len(warned_steps)
+
+
+def WarnedList():
+  return list(warned_steps)

--- a/src/buildbot.py
+++ b/src/buildbot.py
@@ -35,12 +35,9 @@ def Link(label, url):
   sys.stdout.write('@@@STEP_LINK@%s@%s@@@\n' % (label, url))
 
 
-def Fail(warn_only=False):
+def Fail():
   """Mark one step as failing, but keep going."""
   sys.stdout.flush()
-  if warn_only:
-    Warn()
-    return
   sys.stdout.write('\n@@@STEP_FAILURE@@@\n')
   global failed_steps
   failed_steps.append(current_step)
@@ -55,6 +52,8 @@ def FailedList():
 
 
 def Warn():
+  """We mark this step as failing, but this step is flaky so we don't care
+  enough about this to make the bot red."""
   sys.stdout.flush()
   sys.stdout.write('\n@@@STEP_WARNINGS@@@\n')
   global warned_steps

--- a/src/buildbot.py
+++ b/src/buildbot.py
@@ -67,3 +67,7 @@ def Warned():
 
 def WarnedList():
   return list(warned_steps)
+
+
+def DidStepFailOrWarn(step):
+  return step in failed_steps or step in warned_steps


### PR DESCRIPTION
Currently JSC build is using cmake build, which is not the official
build, and this makes JSC build flaky. This makes JSC build failure
not stop the whole waterfall process so that we can proceed to the
test stage.