### PR TITLE
Fix a bug in windows clobbering

### DIFF
--- a/src/file_util.py
+++ b/src/file_util.py
@@ -20,8 +20,9 @@
 import errno
 import os
 import shutil
-import subprocess
 import sys
+
+import proc
 
 
 def Chdir(path):
@@ -58,7 +59,7 @@ def Remove(path):
   if sys.platform == 'win32':
     # shutil.rmtree() may not work in Windows if a directory contains read-only
     # files.
-    subprocess.check_call('rmdir /S /Q "%s"' % path, shell=True)
+    proc.check_call('rmdir /S /Q "%s"' % path, shell=True)
   else:
     shutil.rmtree(path)
 

--- a/src/file_util.py
+++ b/src/file_util.py
@@ -20,9 +20,8 @@
 import errno
 import os
 import shutil
+import subprocess
 import sys
-
-import proc
 
 
 def Chdir(path):
@@ -59,7 +58,7 @@ def Remove(path):
   if sys.platform == 'win32':
     # shutil.rmtree() may not work in Windows if a directory contains read-only
     # files.
-    proc.check_call(['rmdir', '/S', '/Q', '"' + path + '"'])
+    subprocess.check_call('rmdir /S /Q "%s"' % path, shell=True)
   else:
     shutil.rmtree(path)
 


### PR DESCRIPTION
Shell commands like `rmdir` should have `shell=True` in `subprocess`
commands. Because `proc.check_call` assumes it takes a list and here we
want a command string, we just use `subprocess.check_call` directly here
with `shell=True`.