### PR TITLE
Set max concurrent triggering invocations to 4

### DIFF
--- a/luci-scheduler.cfg
+++ b/luci-scheduler.cfg
@@ -37,6 +37,10 @@ job {
   id: "linux"
   acl_sets: "default"
   schedule: "triggered"
+  triggering_policy: {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 4
+  }
   buildbucket: {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.wasm.ci"
@@ -48,6 +52,10 @@ job {
   id: "windows"
   acl_sets: "default"
   schedule: "triggered"
+  triggering_policy: {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 4
+  }
   buildbucket: {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.wasm.ci"
@@ -59,6 +67,10 @@ job {
   id: "mac"
   acl_sets: "default"
   schedule: "triggered"
+  triggering_policy: {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 4
+  }
   buildbucket: {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.wasm.ci"


### PR DESCRIPTION
4 is the current number of allocated bots on Linux, but keep it
uniform.