### PR TITLE
Revert "Set default target triple to wasm32-wasi (#563)"

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -807,7 +807,6 @@ def LLVM():
       '-DLLVM_TOOL_LTO_BUILD=OFF',
       '-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON',
       '-DLLVM_ENABLE_ASSERTIONS=ON',
-      '-DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-wasi',
       '-DLLVM_TARGETS_TO_BUILD=X86;WebAssembly',
       '-DLLVM_ENABLE_PROJECTS=lld;clang',
       # linking libtinfo dynamically causes problems on some linuxes,


### PR DESCRIPTION
This reverts commit 864a7e382cb9a89ed38e5f4b3fd66e2cb5952ef7.

We'd like to land this but unfortunately emscripten depends on the
host being the default for testing purposes.