### PR TITLE
Split Emscripten build step into upstream and fastcomp variants

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -993,6 +993,7 @@ def Fastcomp():
 def BuildEmscriptenOptimizer():
   # Remove cached library builds (e.g. libc, libc++) to force them to be
   # rebuilt in the step below.
+  buildbot.Step('emscripten (optimizer)')
   Remove(EMSCRIPTEN_CACHE_DIR)
   src_dir = GetSrcDir('emscripten')
   em_install_dir = GetInstallDir('emscripten')
@@ -1020,7 +1021,6 @@ def BuildEmscriptenOptimizer():
 
 
 def Emscripten(variant):
-  buildbot.Step('emscripten')
   if variant == 'upstream':
     # This work is only done once (not per-variant), so only do it if the
     # variant is 'upstream'. This means that the upstream variant does

--- a/src/build.py
+++ b/src/build.py
@@ -1022,7 +1022,8 @@ def Emscripten(variant):
     proc.check_call(command, cwd=optimizer_out_dir, env=cc_env)
     proc.check_call(['ninja'] + host_toolchains.NinjaJobs(),
                     cwd=optimizer_out_dir, env=cc_env)
-    CopyBinaryToArchive(Executable(os.path.join(optimizer_out_dir, 'optimizer')))
+    CopyBinaryToArchive(Executable(
+        os.path.join(optimizer_out_dir, 'optimizer')))
 
   def WriteEmscriptenConfig(infile, outfile):
     with open(infile) as config:
@@ -1049,7 +1050,8 @@ def Emscripten(variant):
 
   config, cache_subdir, cache_libs = configs[variant]
 
-  # Set up the emscripten config and compile the libraries for the specified variant
+  # Set up the emscripten config and compile the libraries for the specified
+  # variant
   buildbot.Step('emscripten (%s)' % variant)
   print 'Config file: ', config
   src_config = os.path.join(SCRIPT_DIR, os.path.basename(config))

--- a/src/build.py
+++ b/src/build.py
@@ -1016,8 +1016,7 @@ def BuildEmscriptenOptimizer():
   proc.check_call(command, cwd=optimizer_out_dir, env=cc_env)
   proc.check_call(['ninja'] + host_toolchains.NinjaJobs(),
                   cwd=optimizer_out_dir, env=cc_env)
-  CopyBinaryToArchive(Executable(
-      os.path.join(optimizer_out_dir, 'optimizer')))
+  CopyBinaryToArchive(Executable(os.path.join(optimizer_out_dir, 'optimizer')))
 
 
 def Emscripten(variant):
@@ -1086,9 +1085,9 @@ def Emscripten(variant):
     # Use emscripten's embuilder to prebuild the system libraries.
     # This depends on binaryen already being built and installed into the
     # archive/install dir.
-    proc.check_call([
-        sys.executable, os.path.join(GetInstallDir('emscripten'), 'embuilder.py'),
-        'build', 'SYSTEM'])
+    proc.check_call([sys.executable,
+                     os.path.join(GetInstallDir('emscripten'), 'embuilder.py'),
+                     'build', 'SYSTEM'])
 
   except proc.CalledProcessError:
     # Note the failure but allow the build to continue.

--- a/src/build.py
+++ b/src/build.py
@@ -990,34 +990,39 @@ def Fastcomp():
   CopyLLVMTools(build_dir, 'fastcomp')
 
 
-def Emscripten():
+def Emscripten(variant):
   buildbot.Step('emscripten')
-  # Remove cached library builds (e.g. libc, libc++) to force them to be
-  # rebuilt in the step below.
-  Remove(EMSCRIPTEN_CACHE_DIR)
-  src_dir = GetSrcDir('emscripten')
-  em_install_dir = GetInstallDir('emscripten')
-  Remove(em_install_dir)
-  print 'Copying directory %s to %s' % (src_dir, em_install_dir)
-  shutil.copytree(src_dir,
-                  em_install_dir,
-                  symlinks=True,
-                  # Ignore the big git blob so it doesn't get archived.
-                  ignore=shutil.ignore_patterns('.git'))
+  if variant == 'upstream':
+    # This work is only done once (not per-variant), so only do it if the
+    # variant is 'upstream'. This means that the upstream variant does
+    # need to go first.
 
