### PR TITLE
Update OCaml build to work with 4.05

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -944,8 +944,9 @@ def OCaml():
   makefile = os.path.join(OCAML_DIR, 'config', 'Makefile')
   if not os.path.isfile(makefile):
     configure = os.path.join(OCAML_DIR, 'configure')
-    cc_flag = ['-cc', CC,
-               '-aspp', CC + ' -c'] if sys.platform != 'darwin' else []
+    cc_flag = ['-cc', CC, '-aspp', CC + ' -c']
+    if sys.platform == 'darwin':
+      cc_flag = []
     proc.check_call(
         [configure, '-prefix', OCAML_OUT_DIR, '--no-ocamldoc'] + cc_flag,
         cwd=OCAML_DIR)

--- a/src/build.py
+++ b/src/build.py
@@ -943,9 +943,10 @@ def OCaml():
   makefile = os.path.join(OCAML_DIR, 'config', 'Makefile')
   if not os.path.isfile(makefile):
     configure = os.path.join(OCAML_DIR, 'configure')
-    cc_flag = ['-cc', CC] if sys.platform != 'darwin' else []
+    cc_flag = ['-cc', CC, '-aspp', CC + ' -c'] if sys.platform != 'darwin' else []
     proc.check_call(
-        [configure, '-prefix', OCAML_OUT_DIR] + cc_flag, cwd=OCAML_DIR)
+        [configure, '-prefix', OCAML_OUT_DIR, '--no-ocamldoc'] + cc_flag,
+        cwd=OCAML_DIR)
   proc.check_call(['make', 'world.opt', '-j%s' % NPROC], cwd=OCAML_DIR)
   proc.check_call(['make', 'install'], cwd=OCAML_DIR)
   ocamlbuild = os.path.join(OCAML_BIN_DIR, 'ocamlbuild')

--- a/src/build.py
+++ b/src/build.py
@@ -60,7 +60,7 @@ V8_SRC_DIR = os.path.join(WORK_DIR, 'v8', 'v8')
 JSC_SRC_DIR = os.path.join(WORK_DIR, 'jsc')
 WABT_SRC_DIR = os.path.join(WORK_DIR, 'wabt')
 
-OCAML_DIR = os.path.join(WORK_DIR, 'ocaml') # OCaml always does in-tree build
+OCAML_DIR = os.path.join(WORK_DIR, 'ocaml')  # OCaml always does in-tree build
 OCAMLBUILD_DIR = os.path.join(WORK_DIR, 'ocamlbuild')
 
 SPEC_SRC_DIR = os.path.join(WORK_DIR, 'spec')
@@ -413,7 +413,8 @@ class Source(object):
       proc.check_call(['git'] + clone)
 
     GitUpdateRemote(self.src_dir, self.git_repo, WATERFALL_REMOTE)
-    proc.check_call(['git', 'fetch', '--tags', WATERFALL_REMOTE], cwd=self.src_dir)
+    proc.check_call(['git', 'fetch', '--tags', WATERFALL_REMOTE],
+                    cwd=self.src_dir)
     if not self.checkout.startswith(WATERFALL_REMOTE + '/'):
       sys.stderr.write(('WARNING: `git checkout %s` not based on waterfall '
                         'remote (%s), checking out local branch'
@@ -532,7 +533,6 @@ def SyncPrebuiltCMake(name, src_dir, git_repo):
       contents_dir = os.path.join(contents_dir, 'CMake.app', 'Contents')
 
     os.rename(contents_dir, PREBUILT_CMAKE_DIR)
-
 
 
 def SyncWindowsNode():


### PR DESCRIPTION
1. Switch from a source tarball to use a release tag on the official github repo, using our standard git checkout mechanism.
2. Check out and build `ocamlbuild` which is no longer packaged with the compiler/runtime sources.