### PR TITLE
Remove frame-address.c from expected failures

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -123,8 +123,6 @@ pr49279.c.js asm2wasm
 # aborts in native clang
 20031003-1.c.js O0 # abort() in emwasm
 
-frame-address.c.js emwasm,lld,O3
-
 # hoisting of conditional cast causing wasm float->int conversion trap
 # https://github.com/WebAssembly/binaryen/issues/983
 20040831-1.c.js asm2wasm,O0
@@ -203,7 +201,6 @@ template__new11.C.o.wasm O2
 # abort()
 20101011-1.c.o.wasm
 30101025-1.c.o.wasm
-frame-address.c.o.wasm O2
 3r39339.c.o.wasm
 
 fprintf-chk-1.c.o.wasm O2


### PR DESCRIPTION
It used to fail when any optimization flag was on and the reason was
RegStackify's stack pointer store check was incorrect. This test is now
passing after the LLVM fix (https://reviews.llvm.org/rL350906).

In detail: In `check_fa_mid`, the original code order was
```
  ...
  i32.call  check_fa_work@FUNCTION
  global.set  __stack_pointer@GLOBAL
  ...
```

But the previous code incorrectly reordered the call to `check_fa_work`
after `global.set` while stackifying registers. `check_fa_work` has
`global.get  __stack_pointer@GLOBAL` instruction itself, resulting in
loading an incorrect value.