### PR TITLE
Don't run asm2wasm emscripten tests on mac

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1553,7 +1553,7 @@ ALL_TESTS = [
     # These tests do have interesting differences on OSes (especially the
     # 'other' tests) and eventually should run everywhere.
     Test('emtest', TestEmtest),
-    Test('emtest-asm', TestEmtestAsm2Wasm, Filter(exclude=['mac'])),
+    Test('emtest-asm', TestEmtestAsm2Wasm, Filter(exclude=['mac', 'windows'])),
 ]
 
 

--- a/src/build.py
+++ b/src/build.py
@@ -1553,7 +1553,7 @@ ALL_TESTS = [
     # These tests do have interesting differences on OSes (especially the
     # 'other' tests) and eventually should run everywhere.
     Test('emtest', TestEmtest),
-    Test('emtest-asm', TestEmtestAsm2Wasm),
+    Test('emtest-asm', TestEmtestAsm2Wasm, Filter(exclude=['mac'])),
 ]
 
 


### PR DESCRIPTION
Just to reduce the test matrix, as we don't expect major mac differences
and the important cases are still covered by the wasm backend emscripten
tests.