### PR TITLE
Avoid libtinfo specifically on linux, where we are seeing issues

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -809,7 +809,7 @@ def LLVM():
       '-DLLVM_ENABLE_PROJECTS=lld;clang',
       # linking libtinfo dynamically causes problems on some linuxes,
       # https://github.com/emscripten-core/emsdk/issues/252
-      '-DLLVM_ENABLE_TERMINFO=0',
+      '-DLLVM_ENABLE_TERMINFO=%d' % (not IsLinux()),
   ])
 
   jobs = host_toolchains.NinjaJobs()
@@ -961,7 +961,7 @@ def Fastcomp():
       '-DLLVM_ENABLE_ASSERTIONS=ON',
       # linking libtinfo dynamically causes problems on some linuxes,
       # https://github.com/emscripten-core/emsdk/issues/252
-      '-DLLVM_ENABLE_TERMINFO=0',
+      '-DLLVM_ENABLE_TERMINFO=%d' % (not IsLinux()),
       ('-DLLVM_EXTERNAL_CLANG_SOURCE_DIR=%s' %
        GetSrcDir('emscripten-fastcomp-clang'))
   ])


### PR DESCRIPTION
As not having it removes colors on some systems. Oddly on one machine I didn't see this, but testing on another, I do - all the colors are gone.

The eventual solution may be to statically link libtinfo. Meanwhile with it we get errors on some linuxes but proper colors, and without it we avoid linux errors but have no colors. With this PR at least the loss of colors is just on linux.

See

https://github.com/emscripten-core/emsdk/issues/252

https://github.com/WebAssembly/waterfall/pull/539

https://github.com/WebAssembly/waterfall/pull/540