### PR TITLE
Add tls/thread_local torture tests to llc xfails

### DIFF
--- a/src/test/lld_known_gcc_test_failures.txt
+++ b/src/test/lld_known_gcc_test_failures.txt
@@ -12,5 +12,14 @@ medce-1.c.o O0
 asan__interception-test-1.C.o  # Undefined symbol: __interceptor_strtol
 tree-ssa__pr20458.C.o  # Undefined symbol: std::locale::locale
 
+
+# These tests use TLS and need to link libpthread
+tls__thread_local3.C.o
+tls__thread_local3g.C.o
+tls__thread_local4.C.o
+tls__thread_local4g.C.o
+tls__thread_local5.C.o
+tls__thread_local5g.C.o
+
 # Untriaged
 warn__pr33738.C.o

--- a/src/test/lld_known_gcc_test_failures.txt
+++ b/src/test/lld_known_gcc_test_failures.txt
@@ -13,7 +13,7 @@ asan__interception-test-1.C.o  # Undefined symbol: __interceptor_strtol
 tree-ssa__pr20458.C.o  # Undefined symbol: std::locale::locale
 
 
-# These tests use TLS and need to link libpthread
+# These tests compile but need to actually create threads to run correctly.
 tls__thread_local3.C.o
 tls__thread_local3g.C.o
 tls__thread_local4.C.o


### PR DESCRIPTION
They now compile, but don't run because they require actual thread creation.