### PR TITLE
Delete warn_only flag from emwasm testsuite

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1549,7 +1549,7 @@ def TestEmtest():
       'emwasm',
       EMSCRIPTEN_CONFIG_WASM,
       EMSCRIPTEN_TEST_OUT_DIR,
-      warn_only=True)
+      warn_only=False)
 
 
 def TestEmtestAsm2Wasm():


### PR DESCRIPTION
#130 added two emscripten tests (asm2wasm and emwasm) and set only
asm2wasm to `warn_only=False` because it was the officially supported
toolchain then. Then would now be a good time to delete `warn_only=True`
for emwasm too?