### PR TITLE
Update expectations on failing asan tests

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -197,7 +197,6 @@ pr23135.c.o.wasm O0
 loop-2g.c.o.wasm
 loop-2f.c.o.wasm
 
-ubsan__return-1.C.o.wasm
 abi__bitfield1.C.o.wasm
 abi__vbase13.C.o.wasm
 eh__alias1.C.o.wasm
@@ -273,3 +272,10 @@ torture__stackalign__throw-1.C.o.wasm
 torture__stackalign__throw-2.C.o.wasm
 torture__stackalign__throw-3.C.o.wasm
 tree-ssa__pr33604.C.o.wasm
+
+### Sanitizer tests
+# Because we don't run sanitizers on them, they may succeed or fail, and we
+# should not care about the results. For now we list tests that happen to fail.
+asan__deep-stack-uaf-1.C.o.wasm
+asan__symbolize-callback-1.C.o.wasm
+ubsan__return-1.C.o.wasm


### PR DESCRIPTION
We don't run sanitizers on them, so all sanitizer tests (ubsan, asan,
tsan, ...) may start to fail at any point, and we shouldn't care about
the results. For now I update the expectation to match the current
behavior, but if this happens frequently enough, we may need to fix the
runner script so that we can skip those tests or something.

The two asan tests started to fail after CraneStation/wasi-libc#112, just for
reference.