### PR TITLE
Add icudtl.dat to V8 install

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -879,7 +879,8 @@ def V8():
   proc.check_call(['tools/run-tests.py', 'unittests', '--no-presubmit',
                    '--shell-dir', V8_OUT_DIR],
                   cwd=V8_SRC_DIR)
-  to_archive = [Executable('d8'), 'natives_blob.bin', 'snapshot_blob.bin']
+  to_archive = [Executable('d8'), 'natives_blob.bin', 'snapshot_blob.bin',
+                'icudtl.dat']
   for a in to_archive:
     CopyBinaryToArchive(os.path.join(V8_OUT_DIR, a))
 

--- a/src/build.py
+++ b/src/build.py
@@ -879,6 +879,8 @@ def V8():
   proc.check_call(['tools/run-tests.py', 'unittests', '--no-presubmit',
                    '--shell-dir', V8_OUT_DIR],
                   cwd=V8_SRC_DIR)
+  # Copy the V8 blobs as well as the ICU data file for timezone data.
+  # icudtl.dat is the little-endian version, which goes with x64.
   to_archive = [Executable('d8'), 'natives_blob.bin', 'snapshot_blob.bin',
                 'icudtl.dat']
   for a in to_archive:


### PR DESCRIPTION
V8 commit d9a25842d3aba82ead5e06c7fd7cb4896e6ad202 changed Date objects
to use ICU timezone data, which is read from the icudtl.dat file.