### PR TITLE
Restore printing of archive contents before upload

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -293,8 +293,6 @@ def CopyLibraryToSysroot(library):
 def Archive(directory, print_content=False):
   """Create an archive file from directory."""
   # Use the format "native" to the platform
-  if not buildbot.IsBot():
-    return
   if IsWindows():
     return Zip(directory, print_content)
   return Tar(directory, print_content)
@@ -1208,7 +1206,7 @@ def ArchiveBinaries():
   # TODO(sergiyb): Restore printing list of binaries on Linux and Mac once it
   # works. See https://crbug.com/916775 and https://crbug.com/940663
   UploadArchive(
-      'binaries', Archive(GetInstallDir(), print_content=IsWindows()))
+      'binaries', Archive(GetInstallDir(), print_content=IsBot()))
 
 
 def DebianPackage():

--- a/src/build.py
+++ b/src/build.py
@@ -1203,8 +1203,6 @@ def ArchiveBinaries():
   if not buildbot.IsUploadingBot():
     return
   # All relevant binaries were copied to the LLVM directory.
-  # TODO(sergiyb): Restore printing list of binaries on Linux and Mac once it
-  # works. See https://crbug.com/916775 and https://crbug.com/940663
   UploadArchive(
       'binaries', Archive(GetInstallDir(), print_content=IsBot()))
 


### PR DESCRIPTION
This should work again with the new bot infrastructure.
Also remove redundant check in subroutine, which makes things
easier to test locally.