### PR TITLE
Force Python UTF-8 mode when running tests

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1858,6 +1858,9 @@ def run(sync_filter, build_filter, test_filter):
     Summary()
     return 1
 
+  # Override the default locale to use UTF-8 encoding for all files and stdio
+  # streams (see PEP540), since oure test files are encoded with UTF-8.
+  os.environ['PYTHONUTF8'] = '1'
   for t in test_filter.Apply(ALL_TESTS):
     t.Test()
 


### PR DESCRIPTION
This overrides the default locale to always use UTF-8 for decoding text
files (on Windows the default is mbcs/cp1252). This is because our test
files are all encoded with UTF-8.