### PR TITLE
Don't assert when there are no files to execute

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1353,6 +1353,10 @@ def ExecuteLLVMTorture(name, runner, indir, fails, attributes, extension, opt,
     return None
   assert os.path.isfile(runner), 'Cannot find runner at %s' % runner
   files = os.path.join(indir, '*.%s' % extension)
+  if len(glob.glob(files)) == 0:
+    print "No files found by", files
+    buildbot.Fail()
+    return
   unexpected_result_count = execute_files.run(
       runner=runner,
       files=files,


### PR DESCRIPTION
We're currently failing to link any files with lld, which causes
execute_files to assert, which prevents any later tests from running.
This allows later tests to still run.