### PR TITLE
Force clobbering on windows

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -690,7 +690,7 @@ def Clobber():
   if os.environ.get('BUILDBOT_CLOBBER'):
     buildbot.Step('Clobbering work dir')
     if os.path.isdir(WORK_DIR):
-      shutil.rmtree(WORK_DIR)
+      Remove(WORK_DIR)
 
 
 class Filter(object):

--- a/src/file_util.py
+++ b/src/file_util.py
@@ -50,17 +50,21 @@ def Mkdir(path):
 
 def Remove(path):
   """Remove file or directory if it exists, do nothing otherwise."""
-  if os.path.exists(path):
-    print 'Removing %s' % path
+  if not os.path.exists(path):
+    return
+  print 'Removing %s' % path
+  if sys.platform == 'win32':
+    # shutil.rmtree() may not work in Windows if a directory contains read-only
+    # files.
+    if os.path.isdir(path):
+      proc.check_call(['rmdir', '/S', '/Q', '"' + path + '"'])
+    else:
+      os.remove(path)
+  else:
     if os.path.isdir(path):
       shutil.rmtree(path)
     else:
       os.remove(path)
-
-  # shutil.rmtree() may not work in Windows if a directory contains read-only
-  # files.
-  if os.path.exists(path) and sys.platform == 'win32':
-    proc.check_call(['rmdir', '/S', '/Q', path])
 
 
 def CopyTree(src, dst):

--- a/src/file_util.py
+++ b/src/file_util.py
@@ -57,7 +57,7 @@ def Remove(path):
 
   # shutil.rmtree() may not work in Windows if a directory contains read-only
   # files.
-  if os.path.exists(path) and sys.platform. == 'win32':
+  if os.path.exists(path) and sys.platform == 'win32':
     proc.check_call(['rmdir', '/S', '/Q', path])
 
 

--- a/src/file_util.py
+++ b/src/file_util.py
@@ -53,18 +53,15 @@ def Remove(path):
   if not os.path.exists(path):
     return
   print 'Removing %s' % path
+  if not os.path.isdir(path):
+    os.remove(path)
+    return
   if sys.platform == 'win32':
     # shutil.rmtree() may not work in Windows if a directory contains read-only
     # files.
-    if os.path.isdir(path):
-      proc.check_call(['rmdir', '/S', '/Q', '"' + path + '"'])
-    else:
-      os.remove(path)
+    proc.check_call(['rmdir', '/S', '/Q', '"' + path + '"'])
   else:
-    if os.path.isdir(path):
-      shutil.rmtree(path)
-    else:
-      os.remove(path)
+    shutil.rmtree(path)
 
 
 def CopyTree(src, dst):

--- a/src/file_util.py
+++ b/src/file_util.py
@@ -20,6 +20,7 @@
 import errno
 import os
 import shutil
+import proc
 
 
 def Chdir(path):
@@ -53,6 +54,11 @@ def Remove(path):
       shutil.rmtree(path)
     else:
       os.remove(path)
+
+  # shutil.rmtree() may not work in Windows if a directory contains read-only
+  # files.
+  if os.path.exists(path) and sys.platform. == 'win32':
+    proc.check_call(['rmdir', '/S', '/Q', path])
 
 
 def CopyTree(src, dst):

--- a/src/file_util.py
+++ b/src/file_util.py
@@ -20,6 +20,8 @@
 import errno
 import os
 import shutil
+import sys
+
 import proc
 
 


### PR DESCRIPTION
`shutil.rmtree()` does not work when there are read-only files in a
directory. This works around that problem.