### PR TITLE
Flush stdout after multiprocessing pool join

### DIFF
--- a/src/testing.py
+++ b/src/testing.py
@@ -236,6 +236,7 @@ def execute(tester, inputs, fails, exclusions=None, attributes=None):
     results = pool.map(tester, inputs)
     pool.close()
     pool.join()
+    sys.stdout.flush()
   sys.stdout.write('\nDone.')
 
   results = sorted(results)


### PR DESCRIPTION
Mac bot builds currently always fail with EAGAIN on stdout.write calls on line
247 below. One possible explanation might be a full buffer somewhere underneath,
so try flushing stdout after joining the pool and before trying to write
anything else.