### PR TITLE
Build asm.js optimizer in release mode

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -999,7 +999,8 @@ def Emscripten():
   Mkdir(optimizer_out_dir)
   cc_env = BuildEnv(optimizer_out_dir)
   command = CMakeCommandNative([
-      os.path.join(src_dir, 'tools', 'optimizer')
+      os.path.join(src_dir, 'tools', 'optimizer'),
+      '-DCMAKE_BUILD_TYPE=Release'
   ])
   proc.check_call(command, cwd=optimizer_out_dir, env=cc_env)
   proc.check_call(['ninja'] + host_toolchains.NinjaJobs(),


### PR DESCRIPTION
I verified that at least locally for me, without this that executable is built with no optimizations.