### PR TITLE
Add 2 emwasm compile XFAILS

### DIFF
--- a/src/test/emwasm_compile_known_gcc_test_failures.txt
+++ b/src/test/emwasm_compile_known_gcc_test_failures.txt
@@ -67,10 +67,10 @@
 
 # Works with asm2wasm
 	20030913-1.c # glob multiply defined in wasm but not asm2wasm
-        960218-1.c # glob multiply defined in wasm but not asm2wasm
+	960218-1.c # glob multiply defined in wasm but not asm2wasm
 	pr17377.c # __builtin_return_address
-        20030323-1.c # __builtin_return_address
-        20030811-1.c # __builtin_return_address
+	20030323-1.c # __builtin_return_address
+	20030811-1.c # __builtin_return_address
 
 # Untriaged
 	pr56982.c O3

--- a/src/test/emwasm_compile_known_gcc_test_failures.txt
+++ b/src/test/emwasm_compile_known_gcc_test_failures.txt
@@ -69,6 +69,8 @@
 	20030913-1.c # glob multiply defined in wasm but not asm2wasm
         960218-1.c # glob multiply defined in wasm but not asm2wasm
 	pr17377.c # __builtin_return_address
+        20030323-1.c # __builtin_return_address
+        20030811-1.c # __builtin_return_address
 
 # Untriaged
 	pr56982.c O3


### PR DESCRIPTION
Wasm backend has never supported __builtin_return_address; presumably the tests only worked before due to something optimizing them away.