### PR TITLE
Remove pr30778.c from list of known spec failures

### DIFF
--- a/src/test/spec_known_gcc_test_failures.txt
+++ b/src/test/spec_known_gcc_test_failures.txt
@@ -101,7 +101,6 @@ pr15262-1.c.o.wasm O0 # env.malloc
 pr20621-1.c.o.wasm O0 # env.memcpy
 pr22061-1.c.o.wasm O0 # env.memset
 pr23135.c.o.wasm O0 # env.memcpy
-pr30778.c.o.wasm O0 # env.memset
 pr33142.c.o.wasm O0 # env.abs
 pr33870-1.c.o.wasm # env.memset
 pr33870.c.o.wasm # env.memset


### PR DESCRIPTION
Seems that the O0 build no longer depends on memset.