### PR TITLE
Build Linux binaries in V8's sysroot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
     - name: install dependencies
       run: sudo apt-get --quiet install ninja-build devscripts
     - name: build.py
-      run: ./src/build.py --sync-include=cmake,wabt --build-include=wabt,debian --no-test --no-host-clang
+      run: ./src/build.py --sync-include=cmake,wabt --build-include=wabt,debian --no-test --no-host-clang --no-sysroot

--- a/src/build.py
+++ b/src/build.py
@@ -1003,6 +1003,7 @@ def Fastcomp():
       GetSrcDir('emscripten-fastcomp'),
       '-DCMAKE_CXX_FLAGS=-Wno-nonportable-include-path',
       '-DLLVM_ENABLE_LIBXML2=OFF',
+      '-DLLVM_INCLUDE_TESTS=OFF',
       '-DLLVM_INCLUDE_EXAMPLES=OFF',
       '-DLLVM_BUILD_LLVM_DYLIB=%s' % build_dylib,
       '-DLLVM_LINK_LLVM_DYLIB=%s' % build_dylib,

--- a/src/build.py
+++ b/src/build.py
@@ -85,6 +85,7 @@ LLVM_VERSION = '11.0.0'
 CLOBBER_BUILD_TAG = 15
 
 V8_BUILD_SUBDIR = os.path.join('out.gn', 'x64.release')
+V8_LINUX_SYSROOT = 'build/linux/debian_sid_amd64-sysroot'
 
 options = None
 
@@ -750,7 +751,9 @@ def CMakeCommandBase():
 
 def CMakeCommandNative(args, force_host_clang=True):
   command = CMakeCommandBase()
-  command.append('-DCMAKE_INSTALL_PREFIX=%s' % GetInstallDir())
+  command.extend(['-DCMAKE_INSTALL_PREFIX=%s' % GetInstallDir(),
+                  '-DCMAKE_SYSROOT=%s' %
+                  os.path.join(work_dirs.GetV8(), V8_LINUX_SYSROOT)])
   if force_host_clang:
     command.extend(OverrideCMakeCompiler())
     # Goma doesn't have MSVC in its cache, so don't use it in this case
@@ -818,6 +821,7 @@ def LLVM():
   command = CMakeCommandNative([
       GetLLVMSrcDir('llvm'),
       '-DCMAKE_CXX_FLAGS=-Wno-nonportable-include-path',
+      '-DLLVM_ENABLE_LIBXML2=OFF',
       '-DLLVM_INCLUDE_EXAMPLES=OFF',
       '-DCOMPILER_RT_BUILD_XRAY=OFF',
       '-DCOMPILER_RT_INCLUDE_TESTS=OFF',

--- a/src/build.py
+++ b/src/build.py
@@ -752,7 +752,7 @@ def CMakeCommandBase():
 def CMakeCommandNative(args):
   command = CMakeCommandBase()
   command.append('-DCMAKE_INSTALL_PREFIX=%s' % GetInstallDir())
-  if host_toolchains.ShouldUseSysroot():
+  if IsLinux() and host_toolchains.ShouldUseSysroot():
     command.append('-DCMAKE_SYSROOT=%s' %
                    os.path.join(work_dirs.GetV8(), V8_LINUX_SYSROOT))
   if host_toolchains.ShouldForceHostClang():

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -25,6 +25,7 @@ import work_dirs
 
 
 force_host_clang = True
+use_sysroot = True
 
 
 def SetupToolchain():
@@ -150,3 +151,12 @@ def SetForceHostClang(force):
 
 def ShouldForceHostClang():
   return force_host_clang
+
+
+def SetUseSysroot(use):
+  global use_sysroot
+  use = use_sysroot
+
+
+def ShouldUseSysroot():
+  return use_sysroot

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -155,7 +155,7 @@ def ShouldForceHostClang():
 
 def SetUseSysroot(use):
   global use_sysroot
-  use = use_sysroot
+  use_sysroot = use
 
 
 def ShouldUseSysroot():


### PR DESCRIPTION
This uses a hermetic build environment that will have broader
compatibility than whatever happens to be on the buildbots.

Also disable libxml2 in the LLVM build; for some reason CMake has trouble finding
it in the sysroot, but it's only needed for generating Windows manifests which we 
don't need.