### PR TITLE
 Make waterfall use prebuilt Java

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -193,16 +193,19 @@ NODE_BIN = Executable(os.path.join(WORK_DIR,
 # compiler that requires Java SE 8.0 (version 52) or above
 JAVA_VERSION = '9.0.1'
 
+
 def JavaDir():
   outdir = 'jre-' + JAVA_VERSION
   if IsMac():
     return outdir + '.jre'
   return outdir
 
+
 def JavaBinDir():
   if IsMac():
     return os.path.join('Contents', 'Home', 'bin')
   return 'bin'
+
 
 JAVA_DIR = os.path.join(WORK_DIR, JavaDir())
 JAVA_BIN = Executable(os.path.join(JAVA_DIR, JavaBinDir(), 'java'))
@@ -674,7 +677,7 @@ ALL_SOURCES = [
     Source('musl', MUSL_SRC_DIR,
            MUSL_GIT_BASE + 'musl.git',
            checkout=RemoteBranch('wasm-prototype-1')),
-    Source('java', '', '', # The source and git args are ignored.
+    Source('java', '', '',  # The source and git args are ignored.
            custom_sync=SyncPrebuiltJava)
 ]
 

--- a/src/build.py
+++ b/src/build.py
@@ -610,7 +610,8 @@ def SyncGNUWin32(name, src_dir, git_repo):
 
 
 def SyncPrebuiltJava(name, src_dir, git_repo):
-  platform = {'linux2': 'linux', 'darwin': 'osx', 'win32': 'x64'}[sys.platform]
+  platform = {'linux2': 'linux', 'darwin': 'osx',
+              'win32': 'windows'}[sys.platform]
   tarball = 'jre-' + JAVA_VERSION + '_' + platform + '-x64_bin.tar.gz'
   java_url = WASM_STORAGE_BASE + tarball
   SyncArchive(JAVA_DIR, name, java_url)

--- a/src/build.py
+++ b/src/build.py
@@ -608,8 +608,12 @@ def SyncGNUWin32(name, src_dir, git_repo):
 
 def SyncPrebuiltJava(name, src_dir, git_repo):
   # FIXME test
-  CopyTree('/usr/local/google/home/aheejin/Downloads/jre/linux/jre-9.0.1',
-           WORK_DIR + '/jre-9.0.1')
+  if IsLinux():
+    CopyTree('/usr/local/google/home/aheejin/Downloads/jre/linux/jre-9.0.1',
+             WORK_DIR + '/jre-9.0.1')
+  if IsMac():
+    CopyTree('/Users/aheejin/Downloads/jre/mac/jre-9.0.1.jre',
+             WORK_DIR + '/jre-9.0.1.jre')
   return
 
   platform = {'linux2': 'linux', 'darwin': 'osx', 'win32': 'x64'}[sys.platform]

--- a/src/build.py
+++ b/src/build.py
@@ -197,7 +197,7 @@ JAVA_VERSION = '9.0.1'
 def JavaDir():
   outdir = 'jre-' + JAVA_VERSION
   if IsMac():
-    return outdir + '.jre'
+    outdir += '.jre'
   return outdir
 
 

--- a/src/build.py
+++ b/src/build.py
@@ -607,18 +607,9 @@ def SyncGNUWin32(name, src_dir, git_repo):
 
 
 def SyncPrebuiltJava(name, src_dir, git_repo):
-  # FIXME test
-  if IsLinux():
-    CopyTree('/usr/local/google/home/aheejin/Downloads/jre/linux/jre-9.0.1',
-             WORK_DIR + '/jre-9.0.1')
-  if IsMac():
-    CopyTree('/Users/aheejin/Downloads/jre/mac/jre-9.0.1.jre',
-             WORK_DIR + '/jre-9.0.1.jre')
-  return
-
   platform = {'linux2': 'linux', 'darwin': 'osx', 'win32': 'x64'}[sys.platform]
-  tarball = 'jre-' + JAVA_VERSION + '_' + platform + '_bin.tar.gz'
-  java_url = WASM_STORGE_BASE + tarball
+  tarball = 'jre-' + JAVA_VERSION + '_' + platform + '-x64_bin.tar.gz'
+  java_url = WASM_STORAGE_BASE + tarball
   SyncArchive(JAVA_DIR, name, java_url)
 
 

--- a/src/emscripten_config
+++ b/src/emscripten_config
@@ -28,7 +28,7 @@ NODE_JS = os.path.expanduser(os.getenv('NODE') or prebuilt_node  or '/usr/bin/no
 SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY') or 'js')] # executable
 V8_ENGINE = os.path.join(WASM_INSTALL, 'bin', 'd8') # executable
 
-JAVA = 'java' # executable
+JAVA = '{{PREBUILT_JAVA}}' # executable
 
 TEMP_DIR = '/tmp'
 

--- a/src/emscripten_config_vanilla
+++ b/src/emscripten_config_vanilla
@@ -28,7 +28,7 @@ NODE_JS = os.path.expanduser(os.getenv('NODE') or prebuilt_node or '/usr/bin/nod
 SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY') or 'js')] # executable
 V8_ENGINE = os.path.join(WASM_INSTALL, 'bin', 'd8') # executable
 
-JAVA = 'java' # executable
+JAVA = '{{PREBUILT_JAVA}}' # executable
 
 TEMP_DIR = '/tmp'
 


### PR DESCRIPTION
Java installed in the buildbots are too old while emscripten uses
closure compiler that requires Java SE 8.0 (version 52) or above.