### PR TITLE
Make experimental mac bot fix unconditional

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -283,7 +283,7 @@ def IsBuildbot():
   return BUILDBOT_BUILDNUMBER is not None
 
 
-if IsMac() and IsBuildbot():
+if IsMac():
   # Experimental temp fix for crbug.com/829034 stdout write sometimes fails
   from fcntl import fcntl, F_GETFL, F_SETFL
   fd = sys.stdout.fileno()


### PR DESCRIPTION
BUILDBOT_BUILDNUMBER isn't set in LUCI builds.