### PR TITLE
Third attempt to remove expected failures due to __builtin_constant_p

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -161,6 +161,8 @@ pr60960.c.js asm2wasm # actually fails in asm2wasm, but JS file is still there
 920612-1.c.js O3
 920711-1.c.js O3
 990208-1.c.js O3
+bcp-1.c.js asm2wasm,O3
+builtin-constant.c.js asm2wasm,O3
 fprintf-chk-1.c.js O3
 pr22493-1.c.js O3
 printf-chk-1.c.js O3


### PR DESCRIPTION
These are still present in asm2wasm path.