### PR TITLE
Split LLVM regression into its own buildbot step

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1190,7 +1190,7 @@ def LinkLLVMTorture(name, linker, fails, indir, outdir, extension,
       out=outdir, args=args)
   UploadArchive('torture-%s-%s' % (name, opt), Archive(outdir))
   if 0 != unexpected_result_count:
-    buildbot.FailUnless(lambda: IsWindows() and 'lld' in name)
+    buildbot.Fail()
 
 
 def AssembleLLVMTorture(name, assembler, indir, outdir, fails, opt):
@@ -1218,7 +1218,7 @@ def ExecuteLLVMTorture(name, runner, indir, fails, attributes, extension, opt,
   buildbot.Step('Execute LLVM Torture (%s, %s)' % (name, opt))
   if not indir:
     print 'Step skipped: no input'
-    buildbot.Fail(True)
+    buildbot.Warn()
     return None
   assert os.path.isfile(runner), 'Cannot find runner at %s' % runner
   files = os.path.join(indir, '*.%s' % extension)
@@ -1231,10 +1231,7 @@ def ExecuteLLVMTorture(name, runner, indir, fails, attributes, extension, opt,
       wasmjs=wasmjs,
       extra_files=extra_files)
   if 0 != unexpected_result_count:
-      if warn_only:
-        buildbot.Warn()
-      else:
-        buildbot.Fail()
+    buildbot.FailUnless(lambda: warn_only)
 
 
 class Build(object):
@@ -1533,10 +1530,7 @@ def ExecuteEmscriptenTestSuite(name, config, outdir, warn_only):
          'binaryen2', '--em-config', config],
         cwd=outdir)
   except proc.CalledProcessError:
-    if warn_only:
-      buildbot.Warn()
-    else:
-      buildbot.Fail()
+    buildbot.FailUnless(lambda: warn_only)
 
 
 def TestEmtest():

--- a/src/buildbot.py
+++ b/src/buildbot.py
@@ -70,3 +70,10 @@ def WarnedList():
 
 def DidStepFailOrWarn(step):
   return step in failed_steps or step in warned_steps
+
+
+def FailUnless(predicate):
+  if predicate():
+    Warn()
+  else:
+    Fail()


### PR DESCRIPTION
The regression test runner is currently failing on windows for obscure reasons, but the rest of the tests seem to work, so we can at least run them rather than bailing out completely.
