### PR TITLE
Install arch/generic/bits/*.h from musl as well as arch/wasm32/bits/*.h

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1221,8 +1221,10 @@ def Musl():
 
     CopyTree(os.path.join(MUSL_SRC_DIR, 'include'),
              os.path.join(INSTALL_SYSROOT, 'include'))
-    CopyTree(os.path.join(MUSL_SRC_DIR, 'arch', 'wasm32'),
-             os.path.join(INSTALL_SYSROOT, 'include'))
+    CopyTree(os.path.join(MUSL_SRC_DIR, 'arch', 'generic', 'bits'),
+             os.path.join(INSTALL_SYSROOT, 'include', 'bits'))
+    CopyTree(os.path.join(MUSL_SRC_DIR, 'arch', 'wasm32', 'bits'),
+             os.path.join(INSTALL_SYSROOT, 'include', 'bits'))
     # Strictly speaking the CMake toolchain file isn't part of musl, but does
     # go along with the headers and libs musl installs
     shutil.copy2(os.path.join(SCRIPT_DIR, 'wasm_standalone.cmake'),

--- a/src/build.py
+++ b/src/build.py
@@ -1225,6 +1225,8 @@ def Musl():
              os.path.join(INSTALL_SYSROOT, 'include', 'bits'))
     CopyTree(os.path.join(MUSL_SRC_DIR, 'arch', 'wasm32', 'bits'),
              os.path.join(INSTALL_SYSROOT, 'include', 'bits'))
+    CopyTree(os.path.join(MUSL_OUT_DIR, 'obj', 'include', 'bits'),
+             os.path.join(INSTALL_SYSROOT, 'include', 'bits'))
     # Strictly speaking the CMake toolchain file isn't part of musl, but does
     # go along with the headers and libs musl installs
     shutil.copy2(os.path.join(SCRIPT_DIR, 'wasm_standalone.cmake'),


### PR DESCRIPTION
These should alwasy have been installed but it recently started
mattering becasue I removed bits/mman.h.

This mimics more closely what the musl Makefile does on `install`