### PR TITLE
Make waterfall test multiple optimization levels

### DIFF
--- a/src/assemble_files.py
+++ b/src/assemble_files.py
@@ -41,7 +41,7 @@ def assemble(infile, outfile, extras):
   return commands[basename]
 
 
-def run(assembler, files, fails, out):
+def run(assembler, files, fails, attributes, out):
   """Assemble all files."""
   assert os.path.isfile(assembler), 'Cannot find assembler at %s' % assembler
   assert os.path.isdir(out), 'Cannot find outdir %s' % out
@@ -54,7 +54,8 @@ def run(assembler, files, fails, out):
           outdir=out,
           extras={'assembler': assembler}),
       inputs=assembler_files,
-      fails=fails)
+      fails=fails,
+      attributes=attributes)
 
 
 def main():

--- a/src/build.py
+++ b/src/build.py
@@ -1377,7 +1377,7 @@ def TestBare():
       runner=Executable(os.path.join(INSTALL_BIN, 'd8')),
       indir=lld_out,
       fails=RUN_KNOWN_TORTURE_FAILURES,
-      attributes=common_attrs + ['bare', 'd8', 'lld'],
+      attributes=common_attrs + ['d8', 'lld'],
       extension='wasm',
       optflags=BARE_TEST_OPT_FLAGS,
       warn_only=True,

--- a/src/build.py
+++ b/src/build.py
@@ -1192,6 +1192,7 @@ def LinkLLVMTorture(name, linker, fails, indir, extension, args=None):
       buildbot.Fail()
   return os.path.join(WORK_DIR, 'torture-%s' % name)
 
+
 def AssembleLLVMTorture(name, assembler, indir, fails):
   for opt in BARE_TEST_OPT_FLAGS:
     buildbot.Step('Assemble LLVM Torture (%s, %s)' % (name, opt))
@@ -1349,20 +1350,20 @@ def TestBare():
       linker=Executable(os.path.join(INSTALL_BIN, 'lld')),
       fails=LLD_MUSL_KNOWN_TORTURE_FAILURES,
       indir=TORTURE_O_OUT_DIR,
