### PR TITLE
Sleep after writing emscripten configuration file

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1117,14 +1117,14 @@ def Emscripten(use_asm):
     # unnecessary anyway, and we are planning to fix it. But this is also
     # causing problems for Mac and Windows build in waterfall. The first emcc
     # process sees the configuration file has changed, deletes cache, and
-    # rewrites the sanity file. Then, Mac OS X and Windows' timestamps for mtime
-    # only have 1~2 seconds resolution, which makes it possible that other emcc
-    # processes launched later by the initial emcc process again think the cache
-    # is invalid and delete the cache again, which would then contain half-built
-    # libraries, if less than 1 seconds has elapsed after the first deletion. So
-    # here we make sure that enough time has elapsed between configuration file
-    # writing and sanity checking, so that it would temporarily work on Mac and
-    # Windows.
+    # rewrites the sanity file. Then, Mac OS X and Windows' timestamps for
+    # mtime only have 1~2 seconds resolution, which makes it possible that
+    # other emcc processes launched later by the initial emcc process again
+    # think the cache is invalid and delete the cache again, which would then
+    # contain half-built libraries, if less than 1 seconds has elapsed after
+    # the first deletion. So here we make sure that enough time has elapsed
+    # between configuration file writing and sanity checking, so that it would
+    # temporarily work on Mac and Windows.
     time.sleep(3)
 
     try:

--- a/src/build.py
+++ b/src/build.py
@@ -1111,6 +1111,7 @@ def Emscripten(use_asm):
       # This depends on binaryen already being built and installed into the
       # archive/install dir.
       os.environ['EM_CONFIG'] = config
+      os.environ['EMCC_SKIP_SANITY_CHECK'] = '1'
       proc.check_call([
           sys.executable, os.path.join(emscripten_dir, 'embuilder.py'),
           'build', 'SYSTEM'])
@@ -1120,6 +1121,7 @@ def Emscripten(use_asm):
       buildbot.Fail()
     finally:
       del os.environ['EM_CONFIG']
+      del os.environ['EMCC_SKIP_SANITY_CHECK']
 
   wrapper = os.path.join(SCRIPT_DIR, 'emcc_wrapper.sh')
   shutil.copy2(wrapper, os.path.join(INSTALL_BIN, 'emcc'))

--- a/src/build.py
+++ b/src/build.py
@@ -1106,12 +1106,32 @@ def Emscripten(use_asm):
     print 'Config file: ', config
     src_config = os.path.join(SCRIPT_DIR, os.path.basename(config))
     WriteEmscriptenConfig(src_config, config)
+
+    # FIXME HACK emcc does sanity check by comparing mtime of the sanity file
+    # with that of emscripten config file. The sanity check process in
+    # emscripten thinks current cache is invalid when 'sanity file's mtime <=
+    # config file's mtime'. embuilder launches emcc for each of system library
+    # we need to build, and each of those emcc process in turn launches several
+    # more emcc processes for each of .c source file included in the library.
+    # Each of these emcc processes runs its own sanity check, which is
+    # unnecessary anyway, and we are planning to fix it. But this is also
+    # causing problems for Mac and Windows build in waterfall. The first emcc
+    # process sees the configuration file has changed, deletes cache, and
+    # rewrites the sanity file. Then, Mac OS X and Windows' timestamps for mtime
+    # only have 1~2 seconds resolution, which makes it possible that other emcc
+    # processes launched later by the initial emcc process again think the cache
+    # is invalid and delete the cache again, which would then contain half-built
+    # libraries, if less than 1 seconds has elapsed after the first deletion. So
+    # here we make sure that enough time has elapsed between configuration file
+    # writing and sanity checking, so that it would temporarily work on Mac and
+    # Windows.
+    time.sleep(3)
+
     try:
       # Use emscripten's embuilder to prebuild the system libraries.
       # This depends on binaryen already being built and installed into the
       # archive/install dir.
       os.environ['EM_CONFIG'] = config
-      os.environ['EMCC_SKIP_SANITY_CHECK'] = '1'
       proc.check_call([
           sys.executable, os.path.join(emscripten_dir, 'embuilder.py'),
           'build', 'SYSTEM'])
@@ -1121,7 +1141,6 @@ def Emscripten(use_asm):
       buildbot.Fail()
     finally:
       del os.environ['EM_CONFIG']
-      del os.environ['EMCC_SKIP_SANITY_CHECK']
 
   wrapper = os.path.join(SCRIPT_DIR, 'emcc_wrapper.sh')
   shutil.copy2(wrapper, os.path.join(INSTALL_BIN, 'emcc'))


### PR DESCRIPTION
Each invocation of emcc does sanity check for the current emscripten
cache directory, whose default location is `~/.emscripten_cache`. It
compares the last modification of the configuration file
(`emscripten_config` for asmjs and `emscripten_config_vanilla` for wasm)
with that of the sanity file (`emscripten_config_sanity` for asmjs and
`emscripten_config_vanilla_sanity_wasm` for wasm), and if the
configuration file was modified after the sanity file, deletes the cache
directory and rewrites the sanity file.
https://github.com/kripken/emscripten/blob/a243a941d911698a703fd4e5210a9dbc24bc4e96/tools/shared.py#L512-L533
https://github.com/kripken/emscripten/blob/a243a941d911698a703fd4e5210a9dbc24bc4e96/tools/shared.py#L578-L582

The problem is, emcc thinks the cache is invalid when
`sanity file modification time <= config file modification time`, which
means the cache will be deleted even if two timestamps are equal.
https://github.com/kripken/emscripten/blob/a243a941d911698a703fd4e5210a9dbc24bc4e96/tools/shared.py#L520
This does not happen usually in Linux, but in Mac OS X and Windows, [the
file modification timestamps have only 1 or 2 seconds
resolution](https://docs.python.org/3/library/os.html#os.stat). And
the system library creation by embuilder involves several invocation of
emcc: emcc is invoked per every library (.a or .bc) to build, each of
which also launches multiple emcc processes for each .c file that
belongs to the library. This means it is possible that the cache is
deemed invalid and deleted in the first emcc invocation, but child emcc
processes wlll also delete the cache again, which would then contain
half-built libraries, if less than 1 seconds has elapsed after the the
first deletion.

Modifying the sanity check equation from `<=` to `<` so that the cache
will only be deleted when
`sanity file modification time < config file modification time` does not
seem to be a good solution, because it is also possible that in other
case it is possible that config file creation is followed by sanity file
creation, which warranties the regeneration of sanity file.

This patch just disables checking of sanity file timestamp. The
emscripten cache directory is deleted in the beginning of the function
anyway, so it's ok not to check it for the first emcc call as well.