### PR TITLE
Update windows torture expectations

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -215,10 +215,13 @@ cleanup-5.C.o.wasm
 tc1__dr20.C.o.wasm # printf
 
 # https://bugs.chromium.org/p/v8/issues/detail?id=8211
-20040629-1.c.o.wasm win,O0
 20040705-1.c.o.wasm win,O0
 20040705-2.c.o.wasm win,O0
 pr53645-2.c.o.wasm win,O0
+20040629-1.c.js win,O0
+20040705-1.c.js win,O0
+20040705-2.c.js win,O0
+pr53645-2.c.js win,O0
 
 # Untriaged lld failures
 torture__pr48695.C.o.wasm O2


### PR DESCRIPTION
This appears to be due to d8 differences on windows that we don't quite understand,

https://bugs.chromium.org/p/v8/issues/detail?id=8211

So just update the expectations to get the windows bot green.