### PR TITLE
Remove two known failures from spec_known_gcc_test_failures.txt

### DIFF
--- a/src/test/spec_known_gcc_test_failures.txt
+++ b/src/test/spec_known_gcc_test_failures.txt
@@ -239,12 +239,12 @@ init__delete2.C.o.wasm
 init__dtor3.C.o.wasm
 init__for1.C.o.wasm
 init__init-ref2.C.o.wasm
-init__new11.C.o.wasm
+init__new11.C.o.wasm O0
 init__new26.C.o.wasm
 init__new36.C.o.wasm
 init__placement2.C.o.wasm
 init__ref9.C.o.wasm
-init__value3.C.o.wasm
+init__value3.C.o.wasm O0
 ipa__pr46287-1.C.o.wasm
 ipa__pr46287-2.C.o.wasm
 ipa__pr46287-3.C.o.wasm


### PR DESCRIPTION
Since the default for lld changed to --no-export-dynamic we
not longer export -fvisibility=default symbols.  These two
tests started passing because in the O2 case the operator new
is no longer included in the link.

It seems that operator new always visibility=default so is one
of the few symbols used in the torture tests that is effected.