### PR TITLE
Compile the host binaries with Clang on Windows

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -41,6 +41,7 @@ import proc
 import testing
 import work_dirs
 
+
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 JSVU_OUT_DIR = os.path.expanduser(os.path.join('~', '.jsvu'))
 
@@ -81,7 +82,7 @@ LLVM_VERSION = '10.0.0'
 # Update this number each time you want to create a clobber build.  If the
 # clobber_version.txt file in the build dir doesn't match we remove ALL work
 # dirs.  This works like a simpler version of chromium's landmine feature.
-CLOBBER_BUILD_TAG = 11
+CLOBBER_BUILD_TAG = 12
 
 options = None
 


### PR DESCRIPTION
We still use the MSVC SDK from V8, but now we use V8's (separately-DEPSed)
clang on Windows (the same one that we use on the other platforms).