### PR TITLE
Run emscripten test suite in single core mode on MacOS

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1595,11 +1595,24 @@ def ExecuteEmscriptenTestSuite(name, tests, config, outdir, warn_only=False):
 
 
 def TestEmtest():
-  ExecuteEmscriptenTestSuite(
-      'emwasm',
-      ['wasm2', 'other'],
-      EMSCRIPTEN_CONFIG_WASM,
-      EMSCRIPTEN_TEST_OUT_DIR)
+  # Running in parallel hits a problem on the bots where things hang.
+  if IsMac():
+    old_emcc_cores = os.environ.get('EMCC_CORES')
+    os.environ['EMCC_CORES'] = '1'
+
+  try:
+    ExecuteEmscriptenTestSuite(
+        'emwasm',
+        ['wasm2', 'other'],
+        EMSCRIPTEN_CONFIG_WASM,
+        EMSCRIPTEN_TEST_OUT_DIR)
+
+  finally:
+    if IsMac():
+      if old_emcc_cores:
+        os.environ['EMCC_CORES'] = old_emcc_cores
+      else:
+        del os.environ['EMCC_CORES']
 
 
 def TestEmtestAsm2Wasm():


### PR DESCRIPTION
This may work around odd hangs on the bots.