### PR TITLE
Add ability to completely exclude torture tests from test pipeline

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -240,6 +240,11 @@ BINARYEN_SHELL_KNOWN_TORTURE_FAILURES = [
     os.path.join(BINARYEN_SRC_DIR, 'test',
                  's2wasm_known_binaryen_shell_test_failures.txt')]
 
+# Exclusions (known failures are compiled and run, and expected to fail, whereas
+# exclusions are not even run, e.g. because they have UB which results in
+# infinite loops)
+LLVM_TORTURE_EXCLUSIONS = [os.path.join(SCRIPT_DIR, 'test', 'llvm_torture_exclusions')]
+
 # Optimization levels
 BARE_TEST_OPT_FLAGS = ['O0', 'O2']
 EMSCRIPTEN_TEST_OPT_FLAGS = ['O0', 'O3']
@@ -1288,6 +1293,7 @@ def CompileLLVMTorture(extension, outdir, opt):
       c=c, cxx=cxx, testsuite=GCC_TEST_DIR,
       sysroot_dir=INSTALL_SYSROOT,
       fails=LLVM_KNOWN_TORTURE_FAILURES,
+      exclusions=LLVM_TORTURE_EXCLUSIONS,
       out=outdir,
       config='wasm-' + extension,
       opt=opt)

--- a/src/build.py
+++ b/src/build.py
@@ -240,10 +240,11 @@ BINARYEN_SHELL_KNOWN_TORTURE_FAILURES = [
     os.path.join(BINARYEN_SRC_DIR, 'test',
                  's2wasm_known_binaryen_shell_test_failures.txt')]
 
-# Exclusions (known failures are compiled and run, and expected to fail, whereas
-# exclusions are not even run, e.g. because they have UB which results in
-# infinite loops)
-LLVM_TORTURE_EXCLUSIONS = [os.path.join(SCRIPT_DIR, 'test', 'llvm_torture_exclusions')]
+# Exclusions (known failures are compiled and run, and expected to fail,
+# whereas exclusions are not even run, e.g. because they have UB which
+# results in infinite loops)
+LLVM_TORTURE_EXCLUSIONS = [os.path.join(SCRIPT_DIR, 'test',
+                                        'llvm_torture_exclusions')]
 
 # Optimization levels
 BARE_TEST_OPT_FLAGS = ['O0', 'O2']

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -34,7 +34,7 @@ def create_outname(outdir, infile, extras):
   return os.path.join(outdir, outname)
 
 
-def run(c, cxx, testsuite, sysroot_dir, fails, out, config, opt):
+def run(c, cxx, testsuite, sysroot_dir, fails, exclusions, out, config, opt):
   """Compile all torture tests."""
   cflags_common = ['--std=gnu89', '-DSTACK_SIZE=524288',
                    '-w', '-Wno-implicit-function-declaration', '-' + opt]
@@ -78,6 +78,7 @@ def run(c, cxx, testsuite, sysroot_dir, fails, out, config, opt):
           extras={'c': c, 'cflags': cflags, 'suffix': suffix}),
       inputs=c_test_files,
       fails=fails,
+      exclusions=exclusions,
       attributes=[config, opt])
 
   return result

--- a/src/test/llvm_torture_exclusions
+++ b/src/test/llvm_torture_exclusions
@@ -1,0 +1,2 @@
+# Clang optimizes loop into infinite loop for -O2
+930529-1.c

--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -316,8 +316,3 @@ vfprintf-chk-1.c.o.wasm O2
 20021127-1.c.o.wasm O0
 20031003-1.c.o.wasm O0
 pr23135.c.o.wasm O0
-
-# Clang optimizing loop into infinite loop for -O2
-930529-1.c.s.wast.wasm O2
-930529-1.c.o.wasm O2
-930529-1.c.js emwasm,O3 # asm2wasm uses different clang

--- a/src/testing.py
+++ b/src/testing.py
@@ -220,8 +220,11 @@ def similarity(results, cutoff):
   return similar_groups
 
 
-def execute(tester, inputs, fails, attributes=None):
+def execute(tester, inputs, fails, exclusions=None, attributes=None):
   """Execute tests in parallel, output results, return failure count."""
+  if exclusions:
+    input_exclusions = parse_exclude_files(exclusions, None)
+    inputs = [i for i in inputs if os.path.basename(i) not in input_exclusions]
   if fails:
     input_expected_failures = parse_exclude_files(fails, attributes)
   else:


### PR DESCRIPTION
The test in question has UB and is optimized into an infinite loop. On mac and
linux the python rlimit mechanism is used to kill the program after timeout, but
there's no equivalent functionality for Windows currently. So we just exclude
the test entirely (this also makes everything run faster on mac and linux since
we aren't waiting uselessly for the timeout).