### PR TITLE
Install libclang_shared.so* into wasm-install/lib

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -766,7 +766,7 @@ def CopyLLVMTools(build_dir, prefix=''):
                     'llvm-link', 'llvm-mc', 'llvm-nm', 'llvm-objdump',
                     'llvm-readobj', 'opt', 'llvm-dwarfdump'])
   extra_libs = ['libLLVM*.%s' % ext for ext in ['so', 'dylib', 'dll']]
-  extra_libs.append('libclang_shared.*')
+  extra_libs.append('libclang_shared.so*')
   for p in [glob.glob(os.path.join(build_dir, 'bin', b)) for b in
             extra_bins]:
     for e in p:

--- a/src/build.py
+++ b/src/build.py
@@ -766,6 +766,7 @@ def CopyLLVMTools(build_dir, prefix=''):
                     'llvm-link', 'llvm-mc', 'llvm-nm', 'llvm-objdump',
                     'llvm-readobj', 'opt', 'llvm-dwarfdump'])
   extra_libs = ['libLLVM*.%s' % ext for ext in ['so', 'dylib', 'dll']]
+  extra_libs.append('libclang_shared.*')
   for p in [glob.glob(os.path.join(build_dir, 'bin', b)) for b in
             extra_bins]:
     for e in p:


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/commit/2e97d2aa1bd313350e76be64299f19172a346bf9,
`CLANG_LINK_CLANG_DYLIB` is `ON` whenever `LLVM_LINK_LLVM_DYLIB` is
`ON`. This requires `libclang_shared.so` to be installed in
`wasm-install/lib`, but `-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON` currently
disables its installation. This adds `libclang_shared.so` to `extra_lib`
so it can be installed. This fixes the current emscripten build step
failure in the waterfall.