### PR TITLE
Fix CMake path injection for mac

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1758,7 +1758,7 @@ def run(sync_filter, build_filter, test_filter):
     Mkdir(INSTALL_LIB)
 
   # Add prebuilt cmake to PATH so any subprocesses use a consistent cmake.
-  os.environ['PATH'] = (os.path.join(PREBUILT_CMAKE_DIR, 'bin') +
+  os.environ['PATH'] = (os.path.join(PREBUILT_CMAKE_DIR, CMakeBinDir()) +
                         os.pathsep + os.environ['PATH'])
 
   # TODO(dschuff): Figure out how to make these statically linked?


### PR DESCRIPTION
The bullet and openjpg emscripten test suite tests were failing on mac
because the bots apparently don't have a system-installed CMake anymore,
and the path we were injecting wasn't correct on mac.