### PR TITLE
Use emscripten from github

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -114,7 +114,7 @@ GIT_MIRROR_BASE = 'https://chromium.googlesource.com/'
 LLVM_MIRROR_BASE = 'https://llvm.googlesource.com/'
 GITHUB_MIRROR_BASE = GIT_MIRROR_BASE + 'external/github.com/'
 WASM_GIT_BASE = GITHUB_MIRROR_BASE + 'WebAssembly/'
-EMSCRIPTEN_GIT_BASE = GITHUB_MIRROR_BASE + 'emscripten-core/'
+EMSCRIPTEN_GIT_BASE = 'https://github.com/emscripten-core/'
 MUSL_GIT_BASE = 'https://github.com/jfbastien/'
 OCAML_GIT_BASE = 'https://github.com/ocaml/'
 


### PR DESCRIPTION
Followup for #448 - use emscripten repos from github directly. Hopefully will fix https://github.com/WebAssembly/waterfall/pull/448#issuecomment-456619724 

However, I'm not sure why we used chromium.googlesource instead of github?