### PR TITLE
Add directory override for V8

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1580,6 +1580,9 @@ def ParseArgs():
       '--prebuilt-dir', dest='prebuilt_dir',
       help='Directory for prebuilt output')
   parser.add_argument(
+      '--v8-dir', dest='v8_dir',
+      help='Directory for V8 checkout/build')
+  parser.add_argument(
       '--test-dir', dest='test_dir', help='Directory for test output')
   parser.add_argument(
       '--install-dir', dest='install_dir',
@@ -1700,6 +1703,8 @@ def main():
     work_dirs.SetSync(options.sync_dir)
   if options.build_dir:
     work_dirs.SetBuild(options.build_dir)
+  if options.v8_dir:
+    work_dirs.SetBuild(options.v8_dir)
   if options.test_dir:
     work_dirs.SetTest(options.test_dir)
   if options.install_dir:

--- a/src/build.py
+++ b/src/build.py
@@ -1704,7 +1704,7 @@ def main():
   if options.build_dir:
     work_dirs.SetBuild(options.build_dir)
   if options.v8_dir:
-    work_dirs.SetBuild(options.v8_dir)
+    work_dirs.SetV8(options.v8_dir)
   if options.test_dir:
     work_dirs.SetTest(options.test_dir)
   if options.install_dir:

--- a/src/build.py
+++ b/src/build.py
@@ -632,7 +632,7 @@ def AllSources():
       Source('gcc', GetSrcDir('gcc'),
              GIT_MIRROR_BASE + 'chromiumos/third_party/gcc.git',
              checkout=GCC_REVISION, depth=GCC_CLONE_DEPTH),
-      Source('v8', GetSrcDir('v8', 'v8'),
+      Source('v8', work_dirs.GetV8(),
              GIT_MIRROR_BASE + 'v8/v8.git',
              custom_sync=ChromiumFetchSync),
       Source('tools-clang', GetPrebuilt('tools', 'clang'),
@@ -839,7 +839,7 @@ def LLVM():
 
 def V8():
   buildbot.Step('V8')
-  src_dir = GetSrcDir('v8', 'v8')
+  src_dir = work_dirs.GetV8()
   out_dir = os.path.join(src_dir, 'out.gn', 'x64.release')
   proc.check_call([os.path.join(src_dir, 'tools', 'dev', 'v8gen.py'),
                    '-vv', 'x64.release'],

--- a/src/work_dirs.py
+++ b/src/work_dirs.py
@@ -20,10 +20,11 @@ import os
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_WORK_DIR = os.path.join(os.path.dirname(SCRIPT_DIR), 'src', 'work')
 
-DEFAULT_SYNC_DIR = os.path.join(DEFAULT_WORK_DIR)
-DEFAULT_BUILD_DIR = os.path.join(DEFAULT_WORK_DIR)
-DEFAULT_PREBUILT_DIR = os.path.join(DEFAULT_WORK_DIR)
-DEFAULT_TEST_DIR = os.path.join(DEFAULT_WORK_DIR)
+DEFAULT_SYNC_DIR = DEFAULT_WORK_DIR
+DEFAULT_BUILD_DIR = DEFAULT_WORK_DIR
+DEFAULT_PREBUILT_DIR = DEFAULT_WORK_DIR
+DEFAULT_V8_DIR = os.path.join(DEFAULT_WORK_DIR, 'v8', 'v8')
+DEFAULT_TEST_DIR = DEFAULT_WORK_DIR
 DEFAULT_INSTALL_DIR = os.path.join(DEFAULT_WORK_DIR, 'wasm-install')
 
 dirs = {}
@@ -44,6 +45,7 @@ def MakeGetterSetter(path_type, default):
 GetSync, SetSync = MakeGetterSetter('sync', DEFAULT_SYNC_DIR)
 GetBuild, SetBuild = MakeGetterSetter('build', DEFAULT_BUILD_DIR)
 GetPrebuilt, SetPrebuilt = MakeGetterSetter('prebuilt', DEFAULT_PREBUILT_DIR)
+GetV8, SetV8 = MakeGetterSetter('v8', DEFAULT_V8_DIR)
 GetTest, SetTest = MakeGetterSetter('test', DEFAULT_TEST_DIR)
 GetInstall, SetInstall = MakeGetterSetter('install', DEFAULT_INSTALL_DIR)
 


### PR DESCRIPTION
This allows V8 to be managed separately by the same gclient that checks out
emscripten-releases and be in a parallel directory (separate from the other
sources).