### PR TITLE
Limit llvm build for WebAssembly only

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -834,7 +834,8 @@ def LLVM():
       '-DLLVM_TOOL_LTO_BUILD=OFF',
       '-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON',
       '-DLLVM_ENABLE_ASSERTIONS=ON',
-      '-DLLVM_TARGETS_TO_BUILD=X86;WebAssembly',
+      '-DLLVM_TARGETS_TO_BUILD=WebAssembly',
+      '-DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-wasi'
       '-DLLVM_ENABLE_PROJECTS=lld;clang',
       # linking libtinfo dynamically causes problems on some linuxes,
       # https://github.com/emscripten-core/emsdk/issues/252


### PR DESCRIPTION
This will help speed up the build and test of llvm and should
also avoid confusion when users see x86 support listed (and even
the default) in the underlying compiler.