### PR TITLE
Update GCC bare test expectations for lld and spec

### DIFF
--- a/src/test/lld_known_gcc_test_failures.txt
+++ b/src/test/lld_known_gcc_test_failures.txt
@@ -11,3 +11,11 @@ vfprintf-chk-1.c.o
 # undefined symbol: bar
 # This seems to be clang bug because it occurs for native clang too.
 va-arg-pack-1.c.o
+
+# undefined symbol: link_error
+# Don't care. The test case is faulty. link_error() does not exist.
+medce-1.c.o O0
+
+# Untriaged: undefined symbol
+20070614-1.c.o O0 # __mulsc3
+pr58831.c.o O0 # __assert_fail

--- a/src/test/lld_musl_known_gcc_test_failures.txt
+++ b/src/test/lld_musl_known_gcc_test_failures.txt
@@ -4,3 +4,10 @@
 # undefined symbol: bar
 # This seems to be clang bug because it occurs for native clang too.
 va-arg-pack-1.c.o
+
+# undefined symbol: link_error
+# Don't care. The test case is faulty. link_error() does not exist.
+medce-1.c.o O0
+
+# Untriaged: undefined symbol
+20070614-1.c.o O0 # __mulsc3

--- a/src/test/spec_known_gcc_test_failures.txt
+++ b/src/test/spec_known_gcc_test_failures.txt
@@ -2,7 +2,8 @@
 # interpreter.
 #
 # To run this test:
-# waterfall/src/execute_files.py --runner waterfall/src/work/wasm-install/bin/wasm --files torture-s2wasm/\*.wast --fails waterfall/src/test/spec_known_gcc_test_failures.txt
+# waterfall/src/execute_files.py --runner waterfall/src/work/wasm-install/bin/wasm --files torture-s2wasm/OPT/\*.wast --fails waterfall/src/test/spec_known_gcc_test_failures.txt
+# (replace OPT with optimization level, such as O0 or O2)
 #
 # .wast files are available from wasm-stat.us as wasm-torture-s2wasm-$BUILD.tbz2
 pr44942.c.s.wast # arity mismatch: toolchain problem.
@@ -11,22 +12,34 @@ pr44942.c.s.wast # arity mismatch: toolchain problem.
 #
 # abort / exit are supported by the spec interpreter, the other will come by
 # linking in a libc and runtime.
+20000112-1.c.s.wast O0 # env.strchr
 20000910-2.c.s.wast # env.strchr
 20000914-1.c.s.wast # env.malloc
 20001011-1.c.s.wast # env.strcmp
+20010409-1.c.s.wast O0 # env.strlen
 20010605-2.c.s.wast # env.__netf2
 20010915-1.c.s.wast # env.strcmp
 20010925-1.c.s.wast # env.memcpy
 20011024-1.c.s.wast # env.strcmp
+20011121-1.c.s.wast O0 # env.memcpy
 20020406-1.c.s.wast # env.malloc
 20020413-1.c.s.wast # env.__lttf2
 20021011-1.c.s.wast # env.strcmp
 20021120-3.c.s.wast # env.sprintf
 20030221-1.c.s.wast # env.strlen
+20030626-1.c.s.wast O0 # env.sprintf
+20030626-2.c.s.wast O0 # env.sprintf
 20030715-1.c.s.wast # env.strcmp
 20030914-1.c.s.wast # env.__floatsitf
+20030914-2.c.s.wast O0 # env.memcpy
 20031012-1.c.s.wast # env.memset
 20031204-1.c.s.wast # env.strcpy
+20040208-1.c.s.wast O0 # env.__multf3
+20040223-1.c.s.wast O0 # env.strcpy
+20040313-1.c.s.wast O0 # env.memset
+20040709-1.c.s.wast O0 # env.__netf2
+20040709-2.c.s.wast O0 # env.__netf2
+20041126-1.c.s.wast O0 # env.abs
 20041214-1.c.s.wast # env.strcpy
 20050121-1.c.s.wast # env.__floatsitf
 20050218-1.c.s.wast # env.strlen
@@ -34,8 +47,9 @@ pr44942.c.s.wast # arity mismatch: toolchain problem.
 20050502-2.c.s.wast # env.memcmp
 20050826-1.c.s.wast # env.memset
 20051113-1.c.s.wast # env.malloc
-20060412-1.c.s.wast # env.memsets
+20060412-1.c.s.wast O2 # env.memset
 20070201-1.c.s.wast # env.sprintf
+20070614-1.c.s.wast O0 # env.__mulsc3
 20071018-1.c.s.wast # env.__builtin_malloc
 20071030-1.c.s.wast # env.memset
 20071120-1.c.s.wast # env.__builtin_malloc
@@ -43,19 +57,25 @@ pr44942.c.s.wast # arity mismatch: toolchain problem.
 20080502-1.c.s.wast # env.__eqtf2
 20081218-1.c.s.wast # env.memset
 20090113-1.c.s.wast # env.memset