-      extension= 'o',
+      extension='o',
       args=[libc])
   lld_out = LinkLLVMTorture(
       name='lld',
       linker=Executable(os.path.join(INSTALL_BIN, 'lld')),
       fails=LLD_KNOWN_TORTURE_FAILURES,
       indir=TORTURE_O_OUT_DIR,
-      extension= 'o')
+      extension='o')
   s2wasm_out = LinkLLVMTorture(
       name='s2wasm',
       linker=Executable(os.path.join(INSTALL_BIN, 's2wasm')),
       fails=S2WASM_KNOWN_TORTURE_FAILURES,
       indir=TORTURE_S_OUT_DIR,
-      extension= 's')
+      extension='s')
   wast2wasm_out = AssembleLLVMTorture(
       name='wast2wasm',
       assembler=Executable(os.path.join(INSTALL_BIN, 'wast2wasm')),

--- a/src/build.py
+++ b/src/build.py
@@ -1502,7 +1502,8 @@ def TestAsm():
 def TestEmwasm():
   emscripten_wasm_out = {}
   for opt in EMSCRIPTEN_TEST_OPT_FLAGS:
-    emscripten_wasm_out[opt] = os.path.join(EMSCRIPTENWASM_TORTURE_OUT_DIR, opt)
+    emscripten_wasm_out[opt] = os.path.join(EMSCRIPTENWASM_TORTURE_OUT_DIR,
+                                            opt)
     CompileLLVMTortureBinaryen(
         'emwasm',
         EMSCRIPTEN_CONFIG_WASM,

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -37,7 +37,7 @@ def create_outname(outdir, infile, extras):
 def run(c, cxx, testsuite, sysroot_dir, fails, out, config, opt):
   """Compile all torture tests."""
   cflags_common = ['--std=gnu89', '-DSTACK_SIZE=1044480',
-                   '-w', '-Wno-implicit-function-declaration']
+                   '-w', '-Wno-implicit-function-declaration', '-' + opt]
   cflags_extra = {
       'wasm-s': ['--target=wasm32-unknown-unknown', '-S',
                  '--sysroot=%s' % sysroot_dir],
@@ -68,7 +68,7 @@ def run(c, cxx, testsuite, sysroot_dir, fails, out, config, opt):
                                     c_torture)
   assert os.path.isdir(out), 'Cannot find outdir %s' % out
   c_test_files = glob.glob(os.path.join(c_torture, '*c'))
-  cflags = cflags_common + cflags_extra[config] + ['-' + opt]
+  cflags = cflags_common + cflags_extra[config]
 
   result = testing.execute(
       tester=testing.Tester(

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -34,14 +34,14 @@ def create_outname(outdir, infile, extras):
   return os.path.join(outdir, outname)
 
 
-def run(c, cxx, testsuite, sysroot_dir, fails, out, config):
+def run(c, cxx, testsuite, sysroot_dir, fails, out, config, opt):
   """Compile all torture tests."""
   cflags_common = ['--std=gnu89', '-DSTACK_SIZE=1044480',
                    '-w', '-Wno-implicit-function-declaration']
   cflags_extra = {
-      'wasm-s': ['--target=wasm32-unknown-unknown', '-S', '-O2',
+      'wasm-s': ['--target=wasm32-unknown-unknown', '-S',
                  '--sysroot=%s' % sysroot_dir],
-      'wasm-o': ['--target=wasm32-unknown-unknown-wasm', '-c', '-O2',
+      'wasm-o': ['--target=wasm32-unknown-unknown-wasm', '-c',
                  '--sysroot=%s' % sysroot_dir],
       # Binaryen's native-wasm method uses the JS engine's native support for
       # wasm rather than interpreting the wasm with wasm.js.
@@ -68,7 +68,7 @@ def run(c, cxx, testsuite, sysroot_dir, fails, out, config):
                                     c_torture)
   assert os.path.isdir(out), 'Cannot find outdir %s' % out
   c_test_files = glob.glob(os.path.join(c_torture, '*c'))
-  cflags = cflags_common + cflags_extra[config]
+  cflags = cflags_common + cflags_extra[config] + ['-' + opt]
 
   result = testing.execute(
       tester=testing.Tester(
@@ -78,7 +78,7 @@ def run(c, cxx, testsuite, sysroot_dir, fails, out, config):
           extras={'c': c, 'cflags': cflags, 'suffix': suffix}),
       inputs=c_test_files,
       fails=fails,
-      attributes=[config])
+      attributes=[config, opt])
 
   return result
 

--- a/src/link_assembly_files.py
+++ b/src/link_assembly_files.py
@@ -49,7 +49,7 @@ def link(infile, outfile, extras):
   return commands[basename] + extras['args']
 
 
-def run(linker, files, fails, out, args):
+def run(linker, files, fails, attributes, out, args):
   """Link all files."""
   assert os.path.isfile(linker), 'Cannot find linker at %s' % linker
   assert os.path.isdir(out), 'Cannot find outdir %s' % out
@@ -64,7 +64,8 @@ def run(linker, files, fails, out, args):
           outdir=out,
           extras={'linker': linker, 'args': args}),
       inputs=input_files,
-      fails=fails)
+      fails=fails,
+      attributes=attributes)
 
 
 def main():


### PR DESCRIPTION
Currently bare tests are only compiled with -O0, whereas emcc/binaryen
tests are only compiled with -O2. This makes bare tests compiled with
both -O0 and -O2, and emcc/binaryen tests with both -O0 and -O3.
(The reason for not -O2 again but -O3 is people tend to use -O3 a lot in
real use cases and test emcc with a different set of flags will increase
test coverage.)