### PR TITLE
Reduce torture test STACK_SIZE define

### DIFF
--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -36,7 +36,7 @@ def create_outname(outdir, infile, extras):
 
 def run(c, cxx, testsuite, sysroot_dir, fails, out, config, opt):
   """Compile all torture tests."""
-  cflags_common = ['--std=gnu89', '-DSTACK_SIZE=1044480',
+  cflags_common = ['--std=gnu89', '-DSTACK_SIZE=524288',
                    '-w', '-Wno-implicit-function-declaration', '-' + opt]
   cflags_extra = {
       'wasm-s': ['--target=wasm32-unknown-unknown', '-S',

--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -207,7 +207,6 @@ va-arg-6.c.s.wast.wasm bare-musl
 930622-2.c.s.wast.wasm O0
 960327-1.c.s.wast.wasm O0
 960513-1.c.s.wast.wasm O0
-960521-1.c.s.wast.wasm O0
 complex-6.c.s.wast.wasm O0
 conversion.c.s.wast.wasm O0
 medce-1.c.s.wast.wasm O0
@@ -408,7 +407,6 @@ vfprintf-chk-1.c.o.wasm lld-musl
 930622-2.c.o.wasm O0
 960327-1.c.o.wasm O0
 960513-1.c.o.wasm O0
-960521-1.c.o.wasm lld,O0
 complex-6.c.o.wasm O0
 conversion.c.o.wasm O0
 pr15262-1.c.o.wasm lld-musl,O0

--- a/src/test/spec_known_gcc_test_failures.txt
+++ b/src/test/spec_known_gcc_test_failures.txt
@@ -105,7 +105,6 @@ pr15262-1.c.s.wast O0 # env.malloc
 pr20621-1.c.s.wast O0 # env.memcpy
 pr22061-1.c.s.wast O0 # env.memset
 pr23135.c.s.wast O0 # env.memcpy
-pr28982b.c.s.wast # env.memset
 pr30778.c.s.wast O0 # env.memset
 pr33142.c.s.wast O0 # env.abs
 pr33870-1.c.s.wast # env.memset


### PR DESCRIPTION
A stack overflow in 960521-1.c results in an infinite loop and hangs the
bots. Reducing the size used by some of the tests works around that.