### PR TITLE
Use gclient-managed hermetic mac toolchain on mac bots

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -288,6 +288,15 @@ if IsMac() and IsBuildbot():
   flags = fcntl(fd, F_GETFL)
   fcntl(fd, F_SETFL, flags & ~os.O_NONBLOCK)
 
+  # Use gclient-managed hermetic toolchain on mac LUCI bots.
+  # TODO: Convert bot build to recipes, and this should no longer be necessary.
+  # Force gclient to install the hermetic mac toolchain
+  os.environ['FORCE_MAC_TOOLCHAIN'] = 1
+  # The V8 build_overrides/build.gni specifically forces use of the system
+  # Xcode, so override the override.
+  os.environ['DEVELOPER_DIR'] = os.path.join(V8_SRC_DIR,
+                                             'build', 'mac_files', 'Xcode.app')
+
 # Pin the GCC revision so that new torture tests don't break the bot. This
 # should be manually updated when convenient.
 GCC_REVISION = 'b6125c702850488ac3bfb1079ae5c9db89989406'


### PR DESCRIPTION
Experimental fix to bring up the mac LUCI bot