### PR TITLE
Use Build dir instead of Sync dir for prebuilts

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -93,7 +93,7 @@ def GetBuildDir(*args):
 
 
 def GetPrebuilt(*args):
-  return GetSrcDir(*args)
+  return GetBuildDir(*args)
 
 
 def GetPrebuiltClang(binary):
@@ -181,7 +181,7 @@ PREBUILT_CMAKE_BASE_NAME = 'cmake-%s-%s-%s' % (PREBUILT_CMAKE_VERSION,
 
 
 def PrebuiltCMakeDir(*args):
-  return GetSrcDir(PREBUILT_CMAKE_BASE_NAME, *args)
+  return GetBuildDir(PREBUILT_CMAKE_BASE_NAME, *args)
 
 
 def PrebuiltCMakeBin():
@@ -550,7 +550,7 @@ def SyncArchive(out_dir, name, url):
         return
     print '%s directory exists but is not up-to-date' % name
   print 'Downloading %s from %s' % (name, url)
-  work_dir = work_dirs.GetSync()
+  work_dir = work_dirs.GetBuild()
 
   try:
     f = urllib2.urlopen(url)
@@ -598,7 +598,7 @@ def SyncGNUWin32(name, src_dir, git_repo):
   if not IsWindows():
     return
   url = WASM_STORAGE_BASE + GNUWIN32_ZIP
-  return SyncArchive(GetSrcDir('gnuwin32'), name, url)
+  return SyncArchive(GetBuildDir('gnuwin32'), name, url)
 
 
 def SyncPrebuiltJava(name, src_dir, git_repo):

--- a/src/build.py
+++ b/src/build.py
@@ -102,7 +102,7 @@ def GetPrebuiltClang(binary):
   # TODO: copy clang into the build dir so it gets persisted, or figure out how
   # other bots do it.
   return GetSrcDir('chromium-clang', 'third_party', 'llvm-build',
-                     'Release+Asserts', 'bin', binary)
+                   'Release+Asserts', 'bin', binary)
 
 
 def GetSrcDir(*args):

--- a/src/build.py
+++ b/src/build.py
@@ -97,7 +97,11 @@ def GetPrebuilt(*args):
 
 
 def GetPrebuiltClang(binary):
-  return GetPrebuilt('chromium-clang', 'third_party', 'llvm-build',
+  # For now use the src dir instead of the build dir, because the update script
+  # is managed by gclient.
+  # TODO: copy clang into the build dir so it gets persisted, or figure out how
+  # other bots do it.
+  return GetSrcDir('chromium-clang', 'third_party', 'llvm-build',
                      'Release+Asserts', 'bin', binary)
 
 


### PR DESCRIPTION
Prebuilt host tools (clang, CMake) are logically more like sources
than build artifacts, but put them in the build dir anyway because
on LUCI builders, the src dir will be managed by gclient, backed
by git cache, and cleared on each build (whereas the build dir
can be persisted on the builder for incremental compiles)