### PR TITLE
Add validate of llvm object files

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -245,6 +245,8 @@ SPEC_KNOWN_TORTURE_FAILURES = [os.path.join(SCRIPT_DIR, 'test',
                                             'spec_' + IT_IS_KNOWN)]
 LLD_KNOWN_TORTURE_FAILURES = [os.path.join(SCRIPT_DIR, 'test',
                               'lld_' + IT_IS_KNOWN)]
+VALIDATE_KNOWN_TORTURE_FAILURES = [os.path.join(SCRIPT_DIR, 'test', 
+                                   'validate_' + IT_IS_KNOWN)]
 
 # Exclusions (known failures are compiled and run, and expected to fail,
 # whereas exclusions are not even run, e.g. because they have UB which
@@ -1433,6 +1435,12 @@ def ExecuteLLVMTorture(name, runner, indir, fails, attributes, extension, opt,
     buildbot.FailUnless(lambda: warn_only)
 
 
+def ValidateLLVMTorture(indir, ext, opt):
+  validate = os.path.join(INSTALL_BIN, 'wasm-validate')
+  ExecuteLLVMTorture('validate', validate, indir,
+          VALIDATE_KNOWN_TORTURE_FAILURES, [], ext, opt)
+
+
 class Build(object):
   def __init__(self, name_, runnable_,
                no_windows=False, no_linux=False,
@@ -1545,6 +1553,7 @@ def TestBare():
   # Compile
   for opt in BARE_TEST_OPT_FLAGS:
     CompileLLVMTorture(GetTortureDir('o', opt), opt)
+    ValidateLLVMTorture(GetTortureDir('o', opt), 'o', opt)
 
   # Link/Assemble
   for opt in BARE_TEST_OPT_FLAGS:

--- a/src/build.py
+++ b/src/build.py
@@ -245,7 +245,7 @@ SPEC_KNOWN_TORTURE_FAILURES = [os.path.join(SCRIPT_DIR, 'test',
                                             'spec_' + IT_IS_KNOWN)]
 LLD_KNOWN_TORTURE_FAILURES = [os.path.join(SCRIPT_DIR, 'test',
                               'lld_' + IT_IS_KNOWN)]
-VALIDATE_KNOWN_TORTURE_FAILURES = [os.path.join(SCRIPT_DIR, 'test', 
+VALIDATE_KNOWN_TORTURE_FAILURES = [os.path.join(SCRIPT_DIR, 'test',
                                    'validate_' + IT_IS_KNOWN)]
 
 # Exclusions (known failures are compiled and run, and expected to fail,
@@ -1438,7 +1438,7 @@ def ExecuteLLVMTorture(name, runner, indir, fails, attributes, extension, opt,
 def ValidateLLVMTorture(indir, ext, opt):
   validate = os.path.join(INSTALL_BIN, 'wasm-validate')
   ExecuteLLVMTorture('validate', validate, indir,
-          VALIDATE_KNOWN_TORTURE_FAILURES, [], ext, opt)
+                     VALIDATE_KNOWN_TORTURE_FAILURES, [], ext, opt)
 
 
 class Build(object):

--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -53,7 +53,8 @@ def execute(infile, outfile, extras):
           '--', infile] + extra_files,
       'jsc-asm2wasm': [runner, '--useWebAssembly=1', infile],
       'wasm': [runner, infile],
-      'node': [runner] + wasmjs + [infile] + extra_files
+      'node': [runner] + wasmjs + [infile] + extra_files,
+      'wasm-validate': [runner, '--enable-mutable-globals', infile],
   }
   return commands[config]
 

--- a/src/test/validate_known_gcc_test_failures.txt
+++ b/src/test/validate_known_gcc_test_failures.txt
@@ -1,0 +1,12 @@
+# Expected validation failures in output of llvm backend.
+# Failure here means that llvm is producing bad wasm. This should never happen :(
+
+# error: type mismatch in call
+builtin-bitops-1.c.o
+pr39228.c.o
+pr44942.c.o
+pr47237.c.o
+pr58419.c.o
+
+# error: type mismatch in i32.store
+va-arg-pack-1.c.o


### PR DESCRIPTION
The object files produced by llvm should be valid wasm files
so its good to test this too.