-  # Manually build the native asm.js optimizer (the cmake build in embuilder
-  # doesn't work on the waterfall)
-  optimizer_out_dir = GetBuildDir('em-optimizer-out')
-  Mkdir(optimizer_out_dir)
-  cc_env = BuildEnv(optimizer_out_dir)
-  command = CMakeCommandNative([
-      os.path.join(src_dir, 'tools', 'optimizer'),
-      '-DCMAKE_BUILD_TYPE=Release'
-  ])
-  proc.check_call(command, cwd=optimizer_out_dir, env=cc_env)
-  proc.check_call(['ninja'] + host_toolchains.NinjaJobs(),
-                  cwd=optimizer_out_dir, env=cc_env)
-  CopyBinaryToArchive(Executable(os.path.join(optimizer_out_dir, 'optimizer')))
+    # Remove cached library builds (e.g. libc, libc++) to force them to be
+    # rebuilt in the step below.
+    Remove(EMSCRIPTEN_CACHE_DIR)
+    src_dir = GetSrcDir('emscripten')
+    em_install_dir = GetInstallDir('emscripten')
+    Remove(em_install_dir)
+    print 'Copying directory %s to %s' % (src_dir, em_install_dir)
+    shutil.copytree(src_dir,
+                    em_install_dir,
+                    symlinks=True,
+                    # Ignore the big git blob so it doesn't get archived.
+                    ignore=shutil.ignore_patterns('.git'))
+
+    # Manually build the native asm.js optimizer (the cmake build in embuilder
+    # doesn't work on the waterfall)
+    optimizer_out_dir = GetBuildDir('em-optimizer-out')
+    Mkdir(optimizer_out_dir)
+    cc_env = BuildEnv(optimizer_out_dir)
+    command = CMakeCommandNative([
+        os.path.join(src_dir, 'tools', 'optimizer'),
+        '-DCMAKE_BUILD_TYPE=Release'
+    ])
+    proc.check_call(command, cwd=optimizer_out_dir, env=cc_env)
+    proc.check_call(['ninja'] + host_toolchains.NinjaJobs(),
+                    cwd=optimizer_out_dir, env=cc_env)
+    CopyBinaryToArchive(Executable(os.path.join(optimizer_out_dir, 'optimizer')))
 
   def WriteEmscriptenConfig(infile, outfile):
     with open(infile) as config:
@@ -1035,61 +1040,64 @@ def Emscripten():
   #     that is confusing to debug if the user has a broken setup.
   #   * optimizer.2.exe takes a while to build and also requires a local
   #     compiler environment for native executables.
-  configs = [
-      ('asm2wasm', GetInstallDir(EMSCRIPTEN_CONFIG_FASTCOMP),
-       'asmjs', ('libc.bc', 'generated_struct_info.json')),
-      ('emwasm', GetInstallDir(EMSCRIPTEN_CONFIG_UPSTREAM),
-       'wasm-obj', ('libc.a', 'generated_struct_info.json'))]
+  configs = {
+      'fastcomp': (GetInstallDir(EMSCRIPTEN_CONFIG_FASTCOMP),
+                   'asmjs', ('libc.bc', 'generated_struct_info.json')),
+      'upstream': (GetInstallDir(EMSCRIPTEN_CONFIG_UPSTREAM),
+                   'wasm-obj', ('libc.a', 'generated_struct_info.json'))
+  }
 
-  for config_name, config, cache_subdir, cache_libs in configs:
-    buildbot.Step('emscripten (%s)' % config_name)
-    print 'Config file: ', config
-    src_config = os.path.join(SCRIPT_DIR, os.path.basename(config))
-    WriteEmscriptenConfig(src_config, config)
+  config, cache_subdir, cache_libs = configs[variant]
 
-    # FIXME HACK emcc does sanity check by comparing mtime of the sanity file
-    # with that of emscripten config file. The sanity check process in
-    # emscripten thinks current cache is invalid when 'sanity file's mtime <=
-    # config file's mtime'. embuilder launches emcc for each of system library
-    # we need to build, and each of those emcc process in turn launches several
-    # more emcc processes for each of .c source file included in the library.
-    # Each of these emcc processes runs its own sanity check, which is
-    # unnecessary anyway, and we are planning to fix it. But this is also
-    # causing problems for Mac and Windows build in waterfall. The first emcc
-    # process sees the configuration file has changed, deletes cache, and
-    # rewrites the sanity file. Then, Mac OS X and Windows' timestamps for
-    # mtime only have 1~2 seconds resolution, which makes it possible that
-    # other emcc processes launched later by the initial emcc process again
-    # think the cache is invalid and delete the cache again, which would then
-    # contain half-built libraries, if less than 1 seconds has elapsed after
-    # the first deletion. So here we make sure that enough time has elapsed
-    # between configuration file writing and sanity checking, so that it would
-    # temporarily work on Mac and Windows.
-    if not IsLinux():
-      time.sleep(3)
+  # Set up the emscripten config and compile the libraries for the specified variant
+  buildbot.Step('emscripten (%s)' % variant)
+  print 'Config file: ', config
+  src_config = os.path.join(SCRIPT_DIR, os.path.basename(config))
+  WriteEmscriptenConfig(src_config, config)
 
