### PR TITLE
Write and check stamp file when syncing archives

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -150,18 +150,22 @@ def Executable(name, extension='.exe'):
 def WindowsFSEscape(path):
   return os.path.normpath(path).replace('\\', '/')
 
+
 def NodePlatformName():
   return {'darwin': 'darwin-x64',
           'linux2': 'linux-x64',
           'win32': 'win32'}[sys.platform]
+
 
 def CMakePlatformName():
   return {'linux2': 'Linux',
           'darwin': 'Darwin',
           'win32': 'win32'}[sys.platform]
 
+
 def CMakeArch():
   return 'x86' if IsWindows() else 'x86_64'
+
 
 def CMakeBinDir():
   if IsMac():

--- a/src/build.py
+++ b/src/build.py
@@ -508,7 +508,7 @@ def SyncArchive(out_dir, name, url):
 
   stamp_file = os.path.join(out_dir, 'stamp.txt')
   if os.path.isdir(out_dir):
-    if os.path.exists(stamp_file):
+    if os.path.isfile(stamp_file):
       with open(stamp_file) as f:
         stamp_url = f.read().strip()
       if stamp_url == url:


### PR DESCRIPTION
Also, rename cmake directly to cmake-3.4.3 to more clearly
match the upstream version.

This change is in prepration for updating the cmake version.