### PR TITLE
Split host clang step into separate steps for sync and update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ install:
   - pip install flake8==3.4.1
 script:
   - flake8
-  - ./src/build.py --sync-include=host-toolchain,cmake,wabt --build-include=wabt,debian --no-test
+  - ./src/build.py --sync-include=tools-clang,host-toolchain,cmake,wabt --build-include=wabt,debian --no-test
 notifications:
   email: false

--- a/src/build.py
+++ b/src/build.py
@@ -524,7 +524,7 @@ def SyncToolchain(name, src_dir, git_repo):
   if IsWindows():
     host_toolchains.SyncWinToolchain()
   else:
-    host_toolchains.SyncPrebuiltClang(name, src_dir, git_repo)
+    host_toolchains.SyncPrebuiltClang(name, src_dir)
     cc = GetPrebuiltClang('clang')
     cxx = GetPrebuiltClang('clang++')
     assert os.path.isfile(cc), 'Expect clang at %s' % cc
@@ -636,8 +636,9 @@ def AllSources():
       Source('v8', GetSrcDir('v8', 'v8'),
              GIT_MIRROR_BASE + 'v8/v8.git',
              custom_sync=ChromiumFetchSync),
-      Source('host-toolchain', GetPrebuilt('chromium-clang'),
-             GIT_MIRROR_BASE + 'chromium/src/tools/clang.git',
+      Source('tools-clang', GetSrcDir('chromium-clang', 'tools', 'clang'),
+             GIT_MIRROR_BASE + 'chromium/src/tools/clang.git'),
+      Source('host-toolchain', GetSrcDir('chromium-clang'), '',
              custom_sync=SyncToolchain),
       Source('cr-buildtools', GetSrcDir('build'),
              GIT_MIRROR_BASE + 'chromium/src/build.git'),

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -20,7 +20,6 @@ import json
 import os
 import shutil
 
-import file_util
 import proc
 
 WORK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'work')

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -32,18 +32,10 @@ VS_TOOLCHAIN = os.path.join(V8_SRC_DIR, 'build', 'vs_toolchain.py')
 WIN_TOOLCHAIN_JSON = os.path.join(V8_SRC_DIR, 'build', 'win_toolchain.json')
 
 
-def SyncPrebuiltClang(name, src_dir, git_repo):
+def SyncPrebuiltClang(name, src_dir):
   """Update the prebuilt clang toolchain used by chromium bots"""
   tools_clang = os.path.join(src_dir, 'tools', 'clang')
-  if os.path.isdir(tools_clang):
-    print 'Prebuilt Chromium Clang directory already exists'
-  else:
-    print 'Cloning Prebuilt Chromium Clang directory'
-    file_util.Mkdir(src_dir)
-    file_util.Mkdir(os.path.join(src_dir, 'tools'))
-    proc.check_call(['git', 'clone', git_repo, tools_clang])
-  proc.check_call(['git', 'fetch'], cwd=tools_clang)
-  proc.check_call(['git', 'checkout', 'origin/master'], cwd=tools_clang)
+  assert os.path.isdir(tools_clang)
   proc.check_call(
       [os.path.join(tools_clang, 'scripts', 'update.py')])
   return ('chromium-clang', tools_clang)


### PR DESCRIPTION
Replace the git-checkout portion with a standard source rule.
This will allow replacing that with a DEPS sync.