### PR TITLE
Replace compiler-rt CMake flags with a CMake toolchain description file

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1115,8 +1115,9 @@ def CompilerRT():
   cc_env = BuildEnv(COMPILER_RT_SRC_DIR, bin_subdir=True)
   command = [PREBUILT_CMAKE_BIN, '-G', 'Ninja',
              os.path.join(COMPILER_RT_SRC_DIR, 'lib', 'builtins'),
-             '-DCMAKE_TOOLCHAIN_FILE=' + os.path.join(INSTALL_DIR, 'wasm_standalone.cmake'),
-             # TODO(dschuff): why doesn't setting CMAKE_AR in the toolchain file work?
+             '-DCMAKE_TOOLCHAIN_FILE=' +
+             os.path.join(INSTALL_DIR, 'wasm_standalone.cmake'),
+             # TODO: why doesn't setting CMAKE_AR in the toolchain file work?
              '-DCMAKE_AR=' + os.path.join(INSTALL_BIN, 'llvm-ar'),
              '-DCMAKE_RANLIB=' + os.path.join(INSTALL_BIN, 'llvm-ranlib'),
              '-DCOMPILER_RT_BAREMETAL_BUILD=On',
@@ -1171,9 +1172,10 @@ def Musl():
              os.path.join(INSTALL_SYSROOT, 'include'))
     CopyTree(os.path.join(MUSL_SRC_DIR, 'arch', 'wasm32'),
              os.path.join(INSTALL_SYSROOT, 'include'))
-    # Strictly speaking the CMake toolchain file isn't part of musl, but it does
+    # Strictly speaking the CMake toolchain file isn't part of musl, but does
     # go along with the headers and libs musl installs
-    shutil.copy2(os.path.join(SCRIPT_DIR, 'wasm_standalone.cmake'), INSTALL_DIR)
+    shutil.copy2(os.path.join(SCRIPT_DIR, 'wasm_standalone.cmake'),
+                 INSTALL_DIR)
 
   except proc.CalledProcessError:
     # Note the failure but allow the build to continue.

--- a/src/build.py
+++ b/src/build.py
@@ -47,7 +47,7 @@ WORK_DIR = os.path.join(SCRIPT_DIR, 'work')
 LLVM_SRC_DIR = os.path.join(WORK_DIR, 'llvm')
 CLANG_SRC_DIR = os.path.join(LLVM_SRC_DIR, 'tools', 'clang')
 LLD_SRC_DIR = os.path.join(LLVM_SRC_DIR, 'tools', 'lld')
-COMPILER_RT_SRC_DIR = os.path.join(LLVM_SRC_DIR, 'projects', 'compiler-rt')
+COMPILER_RT_SRC_DIR = os.path.join(WORK_DIR, 'compiler-rt')
 LLVM_TEST_SUITE_SRC_DIR = os.path.join(WORK_DIR, 'llvm-test-suite')
 
 EMSCRIPTEN_SRC_DIR = os.path.join(WORK_DIR, 'emscripten')

--- a/src/build.py
+++ b/src/build.py
@@ -1115,16 +1115,14 @@ def CompilerRT():
   cc_env = BuildEnv(COMPILER_RT_SRC_DIR, bin_subdir=True)
   command = [PREBUILT_CMAKE_BIN, '-G', 'Ninja',
              os.path.join(COMPILER_RT_SRC_DIR, 'lib', 'builtins'),
-             '-DCMAKE_TOOLCHAIN_FILE=' + os.path.join(SCRIPT_DIR, 'wasm_standalone.cmake'),
+             '-DCMAKE_TOOLCHAIN_FILE=' + os.path.join(INSTALL_DIR, 'wasm_standalone.cmake'),
+             # TODO(dschuff): why doesn't setting CMAKE_AR in the toolchain file work?
+             '-DCMAKE_AR=' + os.path.join(INSTALL_BIN, 'llvm-ar'),
+             '-DCMAKE_RANLIB=' + os.path.join(INSTALL_BIN, 'llvm-ranlib'),
              '-DCOMPILER_RT_BAREMETAL_BUILD=On',
              '-DCOMPILER_RT_BUILD_XRAY=OFF',
              '-DCOMPILER_RT_INCLUDE_TESTS=OFF',
              '-DCOMPILER_RT_ENABLE_IOS=OFF',
-             '-DCMAKE_AR=' + os.path.join(INSTALL_BIN, 'llvm-ar'),
-             '-DCMAKE_RANLIB=' + os.path.join(INSTALL_BIN, 'llvm-ranlib'),
-             '-DCMAKE_C_COMPILER=' + os.path.join(INSTALL_BIN, 'clang'),
-             '-DCMAKE_C_COMPILER_TARGET=wasm32-unknown-unknown-wasm',
-             '-DCMAKE_C_COMPILER_WORKS=On',
              '-DCOMPILER_RT_DEFAULT_TARGET_ONLY=On',
              '-DLLVM_CONFIG_PATH=' +
              os.path.join(LLVM_OUT_DIR, 'bin', 'llvm-config'),
@@ -1175,7 +1173,7 @@ def Musl():
              os.path.join(INSTALL_SYSROOT, 'include'))
     # Strictly speaking the CMake toolchain file isn't part of musl, but it does
     # go along with the headers and libs musl installs
-    shutil.copy2(os.path.join(SCRIPT_DIR, 'wasm_standalone.cmake'), INSTALL_SYSROOT)
+    shutil.copy2(os.path.join(SCRIPT_DIR, 'wasm_standalone.cmake'), INSTALL_DIR)
 
   except proc.CalledProcessError:
     # Note the failure but allow the build to continue.

