### PR TITLE
Update test failures for clang loop optimization

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -411,3 +411,8 @@ pr15262-1.c.o.wasm lld-musl,O0
 pr23135.c.o.wasm O0
 pr33142.c.o.wasm lld,O0
 pr42614.c.o.wasm O0
+
+# Clang optimizing loop into infinite loop for -O2
+930529-1.c.s.wast.wasm O2
+930529-1.c.o.wasm O2
+930529-1.c.js emwasm,O3 # asm2wasm uses different clang


### PR DESCRIPTION
The test in question contains the following code

```c
int i;
for (i = ((unsigned) ~0 >> 1) - 3; i <= ((unsigned) ~0 >> 1) + 3; i++) { ... }
```
which I believe is undefined because it relies on the signed integer `i` overflowing in order to terminate, which "can never happen", so clang optimizes it to an infinite loop.