### PR TITLE
Unforce the host clang toolchain for wabt

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -946,7 +946,7 @@ def Wabt():
   proc.check_call(CMakeCommandNative([
       GetSrcDir('wabt'),
       '-DBUILD_TESTS=OFF'
-  ]), cwd=out_dir, env=cc_env)
+  ], force_host_clang=False), cwd=out_dir, env=cc_env)
 
   proc.check_call(['ninja', '-v'], cwd=out_dir, env=cc_env)
   proc.check_call(['ninja', 'install'], cwd=out_dir, env=cc_env)


### PR DESCRIPTION
Chromuim's wabt mirror is stuck and out of date, so we can't roll in the
change that makes the wabt build compatible with windows clang.
So for now, fall back to MSVC