-20100708-1.c.s.wast # env.memset
+20100708-1.c.s.wast O2 # env.memset
 20101011-1.c.s.wast # env.signal
 20111208-1.c.s.wast # env.strlen
+20120207-1.c.s.wast O0 # env.strcpy
 20121108-1.c.s.wast # env.printf
 920501-8.c.s.wast # env.sprintf
 920501-9.c.s.wast # env.sprintf
 920726-1.c.s.wast # env.sprintf
 920810-1.c.s.wast # env.malloc
+921006-1.c.s.wast O0 # env.strcmp
 921117-1.c.s.wast # env.strcmp
 930513-1.c.s.wast # env.sprintf
 930622-2.c.s.wast # env.__floatditf
+930725-1.c.s.wast O0 # env.strcmp
 941014-2.c.s.wast # env.malloc
+950221-1.c.s.wast O0 # env.strcpy
+950426-1.c.s.wast O0 # env.strlen
 960215-1.c.s.wast # env.__addtf3
+960327-1.c.s.wast O0 # env.sprintf
 960405-1.c.s.wast # env.__eqtf2
 960513-1.c.s.wast # env.__subtf3
 960521-1.c.s.wast # env.memset
@@ -78,14 +98,22 @@ memcpy-2.c.s.wast # env.memset
 memcpy-bi.c.s.wast # env.memcmp
 memset-1.c.s.wast # env.memset
 memset-3.c.s.wast # env.memset
+mode-dependent-address.c.s.wast O0 # env.memcpy
 multi-ix.c.s.wast # env.memset
 p18298.c.s.wast # env.strcmp
+pr15262-1.c.s.wast O0 # env.malloc
+pr20621-1.c.s.wast O0 # env.memcpy
+pr22061-1.c.s.wast O0 # env.memset
+pr23135.c.s.wast O0 # env.memcpy
 pr28982b.c.s.wast # env.memset
+pr30778.c.s.wast O0 # env.memset
+pr33142.c.s.wast O0 # env.abs
 pr33870-1.c.s.wast # env.memset
 pr33870.c.s.wast # env.memset
 pr34456.c.s.wast # env.qsort
 pr36038.c.s.wast # env.memcmp
-pr36093.c.s.wast # env.memset
+pr36093.c.s.wast O2 # env.memset
+pr36321.c.s.wast O0 # env.strlen
 pr36765.c.s.wast # env.__builtin_malloc
 pr37573.c.s.wast # env.memcmp
 pr39228.c.s.wast # env.__builtin_isinff
@@ -100,6 +128,7 @@ pr44852.c.s.wast # env.strcmp
 pr47237.c.s.wast # env.__builtin_apply_args
 pr47337.c.s.wast # env.strcmp
 pr49218.c.s.wast # env.__fixsfti
+pr49644.c.s.wast O0 # env.memcpy
 pr51933.c.s.wast # env.memcmp
 pr53688.c.s.wast # env.memset
 pr54471.c.s.wast # env.__multi3
@@ -107,8 +136,13 @@ pr56205.c.s.wast # env.strcmp
 pr56866.c.s.wast # env.memset
 pr56982.c.s.wast # env._setjmp
 pr57130.c.s.wast # env.memcmp
+pr57321.c.s.wast O0 # env.memset
+pr58277-1.c.s.wast O0 # env.memset
+pr58277-2.c.s.wast O0 # env.memset
 pr58419.c.s.wast # env.getpid
+pr58831.c.s.wast O0 # env.__assert_fail
 pr59229.c.s.wast # env.memcmp
+pr60062.c.s.wast O0 # env.strcmp
 printf-1.c.s.wast # env.printf
 regstack-1.c.s.wast # env.__addtf3
 stdarg-1.c.s.wast # env.__netf2
@@ -116,6 +150,7 @@ stdarg-2.c.s.wast # env.__floatsitf
 strcmp-1.c.s.wast # env.strcmp
 strcpy-1.c.s.wast # env.memset
 string-opt-17.c.s.wast # env.strcpy
+string-opt-18.c.s.wast O0 # env.strcmp
 string-opt-5.c.s.wast # env.strlen
 strlen-1.c.s.wast # env.memset
 strncmp-1.c.s.wast # env.strncmp
@@ -139,3 +174,7 @@ fprintf-chk-1.c.s.wast # env.stdout
 gofast.c.s.wast # env.stdout
 vfprintf-1.c.s.wast # env.stdout
 vfprintf-chk-1.c.s.wast # env.stdout
+
+# unknown import: env.link_error
+# Don't care. The test case is faulty. link_error() does not exist.
+medce-1.c.s.wast O0


### PR DESCRIPTION
This updates some of newly discovered failures as we add new
optimization levels to waterfall. Some of lld failures are marked as
'untriaged'.
Currently this only updates steps included in bare tests that are
considered as STEP_FAILURE if unexpected successes/failures occur. More
to come.