### PR TITLE
Don't copy extra libraries anymore

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -765,17 +765,10 @@ def CopyLLVMTools(build_dir, prefix=''):
                    ['FileCheck', 'lli', 'llc', 'llvm-as', 'llvm-dis',
                     'llvm-link', 'llvm-mc', 'llvm-nm', 'llvm-objdump',
                     'llvm-readobj', 'opt', 'llvm-dwarfdump'])
-  extra_libs = ['lib%s*.%s*' % (lib, ext)
-                for lib in ('LLVM', 'clang')
-                for ext in ['so', 'dylib', 'dll']]
   for p in [glob.glob(os.path.join(build_dir, 'bin', b)) for b in
             extra_bins]:
     for e in p:
       CopyBinaryToArchive(os.path.join(build_dir, 'bin', e), prefix)
-  for p in [glob.glob(os.path.join(build_dir, 'lib', l)) for l in
-            extra_libs]:
-    for e in p:
-      CopyLibraryToArchive(os.path.join(build_dir, 'lib', e), prefix)
 
 
 def BuildEnv(build_dir, use_gnuwin32=False, bin_subdir=False,


### PR DESCRIPTION
The bug that necessary shared libraries were not copied when
`LLVM_INSTALL_TOOLCHAIN_ONLY=ON` and `DYLIB=ON` has been fixed upstream:
https://github.com/llvm/llvm-project/commit/a196469e67ce578df4fc9f348cc5b7221f12b239
https://github.com/llvm/llvm-project/commit/1d062dae158c5ba7d1f27010d5e4178e10820ee2

So we don't need to copy them anymore.