### PR TITLE
Add a simple way runs tests single threaded during development

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -39,6 +39,7 @@ from file_util import Chdir, CopyTree, Mkdir, Remove
 import host_toolchains
 import link_assembly_files
 import proc
+import testing
 
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -1804,6 +1805,9 @@ def ParseArgs():
       help='Include only the comma-separated list of test targets')
 
   parser.add_argument(
+      '--no-threads', action='store_true',
+      help='Disable use of thread pool to building and testing')
+  parser.add_argument(
       '--no-tool-tests', dest='run_tool_tests', action='store_false',
       help='Skip the testing of tools (such tools llvm, wabt, v8, spec)')
   parser.add_argument(
@@ -1864,6 +1868,9 @@ def main():
   global options
   start = time.time()
   options = ParseArgs()
+
+  if options.no_threads:
+    testing.single_threaded = True
 
   sync_include = options.sync_include if options.sync else []
   sync_filter = Filter('sync', sync_include, options.sync_exclude)

--- a/src/testing.py
+++ b/src/testing.py
@@ -26,6 +26,7 @@ import proc
 # Set to True to disable execution via thread pool
 single_threaded = False
 
+
 class Result:
   """Result from a single test that was run."""
 

--- a/src/testing.py
+++ b/src/testing.py
@@ -23,7 +23,8 @@ import sys
 
 import proc
 
-SINGLE_THREADED = False
+# Set to True to disable execution via thread pool
+single_threaded = False
 
 class Result:
   """Result from a single test that was run."""
@@ -231,14 +232,15 @@ def execute(tester, inputs, fails, exclusions=None, attributes=None):
   else:
     input_expected_failures = []
   sys.stdout.write('Executing tests.')
-  if SINGLE_THREADED:
+  if single_threaded:
     results = map(tester, inputs)
   else:
     pool = multiprocessing.Pool()
-    results = sorted(pool.map(tester, inputs))
+    results = pool.map(tester, inputs)
     pool.close()
     pool.join()
   sys.stdout.write('\nDone.')
+  results = sorted(results)
   successes = [r for r in results if r]
   failures = [r for r in results if not r]
   if not fails:

--- a/src/testing.py
+++ b/src/testing.py
@@ -23,6 +23,7 @@ import sys
 
 import proc
 
+SINGLE_THREADED = False
 
 class Result:
   """Result from a single test that was run."""
@@ -229,11 +230,14 @@ def execute(tester, inputs, fails, exclusions=None, attributes=None):
     input_expected_failures = parse_exclude_files(fails, attributes)
   else:
     input_expected_failures = []
-  pool = multiprocessing.Pool()
   sys.stdout.write('Executing tests.')
-  results = sorted(pool.map(tester, inputs))
-  pool.close()
-  pool.join()
+  if SINGLE_THREADED:
+    results = map(tester, inputs)
+  else:
+    pool = multiprocessing.Pool()
+    results = sorted(pool.map(tester, inputs))
+    pool.close()
+    pool.join()
   sys.stdout.write('\nDone.')
   successes = [r for r in results if r]
   failures = [r for r in results if not r]


### PR DESCRIPTION
When working on waterfall code the thread pool can sometimes
make this very hard to debug, hiding output and errors in some
cases.