### PR TITLE
Pass --entry=main when linking with lld

### DIFF
--- a/src/link_assembly_files.py
+++ b/src/link_assembly_files.py
@@ -43,7 +43,7 @@ def link(infile, outfile, extras):
   commands = {
       'clang': [linker, '--target=wasm32-unknown-unknown',
                 '--sysroot=%s' % sysroot_dir, '-Wl,-zstack-size=1048576',
-                '-o', outfile, infile],
+                '-Wl,--entry=main', '-o', outfile, infile],
       's2wasm': [linker, '--allocate-stack', '1048576', '-o', outfile, infile],
   }
   return commands[basename] + extras['args']


### PR DESCRIPTION
We are about to land a change to implements visibility
in lld and without this change main could end up not being
exported (since we default to hidden in wasm clang)