### PR TITLE
Try again to update the expectaions for builtin-bitops-1.c.js

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -48,7 +48,7 @@
 # See wasm.js for the list of libc functions which are missing.
 # The right place to put libc functionality would really be libc anyways.
 20101011-1.c.js # signal
-builtin-bitops-1.c.js # __builtin_clrsb
+builtin-bitops-1.c.js asm2wasm # __builtin_clrsb
 pr47237.c.js # __builtin_apply_args
 pr39228.c.js #  __builtin_isinff/isinfl
 


### PR DESCRIPTION
This should only fail under fastcomp (asm2wasm).  A little embarrassed that this took 3 changes
to fix.