### PR TITLE
Install libclang_shared.dylib for mac

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -766,7 +766,7 @@ def CopyLLVMTools(build_dir, prefix=''):
                     'llvm-link', 'llvm-mc', 'llvm-nm', 'llvm-objdump',
                     'llvm-readobj', 'opt', 'llvm-dwarfdump'])
   extra_libs = ['libLLVM*.%s' % ext for ext in ['so', 'dylib', 'dll']]
-  extra_libs.append('libclang_shared.so*')
+  extra_libs += ['libclang_shared.%s*' % ext for ext in ['so', 'dylib', 'dll']]
   for p in [glob.glob(os.path.join(build_dir, 'bin', b)) for b in
             extra_bins]:
     for e in p:


### PR DESCRIPTION
Previously #552 failed to install *.dylib for mac. (This tries to install the
nonexistent *.dll too just in case we enable DYLIB in Windows too, but if the
file doesn't exist, it's ok)