### PR TITLE
Update to use CMake 3.15 on the waterfall

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -177,7 +177,7 @@ def CMakeArch():
   return 'x64' if IsWindows() else 'x86_64'
 
 
-PREBUILT_CMAKE_VERSION = '3.7.2'
+PREBUILT_CMAKE_VERSION = '3.15.3'
 PREBUILT_CMAKE_BASE_NAME = 'cmake-%s-%s-%s' % (PREBUILT_CMAKE_VERSION,
                                                CMakePlatformName(),
                                                CMakeArch())


### PR DESCRIPTION
CMake 3.15 has much nicer support for clang-cl on Windows.