### PR TITLE
Update torture test runner for windows

### DIFF
--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -30,7 +30,7 @@ test_filter = None
 
 def do_compile(infile, outfile, extras):
   """Create the command-line for a C compiler invocation."""
-  if os.path.splitext(infile)[1] == '.C':
+  if os.path.splitext(infile)[1] == '.C' or 'g++.dg' in infile: # lol windows
     return [extras['cxx'], infile, '-o', outfile] + extras['cxxflags']
   else:
     return [extras['cc'], infile, '-o', outfile] + extras['cflags']
@@ -105,7 +105,7 @@ def run(cc, cxx, testsuite, sysroot_dir, fails, exclusions, out, config, opt):
     cxx_test_dir = os.path.join(testsuite, 'g++.dg')
     assert os.path.isdir(cxx_test_dir), ('Cannot find C++ tests at %s' %
                                          cxx_test_dir)
-    test_files += find_runnable_tests(cxx_test_dir, '*.C')
+    test_files += find_runnable_tests(cxx_test_dir, '*.[Cc]')
 
   cflags = cflags_common + cflags_c + cflags_extra[config]
   cxxflags = cflags_common + cflags_cxx + cflags_extra[config]

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -30,7 +30,7 @@ test_filter = None
 
 def do_compile(infile, outfile, extras):
   """Create the command-line for a C compiler invocation."""
-  if os.path.splitext(infile)[1] == '.C' or 'g++.dg' in infile: # lol windows
+  if os.path.splitext(infile)[1] == '.C' or 'g++.dg' in infile:  # lol windows
     return [extras['cxx'], infile, '-o', outfile] + extras['cxxflags']
   else:
     return [extras['cc'], infile, '-o', outfile] + extras['cflags']


### PR DESCRIPTION
Run all .C and .c files from the g++ torture test directory, because there it
contains both (so previously we were not testing the .c files) and Windows
can't tell the difference.

Also check whether the path contains the g++ torture test directory when
deciding whether to use clang or clang++ because Windows can't tell the
difference.