### PR TITLE
Update test expectations

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -161,8 +161,8 @@ pr60960.c.js asm2wasm # actually fails in asm2wasm, but JS file is still there
 920612-1.c.js O3
 920711-1.c.js O3
 990208-1.c.js O3
-bcp-1.c.js O3
-builtin-constant.c.js O3
+bcp-1.c.js asm2wasm,O3
+builtin-constant.c.js asm2wasm,O3
 fprintf-chk-1.c.js O3
 pr22493-1.c.js O3
 printf-chk-1.c.js O3
@@ -190,8 +190,6 @@ va-arg-6.c.o.wasm
 # Don't care/won't fix:
 920612-1.c.o.wasm O2 # abort() # UB
 920711-1.c.o.wasm O2 # abort() # UB for 32-bit longs
-bcp-1.c.o.wasm O2 # abort() # builtin_constant_p depends on opt setting
-builtin-constant.c.o.wasm O2 # abort() # builtin_constant_p depends on opt setting
 pr22493-1.c.o.wasm O2 # abort() # UB
 eeprof-1.c.o.wasm # tests -finstrument-functions
 pr23047.c.o.wasm O2 # tests -fwrapv
@@ -322,3 +320,4 @@ torture__stackalign__throw-1.C.o.wasm
 torture__stackalign__throw-2.C.o.wasm
 torture__stackalign__throw-3.C.o.wasm
 tree-ssa__pr33604.C.o.wasm
+opt__pr15551.C.o.wasm


### PR DESCRIPTION
For opt__pr15551.C it looks like the call to operator new is no
longer elided.