### PR TITLE
Update libcxx/abi builds

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -41,11 +41,6 @@ import link_assembly_files
 import proc
 import testing
 
-def IsWindows():
-  return sys.platform == 'win32'
-
-def Executable(name, extension='.exe'):
-  return name + extension if IsWindows() else name
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 WORK_DIR = os.path.join(SCRIPT_DIR, 'work')
@@ -83,8 +78,8 @@ PREBUILT_CLANG = os.path.join(WORK_DIR, 'chromium-clang')
 PREBUILT_CLANG_TOOLS_CLANG = os.path.join(PREBUILT_CLANG, 'tools', 'clang')
 PREBUILT_CLANG_BIN = os.path.join(
     PREBUILT_CLANG, 'third_party', 'llvm-build', 'Release+Asserts', 'bin')
-CC = Executable(os.path.join(PREBUILT_CLANG_BIN, 'clang'))
-CXX = Executable(os.path.join(PREBUILT_CLANG_BIN, 'clang++'))
+CC = os.path.join(PREBUILT_CLANG_BIN, 'clang')
+CXX = os.path.join(PREBUILT_CLANG_BIN, 'clang++')
 
 LLVM_OUT_DIR = os.path.join(WORK_DIR, 'llvm-out')
 V8_OUT_DIR = os.path.join(V8_SRC_DIR, 'out.gn', 'x64.release')
@@ -161,6 +156,9 @@ def IsLinux():
 def IsMac():
   return sys.platform == 'darwin'
 
+
+def Executable(name, extension='.exe'):
+  return name + extension if IsWindows() else name
 
 
 def WindowsFSEscape(path):
@@ -546,9 +544,10 @@ def ChromiumFetchSync(name, work_dir, git_repo,
 def SyncToolchain(name, src_dir, git_repo):
   if IsWindows():
     host_toolchains.SyncWinToolchain()
-  host_toolchains.SyncPrebuiltClang(name, src_dir, git_repo)
-  assert os.path.isfile(CC), 'Expect clang at %s' % CC
-  assert os.path.isfile(CXX), 'Expect clang++ at %s' % CXX
+  else:
+    host_toolchains.SyncPrebuiltClang(name, src_dir, git_repo)
+    assert os.path.isfile(CC), 'Expect clang at %s' % CC
+    assert os.path.isfile(CXX), 'Expect clang++ at %s' % CXX
 
 
 def SyncArchive(out_dir, name, url):
@@ -1241,7 +1240,7 @@ def LibCXX():
              '-DLIBCXX_CXX_ABI=libcxxabi',
              '-DLIBCXX_CXX_ABI_INCLUDE_PATHS=' +
              os.path.join(LIBCXXABI_SRC_DIR, 'include'),
-             '-DLLVM_PATH='+ LLVM_SRC_DIR,
+             '-DLLVM_PATH=' + LLVM_SRC_DIR,
              '-DCMAKE_TOOLCHAIN_FILE=' + CMAKE_TOOLCHAIN_FILE]
 
   proc.check_call(command, cwd=LIBCXX_OUT_DIR, env=cc_env)
@@ -1267,7 +1266,7 @@ def LibCXXABI():
              '-DLIBCXXABI_LIBCXX_PATH=' + LIBCXX_SRC_DIR,
              '-DLIBCXXABI_LIBCXX_INCLUDES=' +
              os.path.join(INSTALL_SYSROOT, 'include', 'c++', 'v1'),
-             '-DLLVM_PATH='+ LLVM_SRC_DIR,
+             '-DLLVM_PATH=' + LLVM_SRC_DIR,
              '-DCMAKE_TOOLCHAIN_FILE=' + CMAKE_TOOLCHAIN_FILE]
 
   proc.check_call(command, cwd=LIBCXXABI_OUT_DIR, env=cc_env)

