### PR TITLE
Clobber build after recent LLVM_DEFAULT_TARGET_TRIPLE changes

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -82,7 +82,7 @@ LLVM_VERSION = '10.0.0'
 # Update this number each time you want to create a clobber build.  If the
 # clobber_version.txt file in the build dir doesn't match we remove ALL work
 # dirs.  This works like a simpler version of chromium's landmine feature.
-CLOBBER_BUILD_TAG = 9
+CLOBBER_BUILD_TAG = 10
 
 options = None
 


### PR DESCRIPTION
This value was being cached by the cmake build so even after reverting
the change the bot were still getting the same failures.