### PR TITLE
Revert "Temporarily disable compiler-rt (#263)"

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1352,8 +1352,7 @@ def AllBuilds(use_asm=False):
       Build('fastcomp', Fastcomp),
       Build('emscripten', Emscripten, use_asm=use_asm),
       # Target libs
-      # TODO(sbc): Figure out why this was failing on the bots and re-enable
-      # Build('compiler-rt', CompilerRT),
+      Build('compiler-rt', CompilerRT),
       Build('musl', Musl),
       # Archive
       Build('archive', ArchiveBinaries),


### PR DESCRIPTION
This reverts commit 48b89c59d4c8b5959415e047984033e393c57db4.

I think we just need to clobber the bots to make it work