### PR TITLE
Add requests module to vpython environment

### DIFF
--- a/.vpython
+++ b/.vpython
@@ -35,3 +35,66 @@ wheel: <
     platform: "win_amd64"
   >
 >
+
+wheel: <
+  name: "infra/python/wheels/requests-py2_py3"
+  version: "version:2.21.0"
+>
+
+wheel: <
+  name: "infra/python/wheels/urllib3-py2_py3"
+  version: "version:1.24.3"
+>
+wheel: <
+  name: "infra/python/wheels/certifi-py2_py3"
+  version: "version:2019.3.9"
+>
+wheel: <
+  name: "infra/python/wheels/chardet-py2_py3"
+  version: "version:3.0.4"
+>
+wheel: <
+  name: "infra/python/wheels/idna-py2_py3"
+  version: "version:2.8"
+>
+
+##
+# BEGIN pyopenssl and its dependencies.
+##
+
+wheel: <
+  name: "infra/python/wheels/pyopenssl-py2_py3"
+  version: "version:19.0.0"
+>
+wheel: <
+  name: "infra/python/wheels/cryptography/${vpython_platform}"
+  version: "version:2.6.1"
+>
+wheel: <
+  name: "infra/python/wheels/asn1crypto-py2_py3"
+  version: "version:0.22.0"
+>
+wheel: <
+  name: "infra/python/wheels/enum34-py2"
+  version: "version:1.1.6"
+>
+wheel: <
+  name: "infra/python/wheels/ipaddress-py2"
+  version: "version:1.0.18"
+>
+wheel: <
+  name: "infra/python/wheels/cffi/${vpython_platform}"
+  version: "version:1.12.3"
+>
+wheel: <
+  name: "infra/python/wheels/pycparser-py2_py3"
+  version: "version:2.19"
+>
+wheel: <
+  name: "infra/python/wheels/six-py2_py3"
+  version: "version:1.10.0"
+>
+
+##
+# END pyopenssl and its dependencies.
+##


### PR DESCRIPTION
This will cause the module to be available when run on Chromium infrastructure. It's used to fetch URLs on bots where the OpenSSL version is too old to use TLS1.2