### PR TITLE
Clobber build after llvm change

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -139,7 +139,7 @@ LLVM_VERSION = '9.0.0'
 # Update this number each time you want to create a clobber build.  If the
 # clobber_version.txt file in WORK_DIR doesn't match we remove the entire
 # WORK_DIR.  This works like a simpler version of chromium's landmine feature.
-CLOBBER_BUILD_TAG = 3
+CLOBBER_BUILD_TAG = 4
 
 options = None
 


### PR DESCRIPTION
It seems that when a unittest target is removed of renamed the old
binary sticks around and continues to get run during 'check-all'.
This recent change to LLVM is all the builder to fail trying to run
the old test (OptRemarksTests): https://reviews.llvm.org/D58535