### PR TITLE
Replace multiprocessing pool with custom parallel test runner in testing.py

### DIFF
--- a/src/parallel_runner.py
+++ b/src/parallel_runner.py
@@ -1,3 +1,19 @@
+#! /usr/bin/env python
+
+#   Copyright 2018 WebAssembly Community Group participants
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 import multiprocessing
 import Queue
 import sys
@@ -19,7 +35,7 @@ class ParallelRunner(object):
     self.processes = None
     self.result_queue = None
 
-  def run(self, test_function, inputs):
+  def map(self, test_function, inputs):
     test_queue = self.create_test_queue(inputs)
     self.init_processes(test_function, test_queue)
     results = self.collect_results()
@@ -43,9 +59,14 @@ class ParallelRunner(object):
 
   def collect_results(self):
     buffered_results = []
+    num = 0
     while len(self.processes):
       res = get_from_queue(self.result_queue)
       if res is not None:
+        num += 1
+        # Print periodically to assure the bot monitor that we are still alive
+        if num % 10 == 0:
+          print 'Got result', num
         buffered_results.append(res)
       else:
         self.clear_finished_processes()

--- a/src/parallel_runner.py
+++ b/src/parallel_runner.py
@@ -34,10 +34,10 @@ class ParallelRunner(object):
   def init_processes(self, test_function, test_queue):
     self.processes = []
     self.result_queue = multiprocessing.Queue()
-    #self.dedicated_temp_dirs = [tempfile.mkdtemp() for x in range(num_cores())]
-    for x in range(16 or multiprocessing.cpu_count()):
-      p = multiprocessing.Process(target=g_testing_thread,
-                                  args=(test_function, test_queue, self.result_queue))
+    for x in range(multiprocessing.cpu_count()):
+      p = multiprocessing.Process(
+          target=g_testing_thread,
+          args=(test_function, test_queue, self.result_queue))
       p.start()
       self.processes.append(p)
 
@@ -54,16 +54,6 @@ class ParallelRunner(object):
   def clear_finished_processes(self):
     self.processes = [p for p in self.processes if p.is_alive()]
 
-  def combine_results(self, result, buffered_results):
-    print()
-    print('DONE: combining results on main thread')
-    print()
-    # Sort the results back into alphabetical order. Running the tests in
-    # parallel causes mis-orderings, this makes the results more readable.
-    results = sorted(buffered_results, key=lambda res: str(res.test))
-    for r in results:
-      r.updateResult(result)
-    return result
 
 def get_from_queue(q):
   try:

--- a/src/parallel_runner.py
+++ b/src/parallel_runner.py
@@ -1,0 +1,73 @@
+import multiprocessing
+import Queue
+import sys
+
+
+def g_testing_thread(test_function, work_queue, result_queue):
+  for test in iter(lambda: get_from_queue(work_queue), None):
+    result = None
+    try:
+      result = test_function(test)
+    except Exception as e:
+      print >> sys.stderr, "Something went wrong", e
+      raise
+    result_queue.put(result)
+
+
+class ParallelRunner(object):
+  def __init__(self):
+    self.processes = None
+    self.result_queue = None
+
+  def run(self, test_function, inputs):
+    test_queue = self.create_test_queue(inputs)
+    self.init_processes(test_function, test_queue)
+    results = self.collect_results()
+    return results
+
+  def create_test_queue(self, inputs):
+    test_queue = multiprocessing.Queue()
+    for test in inputs:
+      test_queue.put(test)
+    return test_queue
+
+  def init_processes(self, test_function, test_queue):
+    self.processes = []
+    self.result_queue = multiprocessing.Queue()
+    #self.dedicated_temp_dirs = [tempfile.mkdtemp() for x in range(num_cores())]
+    for x in range(16 or multiprocessing.cpu_count()):
+      p = multiprocessing.Process(target=g_testing_thread,
+                                  args=(test_function, test_queue, self.result_queue))
+      p.start()
+      self.processes.append(p)
+
+  def collect_results(self):
+    buffered_results = []
+    while len(self.processes):
+      res = get_from_queue(self.result_queue)
+      if res is not None:
+        buffered_results.append(res)
+      else:
+        self.clear_finished_processes()
+    return buffered_results
+
+  def clear_finished_processes(self):
+    self.processes = [p for p in self.processes if p.is_alive()]
+
+  def combine_results(self, result, buffered_results):
+    print()
+    print('DONE: combining results on main thread')
+    print()
+    # Sort the results back into alphabetical order. Running the tests in
+    # parallel causes mis-orderings, this makes the results more readable.
+    results = sorted(buffered_results, key=lambda res: str(res.test))
+    for r in results:
+      r.updateResult(result)
+    return result
+
+def get_from_queue(q):
+  try:
+    return q.get(True, 0.1)
+  except Queue.Empty:
+    pass
+  return None

--- a/src/testing.py
+++ b/src/testing.py
@@ -89,8 +89,6 @@ class Tester(object):
           # preexec_fn is not supported on Windows
           preexec_fn=Tester.setlimits if sys.platform != 'win32' else None,
           should_log=False)
-      # Flush the logged command so buildbots don't think the script is dead.
-      #sys.stdout.flush()
       return Result(test=basename, success=True, output=output)
     except proc.CalledProcessError as e:
       return Result(test=basename, success=False, output=e.output)

--- a/src/testing.py
+++ b/src/testing.py
@@ -87,7 +87,8 @@ class Tester(object):
           self.command_ctor(test_file, outfile, self.extras),
           stderr=proc.STDOUT, cwd=self.outdir or os.getcwd(),
           # preexec_fn is not supported on Windows
-          preexec_fn=Tester.setlimits if sys.platform != 'win32' else None)
+          preexec_fn=Tester.setlimits if sys.platform != 'win32' else None,
+          should_log=False)
       # Flush the logged command so buildbots don't think the script is dead.
       #sys.stdout.flush()
       return Result(test=basename, success=True, output=output)
@@ -233,7 +234,7 @@ def execute(tester, inputs, fails, exclusions=None, attributes=None):
     results = map(tester, inputs)
   else:
     runner = parallel_runner.ParallelRunner()
-    results = runner.run(tester, inputs)
+    results = runner.map(tester, inputs)
 
     sys.stdout.flush()
   sys.stdout.write('\nDone.')

--- a/src/testing.py
+++ b/src/testing.py
@@ -16,11 +16,11 @@
 
 import difflib
 import math
-import multiprocessing
 import os
 import os.path
 import sys
 
+import parallel_runner
 import proc
 
 # Set to True to disable execution via thread pool
@@ -89,7 +89,7 @@ class Tester(object):
           # preexec_fn is not supported on Windows
           preexec_fn=Tester.setlimits if sys.platform != 'win32' else None)
       # Flush the logged command so buildbots don't think the script is dead.
-      sys.stdout.flush()
+      #sys.stdout.flush()
       return Result(test=basename, success=True, output=output)
     except proc.CalledProcessError as e:
       return Result(test=basename, success=False, output=e.output)
@@ -232,10 +232,9 @@ def execute(tester, inputs, fails, exclusions=None, attributes=None):
   if single_threaded:
     results = map(tester, inputs)
   else:
-    pool = multiprocessing.Pool(maxtasksperchild=32)
-    results = pool.map(tester, inputs)
-    pool.close()
-    pool.join()
+    runner = parallel_runner.ParallelRunner()
+    results = runner.run(tester, inputs)
+
     sys.stdout.flush()
   sys.stdout.write('\nDone.')
 


### PR DESCRIPTION
This avoids printing to stdout from the subprocesses, in hopes of working around the EAGAIN errors on mac.