### PR TITLE
Remove WASM=1 flag not that its the default

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1382,9 +1382,9 @@ def CompileLLVMTortureBinaryen(name, em_config, outdir, fails, opt, lld):
   Remove(outdir)
   Mkdir(outdir)
   if lld:
-    config = 'binaryen-lld'
+    config = 'emscripten-lld'
   else:
-    config = 'binaryen'
+    config = 'emscripten'
   try:
     if not lld:
       os.environ['EMCC_EXPERIMENTAL_USE_LLD'] = '0'

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -77,14 +77,14 @@ def run(cc, cxx, testsuite, sysroot_dir, fails, exclusions, out, config, opt):
       'wasm-s': ['--target=wasm32-unknown-unknown-elf', '-S',
                  '--sysroot=%s' % sysroot_dir],
       'wasm-o': ['-c', '--sysroot=%s' % sysroot_dir],
-      'binaryen': ['-s', 'WASM=1', '--pre-js', pre_js],
-      'binaryen-lld': ['-s', 'WASM=1', '--pre-js', pre_js],
+      'emscripten': ['--pre-js', pre_js],
+      'emscripten-lld': ['--pre-js', pre_js],
   }
   suffix = {
       'wasm-o': '.o',
       'wasm-s': '.s',
-      'binaryen': '.js',
-      'binaryen-lld': '.js',
+      'emscripten': '.js',
+      'emscripten-lld': '.js',
   }[config]
 
   assert os.path.isdir(out), 'Cannot find outdir %s' % out

--- a/src/test/emwasm_compile_known_gcc_test_failures.txt
+++ b/src/test/emwasm_compile_known_gcc_test_failures.txt
@@ -83,6 +83,6 @@
 
 # Only fails at link time in lld, due to the fact that s2wasm infers the
 # types of the missing builtin functions from the call sites but lld doesn't
-builtin-bitops-1.c binaryen-lld,O3 # __builtin_clrsb
-va-arg-pack-1.c binaryen-lld # __builtin_va_arg_pack
-pr39228.c binaryen-lld,O3 # __builtin_isinff
+builtin-bitops-1.c emscripten-lld,O3 # __builtin_clrsb
+va-arg-pack-1.c emscripten-lld # __builtin_va_arg_pack
+pr39228.c emscripten-lld,O3 # __builtin_isinff


### PR DESCRIPTION
Also, rename the binaryen/binaryen-lld to emscripten/emscripten-lld
to more accurately reflect the meaning of these configurations.