### PR TITLE
Build wabt with clang on Windows

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -958,7 +958,7 @@ def Wabt():
   proc.check_call(CMakeCommandNative([
       GetSrcDir('wabt'),
       '-DBUILD_TESTS=OFF'
-  ], force_host_clang=False), cwd=out_dir, env=cc_env)
+  ]), cwd=out_dir, env=cc_env)
 
   proc.check_call(['ninja', '-v'], cwd=out_dir, env=cc_env)
   proc.check_call(['ninja', 'install'], cwd=out_dir, env=cc_env)


### PR DESCRIPTION
This can be done now that we've rolled the new wabt CMake files.