### PR TITLE
Update to travis testing to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: trusty
+dist: xenial
 language: python
 addons:
   apt:


### PR DESCRIPTION
It seems the gcc version on trusty is no longer capable of building
wabt.