### PR TITLE
Build the native asmjs optimizer in a separate step

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1125,7 +1125,6 @@ def Emscripten():
                   # Ignore the big git blob so it doesn't get archived.
                   ignore=shutil.ignore_patterns('.git'))
 
-
   # Manually build the native asm.js optimizer (the cmake build in embuilder
   # doesn't work on the waterfall)
   optimizer_out_dir = os.path.join(WORK_DIR, 'em-optimizer-out')

--- a/src/build.py
+++ b/src/build.py
@@ -1117,16 +1117,17 @@ def Emscripten():
   # rebuilt in the step below.
   Remove(os.path.expanduser(os.path.join('~', '.emscripten_cache')))
   emscripten_dir = os.path.join(INSTALL_DIR, 'emscripten')
-  #Remove(emscripten_dir)
+  Remove(emscripten_dir)
   print 'Copying directory %s to %s' % (EMSCRIPTEN_SRC_DIR, emscripten_dir)
-  #shutil.copytree(EMSCRIPTEN_SRC_DIR,
-  #                emscripten_dir,
-  #                symlinks=True,
-  #                # Ignore the big git blob so it doesn't get archived.
-  #                ignore=shutil.ignore_patterns('.git'))
+  shutil.copytree(EMSCRIPTEN_SRC_DIR,
+                  emscripten_dir,
+                  symlinks=True,
+                  # Ignore the big git blob so it doesn't get archived.
+                  ignore=shutil.ignore_patterns('.git'))
 
 
-  # Manually build the emscripten optimizer
+  # Manually build the native asm.js optimizer (the cmake build in embuilder
+  # doesn't work on the waterfall)
   optimizer_out_dir = os.path.join(WORK_DIR, 'em-optimizer-out')
   Mkdir(optimizer_out_dir)
   cc_env = BuildEnv(optimizer_out_dir)
@@ -1138,7 +1139,7 @@ def Emscripten():
   proc.check_call(['ninja'] + host_toolchains.NinjaJobs(),
                   cwd=optimizer_out_dir, env=cc_env)
   CopyBinaryToArchive(Executable(os.path.join(optimizer_out_dir, 'optimizer')))
-  
+
   def WriteEmscriptenConfig(infile, outfile):
     with open(infile) as config:
       text = config.read().replace('{{WASM_INSTALL}}',

--- a/src/emscripten_config
+++ b/src/emscripten_config
@@ -17,7 +17,7 @@ BINARYEN_ROOT = os.path.join(WASM_INSTALL) # directory
 
 # Add this if you have manually built the JS optimizer executable (in Emscripten/tools/optimizer) and want to run it from a custom location.
 # Alternatively, you can set this as the environment variable EMSCRIPTEN_NATIVE_OPTIMIZER.
-# EMSCRIPTEN_NATIVE_OPTIMIZER='/path/to/custom/optimizer(.exe)'
+EMSCRIPTEN_NATIVE_OPTIMIZER=os.path.join(WASM_INSTALL, 'bin', 'optimizer')
 
 # See below for notes on which JS engine(s) you need
 prebuilt_node = '{{PREBUILT_NODE}}'


### PR DESCRIPTION
The way embuilder builds the native optimizer with cmake doesn't work on the waterfall on Windows; and in any case it's better to force the optimizer binary anyway, to avoid building it on-demand.