### PR TITLE
Use musl-provided wasm.syms

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1142,6 +1142,8 @@ def Musl():
         '--musl', MUSL_SRC_DIR, '--compile-to-wasm'], env=cc_env)
     CopyLibraryToSysroot(os.path.join(MUSL_OUT_DIR, 'libc.a'))
     CopyLibraryToSysroot(os.path.join(MUSL_OUT_DIR, 'crt1.o'))
+    CopyLibraryToSysroot(os.path.join(MUSL_SRC_DIR, 'arch', 'wasm32',
+                                      'wasm.syms'))
 
     # Build musl via s2wasm as single wasm file.
     proc.check_call([
@@ -1155,12 +1157,6 @@ def Musl():
 
     wasm_js = os.path.join(MUSL_SRC_DIR, 'arch', 'wasm32', 'wasm.js')
     CopyLibraryToArchive(wasm_js)
-
-    # Execute wasm.js to generate undefined symbols list
-    syms = proc.check_output([os.path.join(INSTALL_BIN, 'd8'),
-                              wasm_js, '--', '--dump-ffi-symbols'])
-    with open(os.path.join(INSTALL_SYSROOT, 'lib', 'wasm.syms'), 'w') as f:
-      f.write(syms)
 
     CopyTree(os.path.join(MUSL_SRC_DIR, 'include'),
              os.path.join(INSTALL_SYSROOT, 'include'))


### PR DESCRIPTION
No need to auto-generate it anymore.
See: https://github.com/jfbastien/musl/pull/21