### PR TITLE
Don't pass `--enable-mutable-globals` flag

### DIFF
--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -54,7 +54,7 @@ def execute(infile, outfile, extras):
       'jsc-asm2wasm': [runner, '--useWebAssembly=1', infile],
       'wasm': [runner, infile],
       'node': [runner] + wasmjs + [infile] + extra_files,
-      'wasm-validate': [runner, '--enable-mutable-globals', infile],
+      'wasm-validate': [runner, infile],
   }
   return commands[config]
 


### PR DESCRIPTION
Import/export of mutable globals is now the default behavior, so the
flag to enable it has been removed.

See https://github.com/WebAssembly/wabt/pull/884