### PR TITLE
Run make with --output-sync

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1148,7 +1148,7 @@ def Wasi():
   cc_env = BuildEnv(build_dir, use_gnuwin32=True)
   src_dir = GetSrcDir('wasi-sysroot')
   try:
-    proc.check_call([proc.Which('make'), 'startup_files', 'finish',
+    proc.check_call([proc.Which('make'), '--output-sync',
                      '-j%s' % NPROC,
                      'SYSROOT=' + build_dir,
                      'WASM_CC=' + GetInstallDir('bin', 'clang')],


### PR DESCRIPTION
This is an attempt fix the issue we are seeing the bots with make
is error'ing out with `make: write error: stdout`