### PR TITLE
Update expections now that LTO warnings are error in emscripten

### DIFF
--- a/src/test/emwasm_compile_known_gcc_test_failures.txt
+++ b/src/test/emwasm_compile_known_gcc_test_failures.txt
@@ -78,3 +78,7 @@
 builtin-bitops-1.c emscripten,O3 # __builtin_clrsb
 va-arg-pack-1.c emscripten # __builtin_va_arg_pack
 pr39228.c emscripten,O3 # __builtin_isinff
+
+# WebAssembly hasn't implemented (will never?) __builtin_return_address
+20030323-1.c emscripten
+20030811-1.c emscripten


### PR DESCRIPTION
Previously the codegen failure on __builtin_return_address was
being treated as an error (erroneously).