--- a/src/build.py
+++ b/src/build.py
@@ -1234,8 +1234,6 @@ def LibCXX():
   Mkdir(LIBCXX_OUT_DIR)
   cc_env = BuildEnv(LIBCXX_SRC_DIR, bin_subdir=True)
   command = [PREBUILT_CMAKE_BIN, '-G', 'Ninja', os.path.join(LIBCXX_SRC_DIR),
-             #'-DCMAKE_CXX_COMPILER_WORKS=ON',
-             #'-DCMAKE_C_COMPILER_WORKS=ON',
              '-DCMAKE_EXE_LINKER_FLAGS=-nostdlib++',
              '-DLIBCXX_ENABLE_THREADS=OFF',
              '-DLIBCXX_ENABLE_SHARED=OFF',
@@ -1243,8 +1241,6 @@ def LibCXX():
              '-DLIBCXX_CXX_ABI=libcxxabi',
              '-DLIBCXX_CXX_ABI_INCLUDE_PATHS=' +
              os.path.join(LIBCXXABI_SRC_DIR, 'include'),
-             #'-DLLVM_CONFIG_PATH=' +
-             #Executable(os.path.join(LLVM_OUT_DIR, 'bin', 'llvm-config')) + '',
              '-DLLVM_PATH='+ LLVM_SRC_DIR,
              '-DCMAKE_TOOLCHAIN_FILE=' + CMAKE_TOOLCHAIN_FILE]
 
@@ -1261,15 +1257,9 @@ def LibCXXABI():
   cc_env = BuildEnv(LIBCXXABI_SRC_DIR, bin_subdir=True)
   command = [PREBUILT_CMAKE_BIN, '-G', 'Ninja',
              os.path.join(LIBCXXABI_SRC_DIR),
-             #'-DCMAKE_CXX_COMPILER_WORKS=ON',
-             #'-DCMAKE_C_COMPILER_WORKS=ON',
              '-DCMAKE_EXE_LINKER_FLAGS=-nostdlib++',
              '-DLIBCXXABI_ENABLE_SHARED=OFF',
              '-DLIBCXXABI_ENABLE_THREADS=OFF',
-             # Make HandleLLVMOptions.cmake (it can't check for c++11 support
-             # because no C++ programs can be linked until libc++abi is
-             # installed, so chicken and egg.
-             #'-DCXX_SUPPORTS_CXX11=ON',
              # HandleLLVMOptions.cmake include CheckCompilerVersion.cmake.
              # This checks for working <atomic> header, which in turn errors
              # out on systems with threads disabled
@@ -1277,8 +1267,6 @@ def LibCXXABI():
              '-DLIBCXXABI_LIBCXX_PATH=' + LIBCXX_SRC_DIR,
              '-DLIBCXXABI_LIBCXX_INCLUDES=' +
              os.path.join(INSTALL_SYSROOT, 'include', 'c++', 'v1'),
-             #'-DLLVM_CONFIG_PATH=' +
-             #Executable(os.path.join(LLVM_OUT_DIR, 'bin', 'llvm-config')),
              '-DLLVM_PATH='+ LLVM_SRC_DIR,
              '-DCMAKE_TOOLCHAIN_FILE=' + CMAKE_TOOLCHAIN_FILE]
 

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -43,7 +43,7 @@ def SyncPrebuiltClang(name, src_dir, git_repo):
   proc.check_call(['git', 'fetch'], cwd=tools_clang)
   proc.check_call(['git', 'checkout', 'origin/master'], cwd=tools_clang)
   proc.check_call(
-      [os.path.join(tools_clang, 'scripts', 'update.py')])
+      [sys.executable, os.path.join(tools_clang, 'scripts', 'update.py')])
   return ('chromium-clang', tools_clang)
 
 

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -43,7 +43,7 @@ def SyncPrebuiltClang(name, src_dir, git_repo):
   proc.check_call(['git', 'fetch'], cwd=tools_clang)
   proc.check_call(['git', 'checkout', 'origin/master'], cwd=tools_clang)
   proc.check_call(
-      [sys.executable, os.path.join(tools_clang, 'scripts', 'update.py')])
+      [os.path.join(tools_clang, 'scripts', 'update.py')])
   return ('chromium-clang', tools_clang)
 
 


### PR DESCRIPTION
* Remove forcing of `COMPILER_WORKS` in favor of using `-nostdlib++`
* Use LLVM_PATH instead of LLVM_CONFIG_PATH because the latter doesn't work on windows (something about paths)