### PR TITLE
Add -zstack-size to lld builds

### DIFF
--- a/src/link_assembly_files.py
+++ b/src/link_assembly_files.py
@@ -41,8 +41,9 @@ def link(infile, outfile, extras):
   install_root = os.path.dirname(os.path.dirname(linker))
   symfile = os.path.join(install_root, 'sysroot', 'lib', 'wasm.syms')
   commands = {
-      'lld': [linker, '-flavor', 'wasm', '-entry=main',
-              '--allow-undefined-file=' + symfile, '-o', outfile, infile],
+      'lld': [linker, '-flavor', 'wasm', '-z', 'stack-size=1048576',
+              '-entry=main', '--allow-undefined-file=' + symfile, '-o',
+              outfile, infile],
       's2wasm': [linker, '--allocate-stack', '1048576', '-o', outfile, infile],
   }
   return commands[basename] + extras['args']

--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -319,11 +319,8 @@ stdarg-1.c.o.wasm
 va-arg-5.c.o.wasm
 va-arg-6.c.o.wasm
 
-# RuntimeError: memory access out of bounds
-bcp-1.c.o.wasm
-memcpy-1.c.o.wasm
-multi-ix.c.o.wasm
-pr28982b.c.o.wasm
+# Don't care/won't fix:
+bcp-1.c.o.wasm # abort() # builtin_constant_p depends on opt setting
 
 # other
 va-arg-21.c.o.wasm


### PR DESCRIPTION
We pass -DSTACK_SIZE to the compiler but ommited to set the
stack size at link time.