### PR TITLE
Update expectations

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -319,6 +319,7 @@ vfprintf-chk-1.c.o.wasm O2
 20021127-1.c.o.wasm O0
 20031003-1.c.o.wasm O0
 pr23135.c.o.wasm O0
+pr58419.c.o.wasm O2 # getpid linkage issue
 
 # Clang optimizing loop into infinite loop for -O2
 930529-1.c.s.wast.wasm O2


### PR DESCRIPTION
A recent fix to llvm caused functions this test to fail
because the caller is assuming that getpid() is a vararg
function from the implementation is zero args.