### PR TITLE
Build and run the LLVM test suite

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -245,6 +245,9 @@ LLD_KNOWN_TORTURE_FAILURES = [os.path.join(SCRIPT_DIR, 'test',
 LLVM_TORTURE_EXCLUSIONS = [os.path.join(SCRIPT_DIR, 'test',
                                         'llvm_torture_exclusions')]
 
+RUN_LLVM_TESTSUITE_FAILURES = [os.path.join(SCRIPT_DIR, 'test',
+                                            'llvmtest_known_failures.txt')]
+
 # Optimization levels
 BARE_TEST_OPT_FLAGS = ['O0', 'O2']
 EMSCRIPTEN_TEST_OPT_FLAGS = ['O0', 'O3']
@@ -1619,7 +1622,8 @@ def TestLLVMTestSuite():
       '-DTEST_SUITE_RUN_UNDER=' + NodeBin(),
       '-DTEST_SUITE_USER_MODE_EMULATION=ON',
       '-DTEST_SUITE_SUBDIRS=SingleSource',
-      '-DTEST_SUITE_EXTRA_EXE_LINKER_FLAGS=-L %s -s TOTAL_MEMORY=1024MB' % outdir,
+      '-DTEST_SUITE_EXTRA_EXE_LINKER_FLAGS=-L %s -s TOTAL_MEMORY=1024MB' %
+        outdir,
       '-DTEST_SUITE_LLVM_SIZE=' + GetInstallDir('emscripten', 'emsize.py')]
 
   proc.check_call(command, cwd=outdir)
@@ -1639,16 +1643,16 @@ def TestLLVMTestSuite():
   failures = get_names('FAIL')
   successes = get_names('PASS')
 
-  expected_failures = testing.parse_exclude_files([os.path.join(SCRIPT_DIR, 'test/llvmtest_known_failures.txt')], [])
+  expected_failures = testing.parse_exclude_files(RUN_LLVM_TESTSUITE_FAILURES, [])
   unexpected_failures = [f for f in failures if f not in expected_failures]
   unexpected_successes = [f for f in successes if f in expected_failures]
 
   if len(unexpected_failures) > 0:
-    print 'Unexpected failures:'
+    print 'Emscripten unexpected failures:'
     for test in unexpected_failures:
       print test
   if len(unexpected_successes) > 0:
-    print 'Unexpected successes:'
+    print 'Emscripten unexpected successes:'
     for test in unexpected_successes:
       print test
 

--- a/src/build.py
+++ b/src/build.py
@@ -1623,7 +1623,7 @@ def TestLLVMTestSuite():
       '-DTEST_SUITE_USER_MODE_EMULATION=ON',
       '-DTEST_SUITE_SUBDIRS=SingleSource',
       '-DTEST_SUITE_EXTRA_EXE_LINKER_FLAGS=-L %s -s TOTAL_MEMORY=1024MB' %
-        outdir,
+      outdir,
       '-DTEST_SUITE_LLVM_SIZE=' + GetInstallDir('emscripten', 'emsize.py')]
 
   proc.check_call(command, cwd=outdir)
@@ -1643,7 +1643,8 @@ def TestLLVMTestSuite():
   failures = get_names('FAIL')
   successes = get_names('PASS')
 
-  expected_failures = testing.parse_exclude_files(RUN_LLVM_TESTSUITE_FAILURES, [])
+  expected_failures = testing.parse_exclude_files(RUN_LLVM_TESTSUITE_FAILURES,
+                                                  [])
   unexpected_failures = [f for f in failures if f not in expected_failures]
   unexpected_successes = [f for f in successes if f in expected_failures]
 

--- a/src/test/llvmtest_known_failures.txt
+++ b/src/test/llvmtest_known_failures.txt
@@ -1,0 +1,53 @@
+# Known failures for the LLVM test suite (SingleSource only, so far)
+
+# These all require exceptions. Adding -s DISABLE_EXCEPTION_CATCHING=0
+# (e.g. in SingleSource/Regression/C++/EH/CMakeLists.txt) makes them work.
+SingleSource/Regression/C++/EH/Regression-C++-class_hierarchy.js.test
+SingleSource/Regression/C++/EH/Regression-C++-ctor_dtor_count-2.js.test
+SingleSource/Regression/C++/EH/Regression-C++-ctor_dtor_count.js.test
+SingleSource/Regression/C++/EH/Regression-C++-function_try_block.js.test
+SingleSource/Regression/C++/EH/Regression-C++-inlined_cleanup.js.test
+SingleSource/Regression/C++/EH/Regression-C++-recursive-throw.js.test
+SingleSource/Regression/C++/EH/Regression-C++-simple_rethrow.js.test
+SingleSource/Regression/C++/EH/Regression-C++-simple_throw.js.test
+SingleSource/Regression/C++/EH/Regression-C++-throw_rethrow_test.js.test
+
+# All of these are currently untriaged.
+SingleSource/Benchmarks/Misc-C++-EH/spirit.js.test
+SingleSource/Benchmarks/Misc-C++/Large/ray.js.test
+SingleSource/Benchmarks/Polybench/datamining/correlation/correlation.js.test
+SingleSource/Benchmarks/Polybench/datamining/covariance/covariance.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/2mm/2mm.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/3mm/3mm.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/atax/atax.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/bicg/bicg.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/cholesky/cholesky.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/doitgen/doitgen.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/gemm/gemm.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/gemver/gemver.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/gesummv/gesummv.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/mvt/mvt.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/symm/symm.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/syr2k/syr2k.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/syrk/syrk.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/trisolv/trisolv.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/kernels/trmm/trmm.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/solvers/durbin/durbin.js.test
+SingleSource/Benchmarks/Polybench/linear-algebra/solvers/lu/lu.js.test
+SingleSource/Benchmarks/Polybench/medley/floyd-warshall/floyd-warshall.js.test
+SingleSource/Benchmarks/Polybench/stencils/adi/adi.js.test
+SingleSource/Benchmarks/Polybench/stencils/fdtd-2d/fdtd-2d.js.test
+SingleSource/Benchmarks/Polybench/stencils/jacobi-1d-imper/jacobi-1d-imper.js.test
+SingleSource/Benchmarks/Polybench/stencils/jacobi-2d-imper/jacobi-2d-imper.js.test
+SingleSource/Benchmarks/Polybench/stencils/seidel-2d/seidel-2d.js.test
+SingleSource/Benchmarks/Shootout-C++/EH/Shootout-C++-except.js.test
+SingleSource/Benchmarks/Shootout-C++/Shootout-C++-ackermann.js.test
+SingleSource/Regression/C++/EH/Regression-C++-exception_spec_test.js.test
+SingleSource/Regression/C++/Regression-C++-BuiltinTypeInfo.js.test
+SingleSource/Regression/C++/Regression-C++-global_ctor.js.test
+SingleSource/Regression/C/Regression-C-2003-05-23-TransparentUnion.js.test
+SingleSource/Regression/C/Regression-C-ConstructorDestructorAttributes.js.test
+SingleSource/UnitTests/2003-05-14-AtExit.js.test
+SingleSource/UnitTests/C++11/stdthreadbug.js.test
+SingleSource/UnitTests/Threads/2010-12-08-tls.js.test
+SingleSource/UnitTests/Threads/tls.js.test


### PR DESCRIPTION
For now, just the `SingleSource` tests (approximately 300 tests).
There are some current failures, which are listed in the expected_fails file, using the same format as the torture test expectations file.