### PR TITLE
Add Windows XFAIL and optlevel attribute during torture run

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1583,7 +1583,7 @@ def TestBare():
         runner=D8_BIN,
         indir=GetTortureDir('lld', opt),
         fails=RUN_KNOWN_TORTURE_FAILURES,
-        attributes=common_attrs + ['d8', 'lld'],
+        attributes=common_attrs + ['d8', 'lld', opt],
         extension='wasm',
         opt=opt,
         wasmjs=os.path.join(INSTALL_LIB, 'wasm.js'))

--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -214,6 +214,12 @@ vfprintf-chk-1.c.o.wasm O2
 # Missing _Unwind_* functions
 cleanup-5.C.o.wasm
 
+# https://bugs.chromium.org/p/v8/issues/detail?id=8211
+20040629-1.c.o.wasm win,O0
+20040705-1.c.o.wasm win,O0
+20040705-2.c.o.wasm win,O0
+pr53645-2.c.o.wasm win,O0
+
 # Untriaged lld failures
 tc1__dr20.C.o.wasm O2
 torture__pr48695.C.o.wasm O2


### PR DESCRIPTION
Same as #411 but pass the optlevel as an attribute to allow distinguishing between optlevels in the exclusion file.