### PR TITLE
Trigger clobber build after 5a6060f

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -139,7 +139,7 @@ LLVM_VERSION = '9.0.0'
 # Update this number each time you want to create a clobber build.  If the
 # clobber_version.txt file in WORK_DIR doesn't match we remove the entire
 # WORK_DIR.  This works like a simpler version of chromium's landmine feature.
-CLOBBER_BUILD_TAG = 2
+CLOBBER_BUILD_TAG = 3
 
 options = None
 


### PR DESCRIPTION
It looks like the cmake change here requires a clobber build.