### PR TITLE
Make work_dirs paths absolute

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -559,7 +559,7 @@ def SyncArchive(out_dir, name, url):
       t.write(f.read())
       t.flush()
       t.seek(0)
-      print 'Extracting...'
+      print 'Extracting into %s' % work_dir
       ext = os.path.splitext(url)[-1]
       if ext == '.zip':
         with zipfile.ZipFile(t, 'r') as zip:

--- a/src/work_dirs.py
+++ b/src/work_dirs.py
@@ -36,7 +36,7 @@ def MakeGetterSetter(path_type, default):
   def setter(dir):
     if path_type in dirs:
       raise Exception('Path %s set more than once' % path_type)
-    dirs[path_type] = dir
+    dirs[path_type] = os.path.abspath(dir)
 
   return getter, setter
 


### PR DESCRIPTION
This has the effect of making relative paths behave uniformly and easier
to track in bot logs.
Also print the extraction directory for prebuilt archives.