-    os.environ['EM_CONFIG'] = config
-    try:
-      # Use emscripten's embuilder to prebuild the system libraries.
-      # This depends on binaryen already being built and installed into the
-      # archive/install dir.
-      proc.check_call([
-          sys.executable, os.path.join(em_install_dir, 'embuilder.py'),
-          'build', 'SYSTEM'])
+  # FIXME HACK emcc does sanity check by comparing mtime of the sanity file
+  # with that of emscripten config file. The sanity check process in
+  # emscripten thinks current cache is invalid when 'sanity file's mtime <=
+  # config file's mtime'. embuilder launches emcc for each of system library
+  # we need to build, and each of those emcc process in turn launches several
+  # more emcc processes for each of .c source file included in the library.
+  # Each of these emcc processes runs its own sanity check, which is
+  # unnecessary anyway, and we are planning to fix it. But this is also
+  # causing problems for Mac and Windows build in waterfall. The first emcc
+  # process sees the configuration file has changed, deletes cache, and
+  # rewrites the sanity file. Then, Mac OS X and Windows' timestamps for
+  # mtime only have 1~2 seconds resolution, which makes it possible that
+  # other emcc processes launched later by the initial emcc process again
+  # think the cache is invalid and delete the cache again, which would then
+  # contain half-built libraries, if less than 1 seconds has elapsed after
+  # the first deletion. So here we make sure that enough time has elapsed
+  # between configuration file writing and sanity checking, so that it would
+  # temporarily work on Mac and Windows.
+  if not IsLinux():
+    time.sleep(3)
 
-    except proc.CalledProcessError:
-      # Note the failure but allow the build to continue.
-      buildbot.Fail()
-    finally:
-      del os.environ['EM_CONFIG']
+  os.environ['EM_CONFIG'] = config
+  try:
+    # Use emscripten's embuilder to prebuild the system libraries.
+    # This depends on binaryen already being built and installed into the
+    # archive/install dir.
+    proc.check_call([
+        sys.executable, os.path.join(em_install_dir, 'embuilder.py'),
+        'build', 'SYSTEM'])
 
-    # Copy the main system libraries so users don't need to themselves.
-    packaging_dir = GetInstallDir('lib', cache_subdir)
-    if not os.path.isdir(packaging_dir):
-      os.makedirs(packaging_dir)
-    for name in cache_libs:
-      shutil.copy2(os.path.join(EMSCRIPTEN_CACHE_DIR, cache_subdir, name),
-                   os.path.join(packaging_dir, name))
+  except proc.CalledProcessError:
+    # Note the failure but allow the build to continue.
+    buildbot.Fail()
+  finally:
+    del os.environ['EM_CONFIG']
+
+  # Copy the main system libraries so users don't need to themselves.
+  packaging_dir = GetInstallDir('lib', cache_subdir)
+  if not os.path.isdir(packaging_dir):
+    os.makedirs(packaging_dir)
+  for name in cache_libs:
+    shutil.copy2(os.path.join(EMSCRIPTEN_CACHE_DIR, cache_subdir, name),
+                 os.path.join(packaging_dir, name))
 
 
 def CompilerRT():
@@ -1408,7 +1416,8 @@ def AllBuilds():
       Build('wabt', Wabt),
       Build('binaryen', Binaryen),
       Build('fastcomp', Fastcomp),
-      Build('emscripten', Emscripten),
+      Build('emscripten-upstream', Emscripten, None, True, 'upstream'),
+      Build('emscripten-fastcomp', Emscripten, None, True, 'fastcomp'),
       # Target libs
       # TODO: re-enable wasi on windows, see #517
       Build('wasi-libc', WasiLibc, os_filter=Filter(exclude=['windows'])),
@@ -1424,8 +1433,8 @@ def AllBuilds():
 # For now, just the builds used to test WASI and emscripten torture tests
 # on wasm-stat.us
 DEFAULT_BUILDS = ['llvm', 'v8', 'jsvu', 'wabt', 'binaryen', 'fastcomp',
-                  'emscripten', 'wasi-libc', 'compiler-rt', 'libcxx',
-                  'libcxxabi']
+                  'emscripten-upstream', 'emscripten-fastcomp', 'wasi-libc',
+                  'compiler-rt', 'libcxx', 'libcxxabi']
 
 
 def BuildRepos(filter):


### PR DESCRIPTION
More specifically, instead of building libs for both variants, the step
now only builds libs for the specfied variant. This allows the
llvm-test-suite bot to skip building fastcomp altogether.