### PR TITLE
Run emscripten tests in node.js instead of d8

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1514,7 +1514,7 @@ def TestBare():
   for opt in BARE_TEST_OPT_FLAGS:
     ExecuteLLVMTorture(
         name='d8-lld',
-        runner=NODE_BIN,
+        runner=Executable(os.path.join(INSTALL_BIN, 'd8')),
         indir=GetTortureDir('lld', opt),
         fails=RUN_KNOWN_TORTURE_FAILURES,
         attributes=common_attrs + ['d8', 'lld'],
@@ -1546,7 +1546,7 @@ def TestBare():
   for opt in BARE_TEST_OPT_FLAGS:
     ExecuteLLVMTorture(
         name='d8',
-        runner=NODE_BIN,
+        runner=Executable(os.path.join(INSTALL_BIN, 'd8')),
         indir=GetTortureDir('wat2wasm', opt),
         fails=RUN_KNOWN_TORTURE_FAILURES,
         attributes=common_attrs + ['d8'],

--- a/src/build.py
+++ b/src/build.py
@@ -1514,7 +1514,7 @@ def TestBare():
   for opt in BARE_TEST_OPT_FLAGS:
     ExecuteLLVMTorture(
         name='d8-lld',
-        runner=Executable(os.path.join(INSTALL_BIN, 'd8')),
+        runner=NODE_BIN,
         indir=GetTortureDir('lld', opt),
         fails=RUN_KNOWN_TORTURE_FAILURES,
         attributes=common_attrs + ['d8', 'lld'],
@@ -1546,7 +1546,7 @@ def TestBare():
   for opt in BARE_TEST_OPT_FLAGS:
     ExecuteLLVMTorture(
         name='d8',
-        runner=Executable(os.path.join(INSTALL_BIN, 'd8')),
+        runner=NODE_BIN,
         indir=GetTortureDir('wat2wasm', opt),
         fails=RUN_KNOWN_TORTURE_FAILURES,
         attributes=common_attrs + ['d8'],
@@ -1579,7 +1579,7 @@ def TestAsm():
   for opt in EMSCRIPTEN_TEST_OPT_FLAGS:
     ExecuteLLVMTorture(
         name='asm2wasm',
-        runner=Executable(os.path.join(INSTALL_BIN, 'd8')),
+        runner=NODE_BIN,
         indir=GetTortureDir('asm2wasm', opt),
         fails=RUN_KNOWN_TORTURE_FAILURES,
         attributes=['asm2wasm', 'd8'],
@@ -1600,7 +1600,7 @@ def TestEmwasm():
   for opt in EMSCRIPTEN_TEST_OPT_FLAGS:
     ExecuteLLVMTorture(
         name='emwasm',
-        runner=Executable(os.path.join(INSTALL_BIN, 'd8')),
+        runner=NODE_BIN,
         indir=GetTortureDir('emwasm', opt),
         fails=RUN_KNOWN_TORTURE_FAILURES,
         attributes=['emwasm', 'd8'],

--- a/src/emscripten_config
+++ b/src/emscripten_config
@@ -59,4 +59,4 @@ COMPILER_ENGINE = NODE_JS
 #                 run all the tests due to node issue 1669). v8 is currently not recommended
 #                 here because of v8 issue 1822.
 
-JS_ENGINES = [V8_ENGINE] # add this if you have spidermonkey installed too, SPIDERMONKEY_ENGINE]
+JS_ENGINES = [NODE_JS] # add this if you have spidermonkey installed too, SPIDERMONKEY_ENGINE]

--- a/src/emscripten_config_vanilla
+++ b/src/emscripten_config_vanilla
@@ -59,4 +59,4 @@ COMPILER_ENGINE = NODE_JS
 #                 run all the tests due to node issue 1669). v8 is currently not recommended
 #                 here because of v8 issue 1822.
 
-JS_ENGINES = [V8_ENGINE] # add this if you have spidermonkey installed too, SPIDERMONKEY_ENGINE]
+JS_ENGINES = [NODE_JS] # add this if you have spidermonkey installed too, SPIDERMONKEY_ENGINE]

--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -52,7 +52,8 @@ def execute(infile, outfile, extras):
       'jsc-wasm': [runner, '--useWebAssembly=1'] + wasmjs + [
           '--', infile] + extra_files,
       'jsc-asm2wasm': [runner, '--useWebAssembly=1', infile],
-      'wasm': [runner, infile]
+      'wasm': [runner, infile],
+      'node': [runner] + wasmjs + [infile] + extra_files
   }
   return commands[config]
 


### PR DESCRIPTION
Proof of concept to run bare and emscripten tests in node.js.

Everything seems to work but Interestingly there seems to be unexpected successes (compared to d8) in the emscripten torture tests (both asm2wasm and emwasm)