### PR TITLE
Run a limited set of default builds/tests when invoking build.py without filters

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1414,8 +1414,9 @@ def AllBuilds():
 
 # For now, just the builds used to test WASI, and emscripten torture tests on wasm-stat.us
 
-DEFAULT_BUILDS = ['llvm', 'jsvu', 'wabt', 'binaryen', 'fastcomp', 'emscripten',
-                  'wasi-libc', 'compiler-rt', 'libcxx', 'libcxxabi']
+DEFAULT_BUILDS = ['llvm', 'v8', 'jsvu', 'wabt', 'binaryen', 'fastcomp',
+                  'emscripten', 'wasi-libc', 'compiler-rt', 'libcxx',
+                  'libcxxabi']
 
 def BuildRepos(filter):
   for rule in filter.Apply(AllBuilds()):
@@ -1766,9 +1767,9 @@ def main():
 
   sync_include = options.sync_include if options.sync else []
   sync_filter = Filter('sync', sync_include, options.sync_exclude)
-  build_include = options.build_include if options.build else DEFAULT_BUILDS
+  build_include = options.build_include if options.build and options.build_include else DEFAULT_BUILDS
   build_filter = Filter('build', build_include, options.build_exclude)
-  test_include = options.test_include if options.test else DEFAULT_TESTS
+  test_include = options.test_include if options.test and options.test_include else DEFAULT_TESTS
   test_filter = Filter('test', test_include, options.test_exclude)
 
   try:

--- a/src/build.py
+++ b/src/build.py
@@ -1767,9 +1767,11 @@ def main():
 
   sync_include = options.sync_include if options.sync else []
   sync_filter = Filter('sync', sync_include, options.sync_exclude)
-  build_include = options.build_include if options.build and options.build_include else DEFAULT_BUILDS
+  build_include = [] if not options.build else (
+      options.build_include if options.build_include else DEFAULT_BUILDS)
   build_filter = Filter('build', build_include, options.build_exclude)
-  test_include = options.test_include if options.test and options.test_include else DEFAULT_TESTS
+  test_include = [] if not options.test else (
+      options.test_include if options.test_include else DEFAULT_TESTS)
   test_filter = Filter('test', test_include, options.test_exclude)
 
   try:

--- a/src/build.py
+++ b/src/build.py
@@ -1335,11 +1335,12 @@ def ValidateLLVMTorture(indir, ext, opt):
 
 
 class Build(object):
-  def __init__(self, name_, runnable_, os_filter=None,
+  def __init__(self, name_, runnable_, os_filter=None, is_default=True,
                *args, **kwargs):
     self.name = name_
     self.runnable = runnable_
     self.os_filter = os_filter
+    self.is_deafult = is_default
     self.args = args
     self.kwargs = kwargs
 
@@ -1410,6 +1411,11 @@ def AllBuilds():
       Build('debian', DebianPackage),
   ]
 
+
+# For now, just the builds used to test WASI, and emscripten torture tests on wasm-stat.us
+
+DEFAULT_BUILDS = ['llvm', 'jsvu', 'wabt', 'binaryen', 'fastcomp', 'emscripten',
+                  'wasi-libc', 'compiler-rt', 'libcxx', 'libcxxabi']
 
 def BuildRepos(filter):
   for rule in filter.Apply(AllBuilds()):
@@ -1580,6 +1586,9 @@ ALL_TESTS = [
     Test('emtest', TestEmtest),
     Test('emtest-asm', TestEmtestAsm2Wasm, Filter(exclude=['mac', 'windows'])),
 ]
+
+# The default tests to run on wasm-stat.us (just WASI and emwasm torture)
+DEFAULT_TESTS = ['bare', 'emwasm']
 
 
 def TextWrapNameList(prefix, items):
@@ -1757,9 +1766,9 @@ def main():
 
   sync_include = options.sync_include if options.sync else []
   sync_filter = Filter('sync', sync_include, options.sync_exclude)
-  build_include = options.build_include if options.build else []
+  build_include = options.build_include if options.build else DEFAULT_BUILDS
   build_filter = Filter('build', build_include, options.build_exclude)
-  test_include = options.test_include if options.test else []
+  test_include = options.test_include if options.test else DEFAULT_TESTS
   test_filter = Filter('test', test_include, options.test_exclude)
 
   try:

--- a/src/build.py
+++ b/src/build.py
@@ -1412,11 +1412,12 @@ def AllBuilds():
   ]
 
 
-# For now, just the builds used to test WASI, and emscripten torture tests on wasm-stat.us
-
+# For now, just the builds used to test WASI and emscripten torture tests
+# on wasm-stat.us
 DEFAULT_BUILDS = ['llvm', 'v8', 'jsvu', 'wabt', 'binaryen', 'fastcomp',
                   'emscripten', 'wasi-libc', 'compiler-rt', 'libcxx',
                   'libcxxabi']
+
 
 def BuildRepos(filter):
   for rule in filter.Apply(AllBuilds()):


### PR DESCRIPTION
This reduces the number of tests run on the wasm-stat.us waterfall, removing
fastcomp torture tests (which are not worth keeping) and all emscripten
test-suite tests (which we run more comprehensively elsewhere).