### PR TITLE
Use V8's checkout of the chrome build repo instead of managing our own

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ install:
   - pip install flake8==3.4.1
 script:
   - flake8
-  - ./src/build.py --sync-include=tools-clang,host-toolchain,cmake,wabt --build-include=wabt,debian --no-test
+  - ./src/build.py --sync-include=v8,host-toolchain,cmake,wabt --build-include=wabt,debian --no-test
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ install:
   - pip install flake8==3.4.1
 script:
   - flake8
-  - ./src/build.py --sync-include=v8,host-toolchain,cmake,wabt --build-include=wabt,debian --no-test
+  - ./src/build.py --sync-include=cmake,wabt --build-include=wabt,debian --no-test --no-host-clang
 notifications:
   email: false

--- a/src/build.py
+++ b/src/build.py
@@ -710,7 +710,7 @@ def GetRepoInfo():
 # Build rules
 
 def OverrideCMakeCompiler():
-  if IsWindows():
+  if IsWindows() or host_toolchains.ShouldForceHostClang():
     return []
   return ['-DCMAKE_C_COMPILER=' + GetPrebuiltClang('clang'),
           '-DCMAKE_CXX_COMPILER=' + GetPrebuiltClang('clang++')]

--- a/src/build.py
+++ b/src/build.py
@@ -1639,6 +1639,9 @@ def ParseArgs():
       '--git-status', dest='git_status', default=False, action='store_true',
       help='Show git status for each sync target. '
            "Doesn't sync, build, or test")
+  parser.add_argument(
+    '--no-host-clang', dest='host_clang', action='store_false',
+    help="Don't force chrome clang as the host compiler")
 
   return parser.parse_args()
 
@@ -1711,6 +1714,8 @@ def main():
     work_dirs.SetInstall(options.install_dir)
   if options.prebuilt_dir:
     work_dirs.SetPrebuilt(options.prebuilt_dir)
+  if options.no_host_clang:
+    host_toolchains.SetForceHostClang(False)
 
   sync_include = options.sync_include if options.sync else []
   sync_filter = Filter('sync', sync_include, options.sync_exclude)

--- a/src/build.py
+++ b/src/build.py
@@ -710,7 +710,7 @@ def GetRepoInfo():
 # Build rules
 
 def OverrideCMakeCompiler():
-  if IsWindows() or not options.host_clang:
+  if IsWindows() or not options.force_host_clang:
     return []
   return ['-DCMAKE_C_COMPILER=' + GetPrebuiltClang('clang'),
           '-DCMAKE_CXX_COMPILER=' + GetPrebuiltClang('clang++')]

--- a/src/build.py
+++ b/src/build.py
@@ -710,7 +710,7 @@ def GetRepoInfo():
 # Build rules
 
 def OverrideCMakeCompiler():
-  if IsWindows() or host_toolchains.ShouldForceHostClang():
+  if IsWindows() or not host_toolchains.ShouldForceHostClang():
     return []
   return ['-DCMAKE_C_COMPILER=' + GetPrebuiltClang('clang'),
           '-DCMAKE_CXX_COMPILER=' + GetPrebuiltClang('clang++')]

--- a/src/build.py
+++ b/src/build.py
@@ -710,7 +710,7 @@ def GetRepoInfo():
 # Build rules
 
 def OverrideCMakeCompiler():
-  if IsWindows() or not options.force_host_clang:
+  if IsWindows():
     return []
   return ['-DCMAKE_C_COMPILER=' + GetPrebuiltClang('clang'),
           '-DCMAKE_CXX_COMPILER=' + GetPrebuiltClang('clang++')]
@@ -1714,6 +1714,8 @@ def main():
     work_dirs.SetInstall(options.install_dir)
   if options.prebuilt_dir:
     work_dirs.SetPrebuilt(options.prebuilt_dir)
+  if not options.host_clang:
+    host_toolchains.SetForceHostClang(False)
 
   sync_include = options.sync_include if options.sync else []
   sync_filter = Filter('sync', sync_include, options.sync_exclude)

--- a/src/build.py
+++ b/src/build.py
@@ -1640,8 +1640,8 @@ def ParseArgs():
       help='Show git status for each sync target. '
            "Doesn't sync, build, or test")
   parser.add_argument(
-    '--no-host-clang', dest='host_clang', action='store_false',
-    help="Don't force chrome clang as the host compiler")
+      '--no-host-clang', dest='host_clang', action='store_false',
+      help="Don't force chrome clang as the host compiler")
 
   return parser.parse_args()
 
@@ -1714,7 +1714,7 @@ def main():
     work_dirs.SetInstall(options.install_dir)
   if options.prebuilt_dir:
     work_dirs.SetPrebuilt(options.prebuilt_dir)
