### PR TITLE
Add jsvu step

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1548,7 +1548,7 @@ def AllBuilds(use_asm=False):
       Build('llvm', LLVM),
       Build('v8', V8),
       Build('jsc', Jsc, no_windows=True, no_linux=True),
-      Build('jsvu', Jsvu, no_linux=True),
+      Build('jsvu', Jsvu, no_windows=True, no_linux=True),
       Build('wabt', Wabt),
       Build('ocaml', OCaml, no_windows=True),
       Build('spec', Spec, no_windows=True),


### PR DESCRIPTION
This patch adds a step that installs [jsvu](https://github.com/GoogleChromeLabs/jsvu). For now it only does so on Windows (where jsvu then installs a `chakra` binary) and Mac (where jsvu then installs a `javascriptcore` binary), but this can easily be extended in the future.

Hopefully this can replace the complex build systems for these engines and reduce the maintenance cost of this project.