### PR TITLE
Don't link libtinfo

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -807,6 +807,9 @@ def LLVM():
       '-DLLVM_ENABLE_ASSERTIONS=ON',
       '-DLLVM_TARGETS_TO_BUILD=X86;WebAssembly',
       '-DLLVM_ENABLE_PROJECTS=lld;clang',
+      # linking libtinfo dynamically causes problems on some linuxes,
+      # https://github.com/emscripten-core/emsdk/issues/252
+      '-DLLVM_ENABLE_TERMINFO=0',
   ])
 
   jobs = host_toolchains.NinjaJobs()


### PR DESCRIPTION
This may prevent nice colors in the output, but I didn't see that in my local testing (there's no error checking for those flags, though, so not sure I did it right).

Fixes https://github.com/emscripten-core/emsdk/issues/252