--- a/src/build.py
+++ b/src/build.py
@@ -47,7 +47,7 @@ WORK_DIR = os.path.join(SCRIPT_DIR, 'work')
 LLVM_SRC_DIR = os.path.join(WORK_DIR, 'llvm')
 CLANG_SRC_DIR = os.path.join(LLVM_SRC_DIR, 'tools', 'clang')
 LLD_SRC_DIR = os.path.join(LLVM_SRC_DIR, 'tools', 'lld')
-COMPILER_RT_SRC_DIR = os.path.join(WORK_DIR, 'compiler-rt')
+COMPILER_RT_SRC_DIR = os.path.join(LLVM_SRC_DIR, 'projects', 'compiler-rt')
 LLVM_TEST_SUITE_SRC_DIR = os.path.join(WORK_DIR, 'llvm-test-suite')
 
 EMSCRIPTEN_SRC_DIR = os.path.join(WORK_DIR, 'emscripten')

--- a/src/build.py
+++ b/src/build.py
@@ -1115,7 +1115,11 @@ def CompilerRT():
   cc_env = BuildEnv(COMPILER_RT_SRC_DIR, bin_subdir=True)
   command = [PREBUILT_CMAKE_BIN, '-G', 'Ninja',
              os.path.join(COMPILER_RT_SRC_DIR, 'lib', 'builtins'),
+             '-DCMAKE_TOOLCHAIN_FILE=' + os.path.join(SCRIPT_DIR, 'wasm_standalone.cmake'),
              '-DCOMPILER_RT_BAREMETAL_BUILD=On',
+             '-DCOMPILER_RT_BUILD_XRAY=OFF',
+             '-DCOMPILER_RT_INCLUDE_TESTS=OFF',
+             '-DCOMPILER_RT_ENABLE_IOS=OFF',
              '-DCMAKE_AR=' + os.path.join(INSTALL_BIN, 'llvm-ar'),
              '-DCMAKE_RANLIB=' + os.path.join(INSTALL_BIN, 'llvm-ranlib'),
              '-DCMAKE_C_COMPILER=' + os.path.join(INSTALL_BIN, 'clang'),
@@ -1169,6 +1173,9 @@ def Musl():
              os.path.join(INSTALL_SYSROOT, 'include'))
     CopyTree(os.path.join(MUSL_SRC_DIR, 'arch', 'wasm32'),
              os.path.join(INSTALL_SYSROOT, 'include'))
+    # Strictly speaking the CMake toolchain file isn't part of musl, but it does
+    # go along with the headers and libs musl installs
+    shutil.copy2(os.path.join(SCRIPT_DIR, 'wasm_standalone.cmake'), INSTALL_SYSROOT)
 
   except proc.CalledProcessError:
     # Note the failure but allow the build to continue.
@@ -1376,8 +1383,8 @@ def AllBuilds(use_asm=False):
       Build('fastcomp', Fastcomp),
       Build('emscripten', Emscripten, use_asm=use_asm),
       # Target libs
-      Build('compiler-rt', CompilerRT),
       Build('musl', Musl),
+      Build('compiler-rt', CompilerRT),
       # Archive
       Build('archive', ArchiveBinaries),
       Build('debian', DebianPackage),

--- a/src/wasm_standalone.cmake
+++ b/src/wasm_standalone.cmake
@@ -1,12 +1,27 @@
+# Cmake toolchain description file for the waterfall-built clang wasm toolchain
+
 # This is arbitrary, AFAIK, for now.
 cmake_minimum_required(VERSION 3.4.0)
 
 set(CMAKE_SYSTEM_NAME Wasm)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR wasm32)
+set(triple wasm32-unknown-unknown-wasm)
 
-set(WASM_SDKROOT /Users/dschuff/code/waterfall/src/work/wasm-install)
+set(WASM_SDKROOT ${CMAKE_CURRENT_LIST_DIR})
 set(CMAKE_C_COMPILER ${WASM_SDKROOT}/bin/clang)
 set(CMAKE_CXX_COMPILER ${WASM_SDKROOT}/bin/clang++)
+set(CMAKE_AR ${WASM_SDKROOT}/bin/llvm-ar)
+set(CMAKE_RANLIB ${WASM_SDKROOT}/bin/llvm-ranlib)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+
 set(CMAKE_SYSROOT ${WASM_SDKROOT}/sysroot)
 set(CMAKE_STAGING_PREFIX ${WASM_SDKROOT}/sysroot)
+
+# Don't look in the sysroot for executables to run during the build
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# Only look in the sysroot (not in the host paths) for the rest
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/src/wasm_standalone.cmake
+++ b/src/wasm_standalone.cmake
@@ -1,0 +1,12 @@
+# This is arbitrary, AFAIK, for now.
+cmake_minimum_required(VERSION 3.4.0)
+
+set(CMAKE_SYSTEM_NAME Wasm)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR wasm32)
+
+set(WASM_SDKROOT /Users/dschuff/code/waterfall/src/work/wasm-install)
+set(CMAKE_C_COMPILER ${WASM_SDKROOT}/bin/clang)
+set(CMAKE_CXX_COMPILER ${WASM_SDKROOT}/bin/clang++)
+set(CMAKE_SYSROOT ${WASM_SDKROOT}/sysroot)
+set(CMAKE_STAGING_PREFIX ${WASM_SDKROOT}/sysroot)


### PR DESCRIPTION
This prevents CMake from using any host system headers when compiling, (this just happens to work on the linux bot but it breaks the mac bot).