### PR TITLE
Rename libclang_shared.so to libclang-cpp.so

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -766,7 +766,7 @@ def CopyLLVMTools(build_dir, prefix=''):
                     'llvm-link', 'llvm-mc', 'llvm-nm', 'llvm-objdump',
                     'llvm-readobj', 'opt', 'llvm-dwarfdump'])
   extra_libs = ['libLLVM*.%s' % ext for ext in ['so', 'dylib', 'dll']]
-  extra_libs += ['libclang_shared.%s*' % ext for ext in ['so', 'dylib', 'dll']]
+  extra_libs += ['libclang-cpp.%s*' % ext for ext in ['so', 'dylib', 'dll']]
   for p in [glob.glob(os.path.join(build_dir, 'bin', b)) for b in
             extra_bins]:
     for e in p:


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/76b26550e9b91b1b23bfe5ae40f458b69ce6b7c1
renames `libclang_shared` to `libclang-cpp`. Fixes the current waterfall
emscripten build failure. This is probably something we have to fix in the LLVM
upstream, but this makes the waterfall running in the meantime.