### PR TITLE
Add build target for LLVM test dependencies

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -839,6 +839,14 @@ def LLVM():
                      Executable(link))
 
 
+def LLVMTestDepends():
+  buildbot.Step('LLVM Test Dependencies')
+  build_dir = os.path.join(work_dirs.GetBuild(), 'llvm-out')
+  proc.check_call(
+      ['ninja', '-v', 'test-depends'] + host_toolchains.NinjaJobs(),
+      cwd=build_dir, env=BuildEnv(build_dir, bin_subdir=True))
+
+
 def TestLLVMRegression():
   build_dir = os.path.join(work_dirs.GetBuild(), 'llvm-out')
   cc_env = BuildEnv(build_dir, bin_subdir=True)
@@ -1404,6 +1412,7 @@ def AllBuilds():
   return [
       # Host tools
       Build('llvm', LLVM),
+      Build('llvm-test-depends', LLVMTestDepends),
       Build('v8', V8, os_filter=Filter(exclude=['mac'])),
       Build('jsvu', Jsvu, os_filter=Filter(exclude=['windows'])),
       Build('wabt', Wabt),


### PR DESCRIPTION
These are regular host build targets which are required for running the LLVM
regression tests (make check) but which do not build by default from the 'all'
target. An extra build rule is used (instead of bundling it with the test
running) because the emscripten-releases shuts down goma before running
tests.