### PR TITLE
Remove expected failures due to __builtin_constant_p

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -190,8 +190,6 @@ va-arg-6.c.o.wasm
 # Don't care/won't fix:
 920612-1.c.o.wasm O2 # abort() # UB
 920711-1.c.o.wasm O2 # abort() # UB for 32-bit longs
-bcp-1.c.o.wasm O2 # abort() # builtin_constant_p depends on opt setting
-builtin-constant.c.o.wasm O2 # abort() # builtin_constant_p depends on opt setting
 pr22493-1.c.o.wasm O2 # abort() # UB
 eeprof-1.c.o.wasm # tests -finstrument-functions
 pr23047.c.o.wasm O2 # tests -fwrapv


### PR DESCRIPTION
I seems that references to this symbol are not longer present
in clangs -O2, so these tests now pass.