-  if options.no_host_clang:
+  if not options.host_clang:
     host_toolchains.SetForceHostClang(False)
 
   sync_include = options.sync_include if options.sync else []

--- a/src/build.py
+++ b/src/build.py
@@ -710,7 +710,7 @@ def GetRepoInfo():
 # Build rules
 
 def OverrideCMakeCompiler():
-  if IsWindows() or not options.force_host_clang:
+  if IsWindows() or not options.host_clang:
     return []
   return ['-DCMAKE_C_COMPILER=' + GetPrebuiltClang('clang'),
           '-DCMAKE_CXX_COMPILER=' + GetPrebuiltClang('clang++')]

--- a/src/build.py
+++ b/src/build.py
@@ -710,7 +710,7 @@ def GetRepoInfo():
 # Build rules
 
 def OverrideCMakeCompiler():
-  if IsWindows():
+  if IsWindows() or not options.force_host_clang:
     return []
   return ['-DCMAKE_C_COMPILER=' + GetPrebuiltClang('clang'),
           '-DCMAKE_CXX_COMPILER=' + GetPrebuiltClang('clang++')]
@@ -1714,8 +1714,6 @@ def main():
     work_dirs.SetInstall(options.install_dir)
   if options.prebuilt_dir:
     work_dirs.SetPrebuilt(options.prebuilt_dir)
-  if not options.host_clang:
-    host_toolchains.SetForceHostClang(False)
 
   sync_include = options.sync_include if options.sync else []
   sync_filter = Filter('sync', sync_include, options.sync_exclude)

--- a/src/build.py
+++ b/src/build.py
@@ -635,8 +635,6 @@ def AllSources():
       Source('v8', work_dirs.GetV8(),
              GIT_MIRROR_BASE + 'v8/v8.git',
              custom_sync=ChromiumFetchSync),
-      Source('tools-clang', GetPrebuilt('tools', 'clang'),
-             GIT_MIRROR_BASE + 'chromium/src/tools/clang.git'),
       Source('host-toolchain', work_dirs.GetV8(), '',
              custom_sync=SyncToolchain),
       Source('cmake', '', '',  # The source and git args are ignored.

--- a/src/build.py
+++ b/src/build.py
@@ -97,8 +97,8 @@ def GetPrebuilt(*args):
 
 
 def GetPrebuiltClang(binary):
-  return GetPrebuilt('third_party', 'llvm-build',
-                     'Release+Asserts', 'bin', binary)
+  return os.path.join(work_dirs.GetV8(), 'third_party', 'llvm-build',
+                      'Release+Asserts', 'bin', binary)
 
 
 def GetSrcDir(*args):
@@ -637,10 +637,8 @@ def AllSources():
              custom_sync=ChromiumFetchSync),
       Source('tools-clang', GetPrebuilt('tools', 'clang'),
              GIT_MIRROR_BASE + 'chromium/src/tools/clang.git'),
-      Source('host-toolchain', GetPrebuilt(), '',
+      Source('host-toolchain', work_dirs.GetV8(), '',
              custom_sync=SyncToolchain),
-      Source('cr-buildtools', GetSrcDir('build'),
-             GIT_MIRROR_BASE + 'chromium/src/build.git'),
       Source('cmake', '', '',  # The source and git args are ignored.
              custom_sync=SyncPrebuiltCMake),
       Source('nodejs', '', '',  # The source and git args are ignored.

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -24,9 +24,6 @@ import proc
 import work_dirs
 
 
-force_host_clang = True
-
-
 def SetupToolchain():
   return os.path.join(work_dirs.GetV8(), 'build', 'toolchain', 'win',
                       'setup_toolchain.py')
@@ -136,12 +133,3 @@ def NinjaJobs():
   if UsingGoma():
     return ['-j', '50']
   return []
-
-
-def SetForceHostClang(force):
-  global force_host_clang
-  force_host_clang = force
-
-
-def ShouldForceHostClang():
-  return force_host_clang

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -121,8 +121,10 @@ def CMakeLauncherFlags():
   else:
     try:
       compiler_launcher = proc.Which('ccache')
-      flags.extend(['-DCMAKE_%s_FLAGS=-Qunused-arguments' %
-                    c for c in ['C', 'CXX']])
+      if ShouldForceHostClang():
+        # This flag is only present in clang.
+        flags.extend(['-DCMAKE_%s_FLAGS=-Qunused-arguments' %
+                      c for c in ['C', 'CXX']])
     except:
       compiler_launcher = None
 

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -24,6 +24,9 @@ import proc
 import work_dirs
 
 
+force_host_clang = True
+
+
 def SetupToolchain():
   return os.path.join(work_dirs.GetV8(), 'build', 'toolchain', 'win',
                       'setup_toolchain.py')
@@ -133,3 +136,12 @@ def NinjaJobs():
   if UsingGoma():
     return ['-j', '50']
   return []
+
+
+def SetForceHostClang(force):
+  global force_host_clang
+  force_host_clang = force
+
+
+def ShouldForceHostClang():
+  return force_host_clang

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -21,14 +21,20 @@ import os
 import shutil
 
 import proc
+import work_dirs
 
-WORK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'work')
-CR_BUILD_DIR = os.path.join(WORK_DIR, 'build')
-SETUP_TOOLCHAIN = os.path.join(CR_BUILD_DIR, 'toolchain', 'win',
-                               'setup_toolchain.py')
-V8_SRC_DIR = os.path.join(WORK_DIR, 'v8', 'v8')
-VS_TOOLCHAIN = os.path.join(V8_SRC_DIR, 'build', 'vs_toolchain.py')
-WIN_TOOLCHAIN_JSON = os.path.join(V8_SRC_DIR, 'build', 'win_toolchain.json')
+
+def SetupToolchain():
+  return os.path.join(work_dirs.GetV8(), 'build', 'toolchain', 'win',
+                      'setup_toolchain.py')
+
+
+def VSToolchainPy():
+  return os.path.join(work_dirs.GetV8(), 'build', 'vs_toolchain.py')
+
+
+def WinToolchainJson():
+  return os.path.join(work_dirs.GetV8(), 'build', 'win_toolchain.json')
 
 
 def SyncPrebuiltClang(name, src_dir):
@@ -41,7 +47,7 @@ def SyncPrebuiltClang(name, src_dir):
 
 def SyncWinToolchain():
   """Update the VS toolchain used by Chromium bots"""
-  proc.check_call([VS_TOOLCHAIN, 'update'])
+  proc.check_call([VSToolchainPy(), 'update'])
 
 
 def GetVSEnv(dir):
@@ -63,8 +69,8 @@ def GetVSEnv(dir):
 
 def GetRuntimeDir():
   # Get the chromium-packaged toolchain directory info in a JSON file
-  proc.check_call([VS_TOOLCHAIN, 'get_toolchain_dir'])
-  with open(WIN_TOOLCHAIN_JSON) as f:
+  proc.check_call([VSToolchainPy(), 'get_toolchain_dir'])
+  with open(WinToolchainJson()) as f:
     paths = json.load(f)
   # Extract the 64-bit runtime path
   return [path for path in paths['runtime_dirs'] if path.endswith('64')][0]
@@ -74,14 +80,14 @@ def SetUpVSEnv(outdir):
   """Set up the VS build environment used by Chromium bots"""
 
   # Get the chromium-packaged toolchain directory info in a JSON file
-  proc.check_call([VS_TOOLCHAIN, 'get_toolchain_dir'])
-  with open(WIN_TOOLCHAIN_JSON) as f:
+  proc.check_call([VSToolchainPy(), 'get_toolchain_dir'])
+  with open(WinToolchainJson()) as f:
     paths = json.load(f)
 
   # Write path information (usable by a non-chromium build) into an environment
   # block
   runtime_dirs = os.pathsep.join(paths['runtime_dirs'])
-  proc.check_call([SETUP_TOOLCHAIN,
+  proc.check_call([SetupToolchain(),
                    'foo', paths['win_sdk'], runtime_dirs,
                    'win', 'x64', 'environment.x64'],
                   cwd=outdir)
@@ -90,7 +96,7 @@ def SetUpVSEnv(outdir):
 
 def CopyDlls(dir, configuration):
   """Copy MSVS Runtime dlls into a build directory"""
-  proc.check_call([VS_TOOLCHAIN, 'copy_dlls', dir, configuration, 'x64'])
+  proc.check_call([VSToolchainPy(), 'copy_dlls', dir, configuration, 'x64'])
   # LLD needs also concrt140.dll, which the Chromium copy_dlls doesn't include.
   for dll in glob.glob(os.path.join(GetRuntimeDir(), 'concrt140*.dll')):
     print 'Copying %s to %s' % (dll, dir)
@@ -111,7 +117,7 @@ def CMakeLauncherFlags():
     compiler_launcher = os.path.join(GomaDir(), 'gomacc')
   else:
     try:
-      compiler_launcher = proc.Which('ccache', WORK_DIR)
+      compiler_launcher = proc.Which('ccache')
       flags.extend(['-DCMAKE_%s_FLAGS=-Qunused-arguments' %
                     c for c in ['C', 'CXX']])
     except:


### PR DESCRIPTION
Currently we have our own checkout of chrome's build repo (to get the
host clang and the windows SDK) but use V8's checkout to actually
configure it because of a quirk in the directory paths they assume.

This switches to using V8's version consistently.
This has the advantage that we don't need to manage our own checkout
or DEPS entry and don't duplicate V8 logic.