### PR TITLE
Update expectations

### DIFF
--- a/src/test/run_known_gcc_test_failures.txt
+++ b/src/test/run_known_gcc_test_failures.txt
@@ -193,10 +193,6 @@ torture__pr48695.C.o.wasm O2
 20031003-1.c.o.wasm O0
 pr23135.c.o.wasm O0
 
-# Rely on /dev/zero
-loop-2g.c.o.wasm
-loop-2f.c.o.wasm
-
 abi__bitfield1.C.o.wasm
 abi__vbase13.C.o.wasm
 eh__alias1.C.o.wasm


### PR DESCRIPTION
These test now fail gracefully with the latest wasi-libc.  Not sure
exactly why.