### PR TITLE
Update invocation of host_toolchain.py on windows

### DIFF
--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -82,7 +82,7 @@ def SetUpVSEnv(outdir):
   # block
   runtime_dirs = os.pathsep.join(paths['runtime_dirs'])
   proc.check_call([SETUP_TOOLCHAIN,
-                   'foo', paths['win_sdk'], runtime_dirs, 'x64'],
+                   'foo', paths['win_sdk'], runtime_dirs, 'x64', '0'],
                   cwd=outdir)
   return GetVSEnv(outdir)
 


### PR DESCRIPTION
It grew a new required command-line flag in
https://chromium-review.googlesource.com/768549, so give it the value 0
(which means don't disable goma).