### PR TITLE
Add ability to run build.py with a limited set of torture tests

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1805,6 +1805,9 @@ def ParseArgs():
       '--no-threads', action='store_true',
       help='Disable use of thread pool to building and testing')
   parser.add_argument(
+      '--torture-filter',
+      help='Limit which torture tests are run by applying the given glob')
+  parser.add_argument(
       '--no-tool-tests', dest='run_tool_tests', action='store_false',
       help='Skip the testing of tools (such tools llvm, wabt, v8, spec)')
   parser.add_argument(
@@ -1868,6 +1871,8 @@ def main():
 
   if options.no_threads:
     testing.single_threaded = True
+  if options.torture_filter:
+    compile_torture_tests.test_filter = options.torture_filter
 
   sync_include = options.sync_include if options.sync else []
   sync_filter = Filter('sync', sync_include, options.sync_exclude)

--- a/src/build.py
+++ b/src/build.py
@@ -1129,7 +1129,6 @@ def CompilerRT():
 def Musl():
   buildbot.Step('musl')
   Mkdir(MUSL_OUT_DIR)
-  path = os.environ['PATH']
   try:
     cc_env = BuildEnv(MUSL_OUT_DIR, use_gnuwin32=True)
     # Build musl directly to wasm object files in an ar library
@@ -1170,8 +1169,6 @@ def Musl():
   except proc.CalledProcessError:
     # Note the failure but allow the build to continue.
     buildbot.Fail()
-  finally:
-    os.environ['PATH'] = path
 
 
 def ArchiveBinaries():

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -22,6 +22,10 @@ import sys
 
 import testing
 
+# For debugging purposes set this to a source file name to test just a single
+# file.
+TEST_FILTER = None
+
 
 def c_compile(infile, outfile, extras):
   """Create the command-line for a C compiler invocation."""
@@ -67,7 +71,9 @@ def run(c, cxx, testsuite, sysroot_dir, fails, out, config, opt):
   assert os.path.isdir(c_torture), ('Cannot find C torture tests at %s' %
                                     c_torture)
   assert os.path.isdir(out), 'Cannot find outdir %s' % out
-  c_test_files = glob.glob(os.path.join(c_torture, '*c'))
+  c_test_files = glob.glob(os.path.join(c_torture, '*.c'))
+  if TEST_FILTER:
+    c_test_files = [f for f in c_test_files if os.path.basename(f) in TEST_FILTER]
   cflags = cflags_common + cflags_extra[config]
 
   result = testing.execute(

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -25,7 +25,7 @@ import testing
 
 # For debugging purposes set this to a source file name to test just a single
 # file.
-TEST_FILTER = None
+test_filter = None
 
 
 def do_compile(infile, outfile, extras):
@@ -114,8 +114,8 @@ def run(cc, cxx, testsuite, sysroot_dir, fails, exclusions, out, config, opt):
   cflags = cflags_common + cflags_c + cflags_extra[config]
   cxxflags = cflags_common + cflags_cxx + cflags_extra[config]
 
-  if TEST_FILTER:
-    test_files = [f for f in test_files if os.path.basename(f) in TEST_FILTER]
+  if test_filter:
+    test_files = fnmatch.filter(test_files, test_filter)
 
   result = testing.execute(
       tester=testing.Tester(

--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -65,7 +65,9 @@ def run(runner, files, fails, attributes, out, wasmjs='', extra_files=[]):
   if wasmjs:
     assert os.path.isfile(wasmjs), 'Cannot find wasm.js %s' % wasmjs
   executable_files = glob.glob(files)
-  assert len(executable_files), 'No files found by %s' % files
+  if len(executable_files) == 0:
+    print 'No files found by %s' % files
+    return 1
   return testing.execute(
       tester=testing.Tester(
           command_ctor=execute,


### PR DESCRIPTION
 Also remove saving/restoring PATH in Musl() step.  This
step doesn't modify PATH
