### PR TITLE
Remove -DLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN cmake argument

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -824,9 +824,6 @@ def LLVM():
       '-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON',
       '-DLLVM_ENABLE_ASSERTIONS=ON',
       '-DLLVM_TARGETS_TO_BUILD=X86;WebAssembly',
-      # TODO(sbc): Remove this:
-      # https://github.com/WebAssembly/waterfall/issues/467
-      '-DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON',
       '-DLLVM_ENABLE_PROJECTS=lld;clang',
   ])
 


### PR DESCRIPTION
The bots are now upgraded to xenial bots so this should no longer be
needed.

See https://bugs.chromium.org/p/chromium/issues/detail?id=939830

Fixes: #467