### PR TITLE
Use clang driver when linking with lld

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1417,17 +1417,15 @@ def TestBare():
     CompileLLVMTorture('o', GetTortureDir('o', opt), opt)
 
   # Link/Assemble
-  libc = os.path.join(INSTALL_SYSROOT, 'lib', 'libc.a')
   for opt in BARE_TEST_OPT_FLAGS:
     LinkLLVMTorture(
         name='lld',
-        linker=Executable(os.path.join(INSTALL_BIN, 'lld')),
+        linker=Executable(os.path.join(INSTALL_BIN, 'clang')),
         fails=LLD_KNOWN_TORTURE_FAILURES,
         indir=GetTortureDir('o', opt),
         outdir=GetTortureDir('lld', opt),
         extension='o',
-        opt=opt,
-        args=[libc])
+        opt=opt)
   for opt in BARE_TEST_OPT_FLAGS:
     LinkLLVMTorture(
         name='s2wasm',

--- a/src/link_assembly_files.py
+++ b/src/link_assembly_files.py
@@ -27,7 +27,7 @@ def create_outname(outdir, infile, extras):
   """Create the output file's name."""
   basename = os.path.basename(infile)
   linker = os.path.splitext(os.path.basename(extras['linker']))[0]
-  if linker == 'lld':
+  if linker == 'clang':
     outname = basename + '.wasm'
   else:
     outname = basename + '.wast'
@@ -39,11 +39,12 @@ def link(infile, outfile, extras):
   linker = extras['linker']
   basename = os.path.splitext(os.path.basename(linker))[0]
   install_root = os.path.dirname(os.path.dirname(linker))
-  symfile = os.path.join(install_root, 'sysroot', 'lib', 'wasm.syms')
+  sysroot_dir = os.path.join(install_root, 'sysroot')
   commands = {
-      'lld': [linker, '-flavor', 'wasm', '-z', 'stack-size=1048576',
-              '-entry=main', '--allow-undefined-file=' + symfile, '-o',
-              outfile, infile],
+      'clang': [linker, '--target=wasm32-unknown-unknown',
+                '--sysroot=%s' % sysroot_dir,
+                '-Wl,-z', '-Wl,stack-size=1048576',
+              '-Wl,-entry=main', '-o', outfile, infile],
       's2wasm': [linker, '--allocate-stack', '1048576', '-o', outfile, infile],
   }
   return commands[basename] + extras['args']

--- a/src/link_assembly_files.py
+++ b/src/link_assembly_files.py
@@ -42,9 +42,8 @@ def link(infile, outfile, extras):
   sysroot_dir = os.path.join(install_root, 'sysroot')
   commands = {
       'clang': [linker, '--target=wasm32-unknown-unknown',
-                '--sysroot=%s' % sysroot_dir,
-                '-Wl,-z', '-Wl,stack-size=1048576',
-              '-Wl,-entry=main', '-o', outfile, infile],
+                '--sysroot=%s' % sysroot_dir, '-Wl,-zstack-size=1048576',
+                '-o', outfile, infile],
       's2wasm': [linker, '--allocate-stack', '1048576', '-o', outfile, infile],
   }
   return commands[basename] + extras['args']

--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -254,7 +254,6 @@ vprintf-chk-1.c.js O3
 # All these failures also occur with s2wasm linked binaries
 20020406-1.c.o.wasm
 920501-8.c.o.wasm
-complex-5.c.o.wasm
 pr56982.c.o.wasm
 struct-ret-1.c.o.wasm
 va-arg-21.c.o.wasm # vprintf
@@ -275,8 +274,6 @@ vprintf-chk-1.c.o.wasm O2
 960405-1.c.o.wasm
 align-2.c.o.wasm
 complex-7.c.o.wasm
-pr49218.c.o.wasm
-pr54471.c.o.wasm
 regstack-1.c.o.wasm
 stdarg-1.c.o.wasm
 stdarg-2.c.o.wasm


### PR DESCRIPTION
This gives us libc and compiler-rt on the link line for free
and excercises the clang driver.