### PR TITLE
Add support for some of the C++ gcc testsuite

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1568,7 +1568,7 @@ def TestBare():
   for opt in BARE_TEST_OPT_FLAGS:
     LinkLLVMTorture(
         name='lld',
-        linker=Executable(os.path.join(INSTALL_BIN, 'clang')),
+        linker=Executable(os.path.join(INSTALL_BIN, 'clang++')),
         fails=LLD_KNOWN_TORTURE_FAILURES,
         indir=GetTortureDir('o', opt),
         outdir=GetTortureDir('lld', opt),

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -35,7 +35,7 @@ def do_compile(infile, outfile, extras):
 def create_outname(outdir, infile, extras):
   if os.path.splitext(infile)[1] == '.C':
     parts = infile.split(os.path.sep)
-    parts = parts[parts.index('testsuite')+2:]
+    parts = parts[parts.index('testsuite') + 2:]
     basename = '__'.join(parts)
   else:
     basename = os.path.basename(infile)

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -15,6 +15,7 @@
 #   limitations under the License.
 
 import argparse
+import fnmatch
 import glob
 import os
 import os.path
@@ -23,21 +24,48 @@ import sys
 import testing
 
 
-def c_compile(infile, outfile, extras):
+def do_compile(infile, outfile, extras):
   """Create the command-line for a C compiler invocation."""
-  return [extras['cc'], infile, '-o', outfile] + extras['cflags']
+  if os.path.splitext(infile)[1] == '.C':
+    return [extras['cxx'], infile, '-o', outfile] + extras['cxxflags']
+  else:
+    return [extras['cc'], infile, '-o', outfile] + extras['cflags']
 
 
 def create_outname(outdir, infile, extras):
-  basename = os.path.basename(infile)
-  outname = basename + extras['suffix']
-  return os.path.join(outdir, outname)
+  if os.path.splitext(infile)[1] == '.C':
+    parts = infile.split(os.path.sep)
+    parts = parts[parts.index('testsuite')+2:]
+    basename = '__'.join(parts)
+  else:
+    basename = os.path.basename(infile)
+  rtn = os.path.join(outdir, basename + extras['suffix'])
+  if os.path.exists(rtn):
+    raise Exception("already exists: " + rtn)
+  return rtn
+
+
+def find_runnable_tests(directory, pattern):
+  results = []
+  for root, dirs, files in os.walk(directory):
+    if os.path.basename(root) == 'ext':
+      continue
+    for filename in files:
+      if fnmatch.fnmatch(filename, pattern):
+        fullname = os.path.join(root, filename)
+        with open(fullname, 'r') as f:
+          header = f.read(1024)
+        if '{ dg-do run }' in header and 'dg-additional-sources' not in header:
+          results.append(fullname)
+  return results
 
 
 def run(cc, cxx, testsuite, sysroot_dir, fails, exclusions, out, config, opt):
   """Compile all torture tests."""
-  cflags_common = ['--std=gnu89', '-DSTACK_SIZE=524288',
+  cflags_common = ['-DSTACK_SIZE=524288',
                    '-w', '-Wno-implicit-function-declaration', '-' + opt]
+  cflags_c = ['--std=gnu89']
+  cflags_cxx = []
   cflags_extra = {
       'wasm-s': ['--target=wasm32-unknown-unknown', '-S',
                  '--sysroot=%s' % sysroot_dir],
@@ -59,24 +87,37 @@ def run(cc, cxx, testsuite, sysroot_dir, fails, exclusions, out, config, opt):
       'binaryen-inputs': '.js',
   }[config]
 
+  assert os.path.isdir(out), 'Cannot find outdir %s' % out
   assert os.path.isfile(cc), 'Cannot find C compiler at %s' % cc
   assert os.path.isfile(cxx), 'Cannot find C++ compiler at %s' % cxx
   assert os.path.isdir(testsuite), 'Cannot find testsuite at %s' % testsuite
-  # TODO(jfb) Also compile other C tests, as well as C++ tests under g++.dg.
+
+  # Currently we build the following parts of the gcc test suite:
+  #  - testsuite/gcc.c-torture/execute/*.c
+  #  - testsuite/g++.dg (all executable tests)
+  # TODO(sbc) Also more parts of the test suite
   c_torture = os.path.join(testsuite, 'gcc.c-torture', 'execute')
-  assert os.path.isdir(c_torture), ('Cannot find C torture tests at %s' %
-                                    c_torture)
-  assert os.path.isdir(out), 'Cannot find outdir %s' % out
-  c_test_files = glob.glob(os.path.join(c_torture, '*c'))
-  cflags = cflags_common + cflags_extra[config]
+  assert os.path.isdir(c_torture), ('Cannot find C tests at %s' % c_torture)
+  test_files = glob.glob(os.path.join(c_torture, '*.c'))
+
+  if config == 'wasm-o':
+    # Only build the C++ tests when linking with lld
+    cxx_test_dir = os.path.join(testsuite, 'g++.dg')
+    assert os.path.isdir(cxx_test_dir), ('Cannot find C++ tests at %s' %
+                                         cxx_test_dir)
+    test_files += find_runnable_tests(cxx_test_dir, '*.C')
+
+  cflags = cflags_common + cflags_c + cflags_extra[config]
+  cxxflags = cflags_common + cflags_cxx + cflags_extra[config]
 
   result = testing.execute(
       tester=testing.Tester(
-          command_ctor=c_compile,
+          command_ctor=do_compile,
           outname_ctor=create_outname,
           outdir=out,
-          extras={'cc': cc, 'cflags': cflags, 'suffix': suffix}),
-      inputs=c_test_files,
+          extras={'cc': cc, 'cxx': cxx, 'cflags': cflags,
+                  'cxxflags': cxxflags, 'suffix': suffix}),
+      inputs=test_files,
       fails=fails,
       exclusions=exclusions,
       attributes=[config, opt])

--- a/src/libc++abi.imports
+++ b/src/libc++abi.imports
@@ -1,2 +1,3 @@
 _Unwind_RaiseException
 _Unwind_DeleteException
+_Unwind_ForcedUnwind

--- a/src/link_assembly_files.py
+++ b/src/link_assembly_files.py
@@ -27,10 +27,10 @@ def create_outname(outdir, infile, extras):
   """Create the output file's name."""
   basename = os.path.basename(infile)
   linker = os.path.splitext(os.path.basename(extras['linker']))[0]
-  if linker == 'clang':
-    outname = basename + '.wasm'
-  else:
+  if linker == 's2wasm':
     outname = basename + '.wast'
+  else:
+    outname = basename + '.wasm'
   return os.path.join(outdir, outname)
 
 
@@ -41,9 +41,9 @@ def link(infile, outfile, extras):
   install_root = os.path.dirname(os.path.dirname(linker))
   sysroot_dir = os.path.join(install_root, 'sysroot')
   commands = {
-      'clang': [linker, '--target=wasm32-unknown-unknown',
-                '--sysroot=%s' % sysroot_dir, '-Wl,-zstack-size=1048576',
-                '-Wl,--entry=main', '-o', outfile, infile],
+      'clang++': [linker, '--target=wasm32-unknown-unknown',
+                  '--sysroot=%s' % sysroot_dir, '-Wl,-zstack-size=1048576',
+                  '-Wl,--entry=main', '-o', outfile, infile],
       's2wasm': [linker, '--allocate-stack', '1048576', '-o', outfile, infile],
   }
   return commands[basename] + extras['args']

--- a/src/test/lld_known_gcc_test_failures.txt
+++ b/src/test/lld_known_gcc_test_failures.txt
@@ -8,3 +8,12 @@ va-arg-pack-1.c.o
 # undefined symbol: link_error
 # Don't care. The test case is faulty. link_error() does not exist.
 medce-1.c.o O0
+
+asan__interception-test-1.C.o  # Undefined symbol: __interceptor_strtol
+tree-ssa__pr20458.C.o  # Undefined symbol: std::locale::locale
+
+# Crash in lld
+warn__weak1.C.o
+
+# Untriaged
+warn__pr33738.C.o

--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -309,7 +309,108 @@ va-arg-22.c.o.wasm
 fprintf-chk-1.c.o.wasm O2
 vfprintf-chk-1.c.o.wasm O2
 
-# Untriaged lld O0 failures
+# Missing _Unwind_* functions
+cleanup-5.C.o.wasm
+
+# Untriaged lld failures
+tc1__dr20.C.o.wasm O2
+torture__pr48695.C.o.wasm O2
+
 20021127-1.c.o.wasm O0
 20031003-1.c.o.wasm O0
 pr23135.c.o.wasm O0
+abi__covariant3.C.o.wasm O0
+expr__cast4.C.o.wasm O0
+inherit__thunk7.C.o.wasm O0
+init__array33.C.o.wasm O0
+init__attrib1.C.o.wasm O0
+ipa__pr60640-3.C.o.wasm O0
+ipa__pr60640-4.C.o.wasm O0
+rtti__dyncast2.C.o.wasm O0
+template__arg6.C.o.wasm O0
+template__ctor2.C.o.wasm O0
+tree-ssa__pr28003.C.o.wasm O0
+ubsan__return-1.C.o.wasm O0
+
+abi__bitfield1.C.o.wasm
+abi__vbase13.C.o.wasm
+asan__deep-stack-uaf-1.C.o.wasm
+asan__symbolize-callback-1.C.o.wasm
+eh__alias1.C.o.wasm
+eh__cond1.C.o.wasm
+eh__cond4.C.o.wasm
+eh__cond5.C.o.wasm
+eh__cond6.C.o.wasm
+eh__crossjump1.C.o.wasm
+eh__ctor1.C.o.wasm
+eh__ctor2.C.o.wasm
+eh__defarg1.C.o.wasm
+eh__delayslot1.C.o.wasm
+eh__dtor1.C.o.wasm
+eh__elide1.C.o.wasm
+eh__elide2.C.o.wasm
+eh__filter1.C.o.wasm
+eh__filter2.C.o.wasm
+eh__fp-regs.C.o.wasm
+eh__ia64-2.C.o.wasm
+eh__init-temp1.C.o.wasm
+eh__loop1.C.o.wasm
+eh__loop2.C.o.wasm
+eh__new1.C.o.wasm
+eh__omit-frame-pointer.C.o.wasm
+eh__omit-frame-pointer2.C.o.wasm
+eh__partial1.C.o.wasm
+eh__pr29166.C.o.wasm
+eh__registers1.C.o.wasm
+eh__simd-1.C.o.wasm
+eh__simd-2.C.o.wasm
+eh__simd-3.C.o.wasm
+eh__spbp.C.o.wasm
+eh__spec10.C.o.wasm
+eh__spec3.C.o.wasm
+eh__spec7.C.o.wasm
+eh__spec9.C.o.wasm
+eh__synth2.C.o.wasm
+eh__template1.C.o.wasm
+eh__uncaught1.C.o.wasm
+eh__uncaught4.C.o.wasm
+eh__unexpected1.C.o.wasm
+expr__cond12.C.o.wasm
+expr__cond6.C.o.wasm
+init__array12.C.o.wasm
+init__array5.C.o.wasm
+init__copy3.C.o.wasm
+init__ctor1.C.o.wasm
+init__init-ref2.C.o.wasm
+init__new36.C.o.wasm
+init__placement2.C.o.wasm
+init__ref19.C.o.wasm
+init__ref9.C.o.wasm
+ipa__pr63838.C.o.wasm
+opt__20050511-1.C.o.wasm
+opt__const3.C.o.wasm
+opt__eh2.C.o.wasm
+opt__eh3.C.o.wasm
+opt__eh4.C.o.wasm
+opt__pr23299.C.o.wasm
+opt__pr23478.C.o.wasm
+opt__pr36449.C.o.wasm
+opt__static5.C.o.wasm
+other__copy2.C.o.wasm
+rtti__dyncast3.C.o.wasm
+rtti__typeid10.C.o.wasm
+rtti__typeid4.C.o.wasm
+template__friend10.C.o.wasm
+template__pretty1.C.o.wasm
+torture__pr49115.C.o.wasm
+torture__pr60750.C.o.wasm
+torture__stackalign__eh-alloca-1.C.o.wasm
+torture__stackalign__eh-global-1.C.o.wasm
+torture__stackalign__eh-inline-1.C.o.wasm
+torture__stackalign__eh-inline-2.C.o.wasm
+torture__stackalign__eh-vararg-1.C.o.wasm
+torture__stackalign__eh-vararg-2.C.o.wasm
+torture__stackalign__throw-1.C.o.wasm
+torture__stackalign__throw-2.C.o.wasm
+torture__stackalign__throw-3.C.o.wasm
+tree-ssa__pr33604.C.o.wasm


### PR DESCRIPTION
The gcc test suite is spread over several directories.  There are also duplicate filenames across
those directories.  This means we can't just use the test basename for complication output.
I looked into re-creating the nested structure in the output tree, but in the end it was simpler
to convert the full path into single filename (essentially replacing `\` with `__`). Hopefully this
is not too ugly!