### PR TITLE
Use revision instead as the build number for emscripten-releases bot

### DIFF
--- a/src/buildbot.py
+++ b/src/buildbot.py
@@ -62,14 +62,16 @@ def IsBot():
   return BUILDBOT_BUILDNUMBER is not None
 
 
-def BuildNumber():
-  return BUILDBOT_BUILDNUMBER
-
-
 def IsEmscriptenReleasesBot():
   """Return true if running on the emscripten-releases builders,
      False otherwise."""
   return BUILDBOT_MASTERNAME == EMSCRIPTEN_RELEASES_BOT
+
+
+def BuildNumber():
+  if IsEmscriptenReleasesBot():
+    return BUILDBOT_REVISION
+  return BUILDBOT_BUILDNUMBER
 
 
 def IsUploadingBot():


### PR DESCRIPTION
We will use the revision in the storage path rathe than the build number.
Also currenly these bots don't get a valid build number, but they don't need
one.