### PR TITLE
builtin-bitops-1.c is now passing due to LLVM change

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -48,7 +48,6 @@
 # See wasm.js for the list of libc functions which are missing.
 # The right place to put libc functionality would really be libc anyways.
 20101011-1.c.js # signal
-builtin-bitops-1.c.js # __builtin_clrsb
 pr47237.c.js # __builtin_apply_args
 pr39228.c.js #  __builtin_isinff/isinfl
 
@@ -177,7 +176,6 @@ vprintf-chk-1.c.js O3
 pr56982.c.o.wasm
 struct-ret-1.c.o.wasm
 930513-1.c.o.wasm
-builtin-bitops-1.c.o.wasm
 pr39228.c.o.wasm
 pr47237.c.o.wasm
 

--- a/src/test/spec_known_gcc_test_failures.txt
+++ b/src/test/spec_known_gcc_test_failures.txt
@@ -81,7 +81,6 @@
 990628-1.c.o.wasm # env.memset
 991112-1.c.o.wasm # env.isprint
 align-2.c.o.wasm # env.__eqtf2
-builtin-bitops-1.c.o.wasm # env.__builtin_clrsb
 complex-5.c.o.wasm # env.__divsc3
 complex-6.c.o.wasm O0 # env.__subtf3
 complex-7.c.o.wasm # env.__netf2


### PR DESCRIPTION
See: https://reviews.llvm.org/D50471