### PR TITLE
Update prebuilt node.js to 8.9.3

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -174,7 +174,7 @@ def CMakeBinDir():
 
 
 # Use prebuilt Node.js because the buildbots don't have node preinstalled
-NODE_VERSION = '7.0.0'
+NODE_VERSION = '8.9.3'
 NODE_BASE_NAME = 'node-v' + NODE_VERSION + '-'
 
 PREBUILT_CMAKE_VERSION = '3.7.2'


### PR DESCRIPTION
This is the most recent LTS (the previous version was not an LTS, so this
one is more likely to match something users might use) and it supports wasm,
which would allow us to run wasm tests on top of it, if we want to do that
in the future.