### PR TITLE
Add Git executable to CMake command line on Windows

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -941,10 +941,6 @@ def Wabt():
   ]), cwd=out_dir, env=cc_env)
 
   proc.check_call(['ninja', '-v'], cwd=out_dir, env=cc_env)
-  # TODO(sbc): git submodules are not yet fetched so we can't yet endable
-  # wabt tests.
-  # if options.run_tool_tests:
-  #   proc.check_call(['ninja', 'run-tests'], cwd=out_dir, env=cc_env)
   proc.check_call(['ninja', 'install'], cwd=out_dir, env=cc_env)
 
 

--- a/src/build.py
+++ b/src/build.py
@@ -736,7 +736,7 @@ def CMakeCommandBase():
     command.append('-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12')
   elif IsWindows():
     # CMake's usual logic fails to find LUCI's git on Windows
-    git_exe = proc.check_output(['where', 'git']).strip()
+    git_exe = proc.Which('git')
     command.append('-DGIT_EXECUTABLE=%s' % git_exe)
   return command
 

--- a/src/build.py
+++ b/src/build.py
@@ -731,9 +731,13 @@ def CMakeCommandBase():
   command.append('-DPYTHON_EXECUTABLE=%s' % sys.executable)
   command.append('-DCMAKE_EXPORT_COMPILE_COMMANDS=ON')
   command.append('-DCMAKE_BUILD_TYPE=Release')
-  if IsMac:
+  if IsMac():
     # Target macOS Seirra (10.12)
     command.append('-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12')
+  elif IsWindows():
+    # CMake's usual logic fails to find LUCI's git on Windows
+    git_exe = proc.check_output(['where', 'git']).strip()
+    command.append('-DGIT_EXECUTABLE=%s' % git_exe)
   return command
 
 
@@ -936,7 +940,11 @@ def Wabt():
       '-DBUILD_TESTS=OFF'
   ]), cwd=out_dir, env=cc_env)
 
-  proc.check_call(['ninja'], cwd=out_dir, env=cc_env)
+  proc.check_call(['ninja', '-v'], cwd=out_dir, env=cc_env)
+  # TODO(sbc): git submodules are not yet fetched so we can't yet endable
+  # wabt tests.
+  # if options.run_tool_tests:
+  #   proc.check_call(['ninja', 'run-tests'], cwd=out_dir, env=cc_env)
   proc.check_call(['ninja', 'install'], cwd=out_dir, env=cc_env)
 
 


### PR DESCRIPTION
Git's usual FindPackage logic doesn't find it on LUCI (and git's now required
for wabt)