### PR TITLE
Ignore a torture test on windows

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -207,6 +207,7 @@ cleanup-5.C.o.wasm
 tc1__dr20.C.o.wasm # printf
 
 # https://bugs.chromium.org/p/v8/issues/detail?id=8211
+20040629-1.c.o.wasm win,O0
 20040705-1.c.o.wasm win,O0
 20040705-2.c.o.wasm win,O0
 pr53645-2.c.o.wasm win,O0


### PR DESCRIPTION
Which seemed to start working recently, but is now failing again, likely for the same unknown https://bugs.chromium.org/p/v8/issues/detail?id=8211 reason in the comment right above it

This reverts part of the overly-optimistic #460 

Will hopefully get the windows waterfall green.