### PR TITLE
When using proc.Which to find a python script on windows, don't append suffixes

### DIFF
--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -33,7 +33,7 @@ WIN_TOOLCHAIN_JSON = os.path.join(V8_SRC_DIR, 'build', 'win_toolchain.json')
 
 # TODO(sbc): Remove this once upstream llvm is fixed rolled into chrome.
 # See: https://bugs.llvm.org/show_bug.cgi?id=38165
-PREBUILD_CLANG_REVISION = 'f6641a3f5eeda23fbc80c9996dce8b576e99c000'
+PREBUILD_CLANG_REVISION = 'ebf0d4a36bb989c366e78a4c20564cd4656197e6'
 
 
 def SyncPrebuiltClang(name, src_dir, git_repo):

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -33,7 +33,7 @@ WIN_TOOLCHAIN_JSON = os.path.join(V8_SRC_DIR, 'build', 'win_toolchain.json')
 
 # TODO(sbc): Remove this once upstream llvm is fixed rolled into chrome.
 # See: https://bugs.llvm.org/show_bug.cgi?id=38165
-PREBUILD_CLANG_REVISION = 'ebf0d4a36bb989c366e78a4c20564cd4656197e6'
+PREBUILD_CLANG_REVISION = 'f6641a3f5eeda23fbc80c9996dce8b576e99c000'
 
 
 def SyncPrebuiltClang(name, src_dir, git_repo):

--- a/src/proc.py
+++ b/src/proc.py
@@ -29,20 +29,20 @@ import sys
 from subprocess import * # flake8: noqa
 
 
-def Which(filename, cwd, require_executable=True):
+def Which(filename, cwd, is_executable=True):
   if os.path.isabs(filename):
     return filename
 
   to_search = [cwd] + os.environ.get('PATH', '').split(os.pathsep)
   exe_suffixes = ['']
-  if sys.platform == 'win32':
+  if sys.platform == 'win32' and is_executable:
     exe_suffixes = ['.exe', '.bat'] + exe_suffixes
   for path in to_search:
     abs_path = os.path.abspath(os.path.join(path, filename))
     for suffix in exe_suffixes:
       full_path = abs_path + suffix
       if (os.path.isfile(full_path) and
-          (not require_executable or os.access(full_path, os.X_OK))):
+          (not is_executable or os.access(full_path, os.X_OK))):
         return full_path
   raise Exception('File "%s" not found. (cwd=`%s`, PATH=`%s`' %
                   (filename, cwd, os.environ['PATH']))
@@ -51,7 +51,7 @@ def Which(filename, cwd, require_executable=True):
 def SpecialCases(cmd, cwd):
   exe = cmd[0]
   if exe.endswith('.py'):
-    script = Which(exe, cwd, require_executable=False)
+    script = Which(exe, cwd, is_executable=False)
     return [sys.executable, script] + cmd[1:]
   if exe == 'git' or exe == 'gclient':
     return [Which(exe, cwd)] + cmd[1:]


### PR DESCRIPTION
Appending exe/bat suffixes only makes sense when we are looking for a real
executable instead of a script. Despite this fact depot_tools apparently now
includes gsutil.py.bat which turned the previous nonsensical-but-harmless
behavior into broken behavior.