### PR TITLE
Revert "Print fcntl flags on each tester preexec"

### DIFF
--- a/src/testing.py
+++ b/src/testing.py
@@ -72,14 +72,8 @@ class Tester(object):
     try:
       import resource
       resource.setrlimit(resource.RLIMIT_CPU, (90, 90))
-      from fcntl import fcntl, F_GETFL, F_SETFL
-      fd = sys.stdout.fileno()
-      flags = fcntl(fd, F_GETFL)
-      print >> sys.stderr, 'Flags: %s, nonblock: %s' % (hex(flags),
-                                                        flags & os.O_NONBLOCK)
-      fcntl(fd, F_SETFL, flags & ~os.O_NONBLOCK)
     except:
-      raise
+      pass
 
   def __call__(self, test_file):
     """Execute a single test."""


### PR DESCRIPTION
Reverts WebAssembly/waterfall#437