### PR TITLE
Second attempt to convert python to 4-wide indentation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = W504,E114,E111
+ignore = W504
 exclude = ./debian,./src/work

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,3 +1,2 @@
 [style]
 based_on_style = pep8
-indent_width = 2

--- a/src/build.py
+++ b/src/build.py
@@ -801,8 +801,8 @@ def CMakeCommandNative(args):
     command.append('-DCMAKE_INSTALL_PREFIX=%s' % GetInstallDir())
     if IsLinux() and host_toolchains.ShouldUseSysroot():
         command.append('-DCMAKE_SYSROOT=%s' % GetPrebuilt(LINUX_SYSROOT))
-        command.extend('-DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++')
-        command.extend('-DCMAKE_SHARED_LINKER_FLAGS=-static-libstdc++')
+        command.append('-DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++')
+        command.append('-DCMAKE_SHARED_LINKER_FLAGS=-static-libstdc++')
 
     if host_toolchains.ShouldForceHostClang():
         command.extend(OverrideCMakeCompiler())

--- a/src/build.py
+++ b/src/build.py
@@ -41,7 +41,6 @@ import testing
 import work_dirs
 from urllib.request import urlopen, URLError
 
-
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 JSVU_OUT_DIR = os.path.expanduser(os.path.join('~', '.jsvu'))
 
@@ -96,56 +95,56 @@ options = None
 
 
 def GccTestDir():
-  return GetSrcDir('gcc', 'gcc', 'testsuite')
+    return GetSrcDir('gcc', 'gcc', 'testsuite')
 
 
 def GetBuildDir(*args):
-  return os.path.join(work_dirs.GetBuild(), *args)
+    return os.path.join(work_dirs.GetBuild(), *args)
 
 
 def GetPrebuilt(*args):
-  return os.path.join(work_dirs.GetPrebuilt(), *args)
+    return os.path.join(work_dirs.GetPrebuilt(), *args)
 
 
 def GetPrebuiltClang(binary):
-  return os.path.join(work_dirs.GetV8(), 'third_party', 'llvm-build',
-                      'Release+Asserts', 'bin', binary)
+    return os.path.join(work_dirs.GetV8(), 'third_party', 'llvm-build',
+                        'Release+Asserts', 'bin', binary)
 
 
 def GetSrcDir(*args):
-  return os.path.join(work_dirs.GetSync(), *args)
+    return os.path.join(work_dirs.GetSync(), *args)
 
 
 def GetInstallDir(*args):
-  return os.path.join(work_dirs.GetInstall(), *args)
+    return os.path.join(work_dirs.GetInstall(), *args)
 
 
 def GetTestDir(*args):
-  return os.path.join(work_dirs.GetTest(), *args)
+    return os.path.join(work_dirs.GetTest(), *args)
 
 
 def GetLLVMSrcDir(*args):
-  return GetSrcDir('llvm-project', *args)
+    return GetSrcDir('llvm-project', *args)
 
 
 def IsWindows():
-  return sys.platform == 'win32'
+    return sys.platform == 'win32'
 
 
 def IsLinux():
-  return sys.platform.startswith('linux')
+    return sys.platform.startswith('linux')
 
 
 def IsMac():
-  return sys.platform == 'darwin'
+    return sys.platform == 'darwin'
 
 
 def Executable(name, extension='.exe'):
-  return name + extension if IsWindows() else name
+    return name + extension if IsWindows() else name
 
 
 def WindowsFSEscape(path):
-  return os.path.normpath(path).replace('\\', '/')
+    return os.path.normpath(path).replace('\\', '/')
 
 
 # Use prebuilt Node.js because the buildbots don't have node preinstalled
@@ -154,63 +153,68 @@ NODE_BASE_NAME = 'node-v' + NODE_VERSION + '-'
 
 
 def NodePlatformName():
-  return {'darwin': 'darwin-x64',
-          'linux': 'linux-x64',
-          'linux2': 'linux-x64',
-          'win32': 'win-x64'}[sys.platform]
+    return {
+        'darwin': 'darwin-x64',
+        'linux': 'linux-x64',
+        'linux2': 'linux-x64',
+        'win32': 'win-x64'
+    }[sys.platform]
 
 
 def NodeBinDir():
-  node_subdir = NODE_BASE_NAME + NodePlatformName()
-  if IsWindows():
-    return GetPrebuilt(node_subdir)
-  return GetPrebuilt(node_subdir, 'bin')
+    node_subdir = NODE_BASE_NAME + NodePlatformName()
+    if IsWindows():
+        return GetPrebuilt(node_subdir)
+    return GetPrebuilt(node_subdir, 'bin')
 
 
 def NodeBin():
-  return Executable(os.path.join(NodeBinDir(), 'node'))
+    return Executable(os.path.join(NodeBinDir(), 'node'))
 
 
 def CMakePlatformName():
-  return {'linux': 'Linux',
-          'linux2': 'Linux',
-          'darwin': 'Darwin',
-          'win32': 'win64'}[sys.platform]
+    return {
+        'linux': 'Linux',
+        'linux2': 'Linux',
+        'darwin': 'Darwin',
+        'win32': 'win64'
+    }[sys.platform]
 
 
 def CMakeArch():
-  return 'x64' if IsWindows() else 'x86_64'
+    return 'x64' if IsWindows() else 'x86_64'
 
 
 PREBUILT_CMAKE_VERSION = '3.15.3'
-PREBUILT_CMAKE_BASE_NAME = 'cmake-%s-%s-%s' % (PREBUILT_CMAKE_VERSION,
-                                               CMakePlatformName(),
-                                               CMakeArch())
+PREBUILT_CMAKE_BASE_NAME = 'cmake-%s-%s-%s' % (
+    PREBUILT_CMAKE_VERSION, CMakePlatformName(), CMakeArch())
 
 
 def PrebuiltCMakeDir(*args):
-  return GetPrebuilt(PREBUILT_CMAKE_BASE_NAME, *args)
+    return GetPrebuilt(PREBUILT_CMAKE_BASE_NAME, *args)
 
 
 def PrebuiltCMakeBin():
-  if IsMac():
-    bin_dir = os.path.join('CMake.app', 'Contents', 'bin')
-  else:
-    bin_dir = 'bin'
-  return PrebuiltCMakeDir(bin_dir, 'cmake')
+    if IsMac():
+        bin_dir = os.path.join('CMake.app', 'Contents', 'bin')
+    else:
+        bin_dir = 'bin'
+    return PrebuiltCMakeDir(bin_dir, 'cmake')
 
 
 def BuilderPlatformName():
-  return {'linux': 'linux',
-          'linux2': 'linux',
-          'darwin': 'mac',
-          'win32': 'windows'}[sys.platform]
+    return {
+        'linux': 'linux',
+        'linux2': 'linux',
+        'darwin': 'mac',
+        'win32': 'windows'
+    }[sys.platform]
 
 
 def D8Bin():
-  if IsMac():
-    return os.path.join(JSVU_OUT_DIR, 'v8')
-  return Executable(GetInstallDir('bin', 'd8'))
+    if IsMac():
+        return os.path.join(JSVU_OUT_DIR, 'v8')
+    return Executable(GetInstallDir('bin', 'd8'))
 
 
 # Java installed in the buildbots are too old while emscripten uses closure
@@ -219,55 +223,59 @@ JAVA_VERSION = '9.0.1'
 
 
 def JavaDir():
-  outdir = GetPrebuilt('jre-' + JAVA_VERSION)
-  if IsMac():
-    outdir += '.jre'
-  return outdir
+    outdir = GetPrebuilt('jre-' + JAVA_VERSION)
+    if IsMac():
+        outdir += '.jre'
+    return outdir
 
 
 def JavaBin():
-  if IsMac():
-    bin_dir = os.path.join('Contents', 'Home', 'bin')
-  else:
-    bin_dir = 'bin'
-  return Executable(os.path.join(JavaDir(), bin_dir, 'java'))
+    if IsMac():
+        bin_dir = os.path.join('Contents', 'Home', 'bin')
+    else:
+        bin_dir = 'bin'
+    return Executable(os.path.join(JavaDir(), bin_dir, 'java'))
 
 
 # Known failures.
 IT_IS_KNOWN = 'known_gcc_test_failures.txt'
-ASM2WASM_KNOWN_TORTURE_COMPILE_FAILURES = [os.path.join(
-    SCRIPT_DIR, 'test', 'asm2wasm_compile_' + IT_IS_KNOWN)]
-EMWASM_KNOWN_TORTURE_COMPILE_FAILURES = [os.path.join(
-    SCRIPT_DIR, 'test', 'emwasm_compile_' + IT_IS_KNOWN)]
+ASM2WASM_KNOWN_TORTURE_COMPILE_FAILURES = [
+    os.path.join(SCRIPT_DIR, 'test', 'asm2wasm_compile_' + IT_IS_KNOWN)
+]
+EMWASM_KNOWN_TORTURE_COMPILE_FAILURES = [
+    os.path.join(SCRIPT_DIR, 'test', 'emwasm_compile_' + IT_IS_KNOWN)
+]
 
-RUN_KNOWN_TORTURE_FAILURES = [os.path.join(SCRIPT_DIR, 'test',
-                                           'run_' + IT_IS_KNOWN)]
-LLD_KNOWN_TORTURE_FAILURES = [os.path.join(SCRIPT_DIR, 'test',
-                              'lld_' + IT_IS_KNOWN)]
+RUN_KNOWN_TORTURE_FAILURES = [
+    os.path.join(SCRIPT_DIR, 'test', 'run_' + IT_IS_KNOWN)
+]
+LLD_KNOWN_TORTURE_FAILURES = [
+    os.path.join(SCRIPT_DIR, 'test', 'lld_' + IT_IS_KNOWN)
+]
 
 # Exclusions (known failures are compiled and run, and expected to fail,
 # whereas exclusions are not even run, e.g. because they have UB which
 # results in infinite loops)
-LLVM_TORTURE_EXCLUSIONS = [os.path.join(SCRIPT_DIR, 'test',
-                                        'llvm_torture_exclusions')]
+LLVM_TORTURE_EXCLUSIONS = [
+    os.path.join(SCRIPT_DIR, 'test', 'llvm_torture_exclusions')
+]
 
-RUN_LLVM_TESTSUITE_FAILURES = [os.path.join(SCRIPT_DIR, 'test',
-                                            'llvmtest_known_failures.txt')]
+RUN_LLVM_TESTSUITE_FAILURES = [
+    os.path.join(SCRIPT_DIR, 'test', 'llvmtest_known_failures.txt')
+]
 
 # Optimization levels
 BARE_TEST_OPT_FLAGS = ['O0', 'O2']
 EMSCRIPTEN_TEST_OPT_FLAGS = ['O0', 'O3']
 
-
 NPROC = multiprocessing.cpu_count()
 
-
 if IsMac():
-  # Experimental temp fix for crbug.com/829034 stdout write sometimes fails
-  from fcntl import fcntl, F_GETFL, F_SETFL
-  fd = sys.stdout.fileno()
-  flags = fcntl(fd, F_GETFL)
-  fcntl(fd, F_SETFL, flags & ~os.O_NONBLOCK)
+    # Experimental temp fix for crbug.com/829034 stdout write sometimes fails
+    from fcntl import fcntl, F_GETFL, F_SETFL
+    fd = sys.stdout.fileno()
+    flags = fcntl(fd, F_GETFL)
+    fcntl(fd, F_SETFL, flags & ~os.O_NONBLOCK)
 
 # Pin the GCC revision so that new torture tests don't break the bot. This
 # should be manually updated when convenient.
@@ -276,1424 +284,1499 @@ GCC_CLONE_DEPTH = 1000
 
 
 def CopyBinaryToArchive(binary, prefix=''):
-  """All binaries are archived in the same tar file."""
-  install_bin = GetInstallDir(prefix, 'bin')
-  print('Copying binary %s to archive %s' % (binary, install_bin))
-  Mkdir(install_bin)
-  shutil.copy2(binary, install_bin)
+    """All binaries are archived in the same tar file."""
+    install_bin = GetInstallDir(prefix, 'bin')
+    print('Copying binary %s to archive %s' % (binary, install_bin))
+    Mkdir(install_bin)
+    shutil.copy2(binary, install_bin)
 
 
 def CopyLibraryToArchive(library, prefix=''):
-  """All libraries are archived in the same tar file."""
-  install_lib = GetInstallDir(prefix, 'lib')
-  print('Copying library %s to archive %s' % (library, install_lib))
-  Mkdir(install_lib)
-  shutil.copy2(library, install_lib)
+    """All libraries are archived in the same tar file."""
+    install_lib = GetInstallDir(prefix, 'lib')
+    print('Copying library %s to archive %s' % (library, install_lib))
+    Mkdir(install_lib)
+    shutil.copy2(library, install_lib)
 
 
 def CopyLibraryToSysroot(library):
-  """All libraries are archived in the same tar file."""
-  install_lib = GetInstallDir('sysroot', 'lib', 'wasm32-wasi')
-  print('Copying library %s to archive %s' % (library, install_lib))
-  Mkdir(install_lib)
-  shutil.copy2(library, install_lib)
+    """All libraries are archived in the same tar file."""
+    install_lib = GetInstallDir('sysroot', 'lib', 'wasm32-wasi')
+    print('Copying library %s to archive %s' % (library, install_lib))
+    Mkdir(install_lib)
+    shutil.copy2(library, install_lib)
 
 
 def Archive(directory, print_content=False):
-  """Create an archive file from directory."""
-  # Use the format "native" to the platform
-  if IsWindows():
-    return Zip(directory, print_content)
-  return Tar(directory, print_content)
+    """Create an archive file from directory."""
+    # Use the format "native" to the platform
+    if IsWindows():
+        return Zip(directory, print_content)
+    return Tar(directory, print_content)
 
 
 def Tar(directory, print_content=False):
-  assert os.path.isdir(directory), 'Must tar a directory to avoid tarbombs'
-  up_directory, basename = os.path.split(directory)
-  tar = os.path.join(up_directory, basename + '.tbz2')
-  Remove(tar)
-  if print_content:
-    proc.check_call(['find', basename, '-type', 'f',
-                     '-exec', 'ls', '-lhS', '{}', '+'], cwd=up_directory)
-  proc.check_call(['tar', 'cjf', tar, basename], cwd=up_directory)
-  proc.check_call(['ls', '-lh', tar], cwd=up_directory)
-  return tar
+    assert os.path.isdir(directory), 'Must tar a directory to avoid tarbombs'
+    up_directory, basename = os.path.split(directory)
+    tar = os.path.join(up_directory, basename + '.tbz2')
+    Remove(tar)
+    if print_content:
+        proc.check_call(
+            ['find', basename, '-type', 'f', '-exec', 'ls', '-lhS', '{}', '+'],
+            cwd=up_directory)
+    proc.check_call(['tar', 'cjf', tar, basename], cwd=up_directory)
+    proc.check_call(['ls', '-lh', tar], cwd=up_directory)
+    return tar
 
 
 def Zip(directory, print_content=False):
-  assert os.path.isdir(directory), 'Must be a directory'
-  dirname, basename = os.path.split(directory)
-  archive = os.path.join(dirname, basename + '.zip')
-  print('Creating zip archive', archive)
-  with zipfile.ZipFile(archive, 'w', zipfile.ZIP_DEFLATED) as z:
-    for root, dirs, files in os.walk(directory):
-      for name in files:
-        fs_path = os.path.join(root, name)
-        zip_path = os.path.relpath(fs_path, os.path.dirname(directory))
-        if print_content:
-          print('Adding', fs_path)
-        z.write(fs_path, zip_path)
-  print('Size:', os.stat(archive).st_size)
-  return archive
+    assert os.path.isdir(directory), 'Must be a directory'
+    dirname, basename = os.path.split(directory)
+    archive = os.path.join(dirname, basename + '.zip')
+    print('Creating zip archive', archive)
+    with zipfile.ZipFile(archive, 'w', zipfile.ZIP_DEFLATED) as z:
+        for root, dirs, files in os.walk(directory):
+            for name in files:
+                fs_path = os.path.join(root, name)
+                zip_path = os.path.relpath(fs_path, os.path.dirname(directory))
+                if print_content:
+                    print('Adding', fs_path)
+                z.write(fs_path, zip_path)
+    print('Size:', os.stat(archive).st_size)
+    return archive
 
 
 def UploadFile(local_name, remote_name):
-  """Archive the file with the given name, and with the LLVM git hash."""
-  if not buildbot.IsUploadingBot():
-    return
-  buildbot.Link('download', cloud.Upload(local_name, '%s/%s/%s' % (
-      buildbot.BuilderName(), buildbot.BuildNumber(), remote_name)))
+    """Archive the file with the given name, and with the LLVM git hash."""
+    if not buildbot.IsUploadingBot():
+        return
+    buildbot.Link(
+        'download',
+        cloud.Upload(
+            local_name, '%s/%s/%s' %
+            (buildbot.BuilderName(), buildbot.BuildNumber(), remote_name)))
 
 
 def UploadArchive(name, archive):
-  """Archive the tar/zip file with the given name and the build number."""
-  if not buildbot.IsUploadingBot():
-    return
-  extension = os.path.splitext(archive)[1]
-  UploadFile(archive, 'wasm-%s%s' % (name, extension))
+    """Archive the tar/zip file with the given name and the build number."""
+    if not buildbot.IsUploadingBot():
+        return
+    extension = os.path.splitext(archive)[1]
+    UploadFile(archive, 'wasm-%s%s' % (name, extension))
 
 
 # Repo and subproject utilities
 
+
 def GitRemoteUrl(cwd, remote):
-  """Get the URL of a remote."""
-  return proc.check_output(
-      ['git', 'config', '--get', 'remote.%s.url' % remote], cwd=cwd).strip()
+    """Get the URL of a remote."""
+    return proc.check_output(
+        ['git', 'config', '--get',
+         'remote.%s.url' % remote], cwd=cwd).strip()
 
 
 def RemoteBranch(branch):
-  """Get the remote-qualified branch name to use for waterfall"""
-  return WATERFALL_REMOTE + '/' + branch
+    """Get the remote-qualified branch name to use for waterfall"""
+    return WATERFALL_REMOTE + '/' + branch
 
 
 def GitUpdateRemote(src_dir, git_repo, remote_name):
-  try:
-    proc.check_call(
-        ['git', 'remote', 'set-url', remote_name, git_repo], cwd=src_dir)
-  except proc.CalledProcessError:
-    # If proc.check_call fails it throws an exception. 'git remote set-url'
-    # fails when the remote doesn't exist, so we should try to add it.
-    proc.check_call(
-        ['git', 'remote', 'add', remote_name, git_repo], cwd=src_dir)
+    try:
+        proc.check_call(['git', 'remote', 'set-url', remote_name, git_repo],
+                        cwd=src_dir)
+    except proc.CalledProcessError:
+        # If proc.check_call fails it throws an exception. 'git remote set-url'
+        # fails when the remote doesn't exist, so we should try to add it.
+        proc.check_call(['git', 'remote', 'add', remote_name, git_repo],
+                        cwd=src_dir)
 
 
 class Filter(object):
-  """Filter for source or build rules, to allow including or excluding only
+    """Filter for source or build rules, to allow including or excluding only
      selected targets.
-  """
-  def __init__(self, name=None, include=None, exclude=None):
     """
-    include:
-      if present, only items in it will be included (if empty, nothing will
-      be included).
-    exclude:
-      if present, items in it will be excluded.
-      include ane exclude cannot both be present.
-    """
-    if include and exclude:
-      raise Exception('Filter cannot include both include and exclude rules')
+    def __init__(self, name=None, include=None, exclude=None):
+        """
+        include:
+          if present, only items in it will be included (if empty, nothing will
+          be included).
+        exclude:
+          if present, items in it will be excluded.
+          include ane exclude cannot both be present.
+        """
+        if include and exclude:
+            raise Exception(
+                'Filter cannot include both include and exclude rules')
 
-    self.name = name
-    self.include = include
-    self.exclude = exclude
+        self.name = name
+        self.include = include
+        self.exclude = exclude
 
-  def Apply(self, targets):
-    """Return the filtered list of targets."""
-    all_names = [t.name for t in targets]
-    specified_names = self.include or self.exclude or []
-    missing_names = [i for i in specified_names if i not in all_names]
-    if missing_names:
-      raise Exception('Invalid step name(s): {0}\n\n'
-                      'Valid {1} steps:\n{2}'
-                      .format(missing_names, self.name,
-                              TextWrapNameList(prefix='', items=targets)))
+    def Apply(self, targets):
+        """Return the filtered list of targets."""
+        all_names = [t.name for t in targets]
+        specified_names = self.include or self.exclude or []
+        missing_names = [i for i in specified_names if i not in all_names]
+        if missing_names:
+            raise Exception('Invalid step name(s): {0}\n\n'
+                            'Valid {1} steps:\n{2}'.format(
+                                missing_names, self.name,
+                                TextWrapNameList(prefix='', items=targets)))
 
-    return [t for t in targets if self.Check(t.name)]
+        return [t for t in targets if self.Check(t.name)]
 
-  def Check(self, target):
-    """Return true if the specified target will be run."""
-    if self.include is not None:
-      return target in self.include
+    def Check(self, target):
+        """Return true if the specified target will be run."""
+        if self.include is not None:
+            return target in self.include
 
-    if self.exclude is not None:
-      return target not in self.exclude
-    return True
+        if self.exclude is not None:
+            return target not in self.exclude
+        return True
 
-  def All(self):
-    """Return true if all possible targets will be run."""
-    return self.include is None and not self.exclude
+    def All(self):
+        """Return true if all possible targets will be run."""
+        return self.include is None and not self.exclude
 
-  def Any(self):
-    """Return true if any targets can be run."""
-    return self.include is None or len(self.include)
+    def Any(self):
+        """Return true if any targets can be run."""
+        return self.include is None or len(self.include)
 
 
 class Source(object):
-  """Metadata about a sync-able source repo on the waterfall"""
-  def __init__(self, name, src_dir, git_repo,
-               checkout=RemoteBranch('master'), depth=None,
-               custom_sync=None, os_filter=None):
-    self.name = name
-    self.src_dir = src_dir
-    self.git_repo = git_repo
-    self.checkout = checkout
-    self.depth = depth
-    self.custom_sync = custom_sync
-    self.os_filter = os_filter
+    """Metadata about a sync-able source repo on the waterfall"""
+    def __init__(self,
+                 name,
+                 src_dir,
+                 git_repo,
+                 checkout=RemoteBranch('master'),
+                 depth=None,
+                 custom_sync=None,
+                 os_filter=None):
+        self.name = name
+        self.src_dir = src_dir
+        self.git_repo = git_repo
+        self.checkout = checkout
+        self.depth = depth
+        self.custom_sync = custom_sync
+        self.os_filter = os_filter
 
-    # Ensure that git URLs end in .git.  We have had issues in the past where
-    # github would not recognize the requests correctly otherwise due to
-    # chromium's builders setting custom GIT_USER_AGENT:
-    # https://bugs.chromium.org/p/chromium/issues/detail?id=711775
-    if git_repo:
-      assert git_repo.endswith('.git'), 'Git URLs should end in .git'
+        # Ensure that git URLs end in .git.  We have had issues in the past
+        # where github would not recognize the requests correctly otherwise due
+        # to chromium's builders setting custom GIT_USER_AGENT:
+        # https://bugs.chromium.org/p/chromium/issues/detail?id=711775
+        if git_repo:
+            assert git_repo.endswith('.git'), 'Git URLs should end in .git'
 
-  def Sync(self, good_hashes=None):
-    if self.os_filter and not self.os_filter.Check(BuilderPlatformName()):
-      print("Skipping %s: Doesn't work on %s" % (self.name,
-                                                 BuilderPlatformName()))
-      return
-    if good_hashes and good_hashes.get(self.name):
-      self.checkout = good_hashes[self.name]
-    if self.custom_sync:
-      self.custom_sync(self.name, self.src_dir, self.git_repo)
-    else:
-      self.GitCloneFetchCheckout()
+    def Sync(self, good_hashes=None):
+        if self.os_filter and not self.os_filter.Check(BuilderPlatformName()):
+            print("Skipping %s: Doesn't work on %s" %
+                  (self.name, BuilderPlatformName()))
+            return
+        if good_hashes and good_hashes.get(self.name):
+            self.checkout = good_hashes[self.name]
+        if self.custom_sync:
+            self.custom_sync(self.name, self.src_dir, self.git_repo)
+        else:
+            self.GitCloneFetchCheckout()
 
-  def GitCloneFetchCheckout(self):
-    """Clone a git repo if not already cloned, then fetch and checkout."""
-    if os.path.isdir(self.src_dir):
-      print('%s directory already exists' % self.name)
-    else:
-      clone = ['clone', self.git_repo, self.src_dir]
-      if self.depth:
-        clone.append('--depth')
-        clone.append(str(self.depth))
-      proc.check_call(['git'] + clone)
+    def GitCloneFetchCheckout(self):
+        """Clone a git repo if not already cloned, then fetch and checkout."""
+        if os.path.isdir(self.src_dir):
+            print('%s directory already exists' % self.name)
+        else:
+            clone = ['clone', self.git_repo, self.src_dir]
+            if self.depth:
+                clone.append('--depth')
+                clone.append(str(self.depth))
+            proc.check_call(['git'] + clone)
 
-    GitUpdateRemote(self.src_dir, self.git_repo, WATERFALL_REMOTE)
-    proc.check_call(['git', 'fetch', '--tags', WATERFALL_REMOTE],
-                    cwd=self.src_dir)
-    if not self.checkout.startswith(WATERFALL_REMOTE + '/'):
-      sys.stderr.write(('WARNING: `git checkout %s` not based on waterfall '
-                        'remote (%s), checking out local branch'
-                        % (self.checkout, WATERFALL_REMOTE)))
-    proc.check_call(['git', 'checkout', self.checkout],
-                    cwd=self.src_dir)
-    proc.check_call(['git', 'submodule', 'update', '--init'], cwd=self.src_dir)
+        GitUpdateRemote(self.src_dir, self.git_repo, WATERFALL_REMOTE)
+        proc.check_call(['git', 'fetch', '--tags', WATERFALL_REMOTE],
+                        cwd=self.src_dir)
+        if not self.checkout.startswith(WATERFALL_REMOTE + '/'):
+            sys.stderr.write(
+                ('WARNING: `git checkout %s` not based on waterfall '
+                 'remote (%s), checking out local branch' %
+                 (self.checkout, WATERFALL_REMOTE)))
+        proc.check_call(['git', 'checkout', self.checkout], cwd=self.src_dir)
+        proc.check_call(['git', 'submodule', 'update', '--init'],
+                        cwd=self.src_dir)
 
-  def CurrentGitInfo(self):
-    if not os.path.exists(self.src_dir):
-      return None
+    def CurrentGitInfo(self):
+        if not os.path.exists(self.src_dir):
+            return None
 
-    def pretty(fmt):
-      return proc.check_output(
-          ['git', 'log', '-n1', '--pretty=format:%s' % fmt],
-          cwd=self.src_dir).strip()
-    try:
-      remote = GitRemoteUrl(self.src_dir, WATERFALL_REMOTE)
-    except proc.CalledProcessError:
-      # Not all checkouts have the '_waterfall' remote (e.g. the waterfall
-      # itself) so fall back to origin on failure
-      remote = GitRemoteUrl(self.src_dir, 'origin')
+        def pretty(fmt):
+            return proc.check_output(
+                ['git', 'log', '-n1',
+                 '--pretty=format:%s' % fmt],
+                cwd=self.src_dir).strip()
 
-    return {
-        'hash': pretty('%H'),
-        'name': pretty('%aN'),
-        'email': pretty('%ae'),
-        'subject': pretty('%s'),
-        'remote': remote,
-    }
+        try:
+            remote = GitRemoteUrl(self.src_dir, WATERFALL_REMOTE)
+        except proc.CalledProcessError:
+            # Not all checkouts have the '_waterfall' remote (e.g. the
+            # waterfall itself) so fall back to origin on failure
+            remote = GitRemoteUrl(self.src_dir, 'origin')
 
-  def PrintGitStatus(self):
-    """"Print the current git status for the sync target."""
-    print('<<<<<<<<<< STATUS FOR', self.name, '>>>>>>>>>>')
-    if os.path.exists(self.src_dir):
-      proc.check_call(['git', 'status'], cwd=self.src_dir)
-    print()
+        return {
+            'hash': pretty('%H'),
+            'name': pretty('%aN'),
+            'email': pretty('%ae'),
+            'subject': pretty('%s'),
+            'remote': remote,
+        }
+
+    def PrintGitStatus(self):
+        """"Print the current git status for the sync target."""
+        print('<<<<<<<<<< STATUS FOR', self.name, '>>>>>>>>>>')
+        if os.path.exists(self.src_dir):
+            proc.check_call(['git', 'status'], cwd=self.src_dir)
+        print()
 
 
-def ChromiumFetchSync(name, work_dir, git_repo,
+def ChromiumFetchSync(name,
+                      work_dir,
+                      git_repo,
                       checkout=RemoteBranch('master')):
-  """Some Chromium projects want to use gclient for clone and dependencies."""
-  if os.path.isdir(work_dir):
-    print('%s directory already exists' % name)
-  else:
-    # Create Chromium repositories one deeper, separating .gclient files.
-    parent = os.path.split(work_dir)[0]
-    Mkdir(parent)
-    proc.check_call(['gclient', 'config', git_repo], cwd=parent)
-    proc.check_call(['git', 'clone', git_repo], cwd=parent)
+    """Some Chromium projects want to use gclient for clone and
+    dependencies."""
+    if os.path.isdir(work_dir):
+        print('%s directory already exists' % name)
+    else:
+        # Create Chromium repositories one deeper, separating .gclient files.
+        parent = os.path.split(work_dir)[0]
+        Mkdir(parent)
+        proc.check_call(['gclient', 'config', git_repo], cwd=parent)
+        proc.check_call(['git', 'clone', git_repo], cwd=parent)
 
-  GitUpdateRemote(work_dir, git_repo, WATERFALL_REMOTE)
-  proc.check_call(['git', 'fetch', WATERFALL_REMOTE], cwd=work_dir)
-  proc.check_call(['git', 'checkout', checkout], cwd=work_dir)
-  proc.check_call(['gclient', 'sync'], cwd=work_dir)
-  return (name, work_dir)
+    GitUpdateRemote(work_dir, git_repo, WATERFALL_REMOTE)
+    proc.check_call(['git', 'fetch', WATERFALL_REMOTE], cwd=work_dir)
+    proc.check_call(['git', 'checkout', checkout], cwd=work_dir)
+    proc.check_call(['gclient', 'sync'], cwd=work_dir)
+    return (name, work_dir)
 
 
 def SyncToolchain(name, src_dir, git_repo):
-  if IsWindows():
-    host_toolchains.SyncWinToolchain()
-  else:
-    host_toolchains.SyncPrebuiltClang(name, src_dir)
-    cc = GetPrebuiltClang('clang')
-    cxx = GetPrebuiltClang('clang++')
-    assert os.path.isfile(cc), 'Expect clang at %s' % cc
-    assert os.path.isfile(cxx), 'Expect clang++ at %s' % cxx
+    if IsWindows():
+        host_toolchains.SyncWinToolchain()
+    else:
+        host_toolchains.SyncPrebuiltClang(name, src_dir)
+        cc = GetPrebuiltClang('clang')
+        cxx = GetPrebuiltClang('clang++')
+        assert os.path.isfile(cc), 'Expect clang at %s' % cc
+        assert os.path.isfile(cxx), 'Expect clang++ at %s' % cxx
 
 
 def SyncArchive(out_dir, name, url, create_out_dir=False):
-  """Download and extract an archive (zip, tar.gz or tar.xz) file from a URL.
+    """Download and extract an archive (zip, tar.gz or tar.xz) file from a URL.
 
-  The extraction happens in the prebuilt dir. If create_out_dir is True,
-  out_dir will be created and the archive will be extracted inside. Otherwise
-  the archive is expected to contain a top-level directory with all the files;
-  this is expected to be 'out_dir', so if 'out_dir' already exists then the
-  download will be skipped.
-  """
-  stamp_file = os.path.join(out_dir, 'stamp.txt')
-  if os.path.isdir(out_dir):
-    if os.path.isfile(stamp_file):
-      with open(stamp_file) as f:
-        stamp_url = f.read().strip()
-      if stamp_url == url:
-        print('%s directory already exists' % name)
-        return
-    print('%s directory exists but is not up-to-date' % name)
-  print('Downloading %s from %s' % (name, url))
+    The extraction happens in the prebuilt dir. If create_out_dir is True,
+    out_dir will be created and the archive will be extracted inside. Otherwise
+    the archive is expected to contain a top-level directory with all the
+    files; this is expected to be 'out_dir', so if 'out_dir' already exists
+    then the download will be skipped.
+    """
+    stamp_file = os.path.join(out_dir, 'stamp.txt')
+    if os.path.isdir(out_dir):
+        if os.path.isfile(stamp_file):
+            with open(stamp_file) as f:
+                stamp_url = f.read().strip()
+            if stamp_url == url:
+                print('%s directory already exists' % name)
+                return
+        print('%s directory exists but is not up-to-date' % name)
+    print('Downloading %s from %s' % (name, url))
 
-  if create_out_dir:
-    os.makedirs(out_dir)
-    work_dir = out_dir
-  else:
-    work_dir = os.path.dirname(out_dir)
+    if create_out_dir:
+        os.makedirs(out_dir)
+        work_dir = out_dir
+    else:
+        work_dir = os.path.dirname(out_dir)
 
-  try:
-    f = urlopen(url)
-    print('URL: %s' % f.geturl())
-    print('Info: %s' % f.info())
-    with tempfile.NamedTemporaryFile() as t:
-      t.write(f.read())
-      t.flush()
-      t.seek(0)
-      print('Extracting into %s' % work_dir)
-      ext = os.path.splitext(url)[-1]
-      if ext == '.zip':
-        with zipfile.ZipFile(t, 'r') as zip:
-          zip.extractall(path=work_dir)
-      elif ext == '.xz':
-        proc.check_call(['tar', '-xvf', t.name], cwd=work_dir)
-      else:
-        tarfile.open(fileobj=t).extractall(path=work_dir)
-  except URLError as e:
-    print('Error downloading %s: %s' % (url, e))
-    raise
+    try:
+        f = urlopen(url)
+        print('URL: %s' % f.geturl())
+        print('Info: %s' % f.info())
+        with tempfile.NamedTemporaryFile() as t:
+            t.write(f.read())
+            t.flush()
+            t.seek(0)
+            print('Extracting into %s' % work_dir)
+            ext = os.path.splitext(url)[-1]
+            if ext == '.zip':
+                with zipfile.ZipFile(t, 'r') as zip:
+                    zip.extractall(path=work_dir)
+            elif ext == '.xz':
+                proc.check_call(['tar', '-xvf', t.name], cwd=work_dir)
+            else:
+                tarfile.open(fileobj=t).extractall(path=work_dir)
+    except URLError as e:
+        print('Error downloading %s: %s' % (url, e))
+        raise
 
-  with open(stamp_file, 'w') as f:
-    f.write(url + '\n')
+    with open(stamp_file, 'w') as f:
+        f.write(url + '\n')
 
 
 def SyncPrebuiltCMake(name, src_dir, git_repo):
-  extension = '.zip' if IsWindows() else '.tar.gz'
-  url = WASM_STORAGE_BASE + PREBUILT_CMAKE_BASE_NAME + extension
-  SyncArchive(PrebuiltCMakeDir(), 'cmake', url)
+    extension = '.zip' if IsWindows() else '.tar.gz'
+    url = WASM_STORAGE_BASE + PREBUILT_CMAKE_BASE_NAME + extension
+    SyncArchive(PrebuiltCMakeDir(), 'cmake', url)
 
 
 def SyncPrebuiltNodeJS(name, src_dir, git_repo):
-  extension = {'darwin': 'tar.xz',
-               'linux': 'tar.xz',
-               'win32': 'zip'}[sys.platform]
-  out_dir = GetPrebuilt(NODE_BASE_NAME + NodePlatformName())
-  tarball = NODE_BASE_NAME + NodePlatformName() + '.' + extension
-  node_url = WASM_STORAGE_BASE + tarball
-  return SyncArchive(out_dir, name, node_url)
+    extension = {
+        'darwin': 'tar.xz',
+        'linux': 'tar.xz',
+        'win32': 'zip'
+    }[sys.platform]
+    out_dir = GetPrebuilt(NODE_BASE_NAME + NodePlatformName())
+    tarball = NODE_BASE_NAME + NodePlatformName() + '.' + extension
+    node_url = WASM_STORAGE_BASE + tarball
+    return SyncArchive(out_dir, name, node_url)
 
 
 # Utilities needed for running LLVM regression tests on Windows
 def SyncGNUWin32(name, src_dir, git_repo):
-  if not IsWindows():
-    return
-  url = WASM_STORAGE_BASE + GNUWIN32_ZIP
-  return SyncArchive(GetPrebuilt('gnuwin32'), name, url)
+    if not IsWindows():
+        return
+    url = WASM_STORAGE_BASE + GNUWIN32_ZIP
+    return SyncArchive(GetPrebuilt('gnuwin32'), name, url)
 
 
 def SyncPrebuiltJava(name, src_dir, git_repo):
-  platform = {'linux': 'linux', 'linux2': 'linux', 'darwin': 'osx',
-              'win32': 'windows'}[sys.platform]
-  tarball = 'jre-' + JAVA_VERSION + '_' + platform + '-x64_bin.tar.gz'
-  java_url = WASM_STORAGE_BASE + tarball
-  SyncArchive(JavaDir(), name, java_url)
+    platform = {
+        'linux': 'linux',
+        'linux2': 'linux',
+        'darwin': 'osx',
+        'win32': 'windows'
+    }[sys.platform]
+    tarball = 'jre-' + JAVA_VERSION + '_' + platform + '-x64_bin.tar.gz'
+    java_url = WASM_STORAGE_BASE + tarball
+    SyncArchive(JavaDir(), name, java_url)
 
 
 def SyncLinuxSysroot(name, src_dir, git_repo):
-  if not (IsLinux() and host_toolchains.ShouldUseSysroot()):
-    return
-  SyncArchive(GetPrebuilt(LINUX_SYSROOT), name, LINUX_SYSROOT_URL,
-              create_out_dir=True)
+    if not (IsLinux() and host_toolchains.ShouldUseSysroot()):
+        return
+    SyncArchive(GetPrebuilt(LINUX_SYSROOT),
+                name,
+                LINUX_SYSROOT_URL,
+                create_out_dir=True)
 
 
 def NoSync(*args):
-  pass
+    pass
 
 
 def AllSources():
-  return [
-      Source('waterfall', SCRIPT_DIR, None, custom_sync=NoSync),
-      Source('llvm', GetSrcDir('llvm-project'),
-             LLVM_GIT_BASE + 'llvm-project.git'),
-      Source('llvm-test-suite', GetSrcDir('llvm-test-suite'),
-             LLVM_MIRROR_BASE + 'llvm-test-suite.git'),
-      Source('emscripten', GetSrcDir('emscripten'),
-             EMSCRIPTEN_GIT_BASE + 'emscripten.git'),
-      Source('fastcomp', GetSrcDir('emscripten-fastcomp'),
-             EMSCRIPTEN_GIT_BASE + 'emscripten-fastcomp.git'),
-      Source('fastcomp-clang',
-             GetSrcDir('emscripten-fastcomp-clang'),
-             EMSCRIPTEN_GIT_BASE + 'emscripten-fastcomp-clang.git'),
-      Source('gcc', GetSrcDir('gcc'),
-             GIT_MIRROR_BASE + 'chromiumos/third_party/gcc.git',
-             checkout=GCC_REVISION, depth=GCC_CLONE_DEPTH),
-      Source('v8', work_dirs.GetV8(),
-             GIT_MIRROR_BASE + 'v8/v8.git',
-             custom_sync=ChromiumFetchSync),
-      Source('host-toolchain', work_dirs.GetV8(), '',
-             custom_sync=SyncToolchain),
-      Source('cmake', '', '',  # The source and git args are ignored.
-             custom_sync=SyncPrebuiltCMake),
-      Source('nodejs', '', '',  # The source and git args are ignored.
-             custom_sync=SyncPrebuiltNodeJS),
-      Source('gnuwin32', '', '',  # The source and git args are ignored.
-             custom_sync=SyncGNUWin32),
-      Source('wabt', GetSrcDir('wabt'),
-             WASM_GIT_BASE + 'wabt.git'),
-      Source('binaryen', GetSrcDir('binaryen'),
-             WASM_GIT_BASE + 'binaryen.git'),
-      Source('wasi-libc', GetSrcDir('wasi-libc'),
-             'https://github.com/CraneStation/wasi-libc.git'),
-      Source('java', '', '',  # The source and git args are ignored.
-             custom_sync=SyncPrebuiltJava),
-      Source('sysroot', '', '',  # The source and git args are ignored.
-             custom_sync=SyncLinuxSysroot)
-  ]
+    return [
+        Source('waterfall', SCRIPT_DIR, None, custom_sync=NoSync),
+        Source('llvm', GetSrcDir('llvm-project'),
+               LLVM_GIT_BASE + 'llvm-project.git'),
+        Source('llvm-test-suite', GetSrcDir('llvm-test-suite'),
+               LLVM_MIRROR_BASE + 'llvm-test-suite.git'),
+        Source('emscripten', GetSrcDir('emscripten'),
+               EMSCRIPTEN_GIT_BASE + 'emscripten.git'),
+        Source('fastcomp', GetSrcDir('emscripten-fastcomp'),
+               EMSCRIPTEN_GIT_BASE + 'emscripten-fastcomp.git'),
+        Source('fastcomp-clang', GetSrcDir('emscripten-fastcomp-clang'),
+               EMSCRIPTEN_GIT_BASE + 'emscripten-fastcomp-clang.git'),
+        Source('gcc',
+               GetSrcDir('gcc'),
+               GIT_MIRROR_BASE + 'chromiumos/third_party/gcc.git',
+               checkout=GCC_REVISION,
+               depth=GCC_CLONE_DEPTH),
+        Source('v8',
+               work_dirs.GetV8(),
+               GIT_MIRROR_BASE + 'v8/v8.git',
+               custom_sync=ChromiumFetchSync),
+        Source('host-toolchain',
+               work_dirs.GetV8(),
+               '',
+               custom_sync=SyncToolchain),
+        Source('cmake',
+               '',
+               '',  # The source and git args are ignored.
+               custom_sync=SyncPrebuiltCMake),
+        Source('nodejs',
+               '',
+               '',  # The source and git args are ignored.
+               custom_sync=SyncPrebuiltNodeJS),
+        Source('gnuwin32',
+               '',
+               '',  # The source and git args are ignored.
+               custom_sync=SyncGNUWin32),
+        Source('wabt', GetSrcDir('wabt'), WASM_GIT_BASE + 'wabt.git'),
+        Source('binaryen', GetSrcDir('binaryen'),
+               WASM_GIT_BASE + 'binaryen.git'),
+        Source('wasi-libc', GetSrcDir('wasi-libc'),
+               'https://github.com/CraneStation/wasi-libc.git'),
+        Source('java',
+               '',
+               '',  # The source and git args are ignored.
+               custom_sync=SyncPrebuiltJava),
+        Source('sysroot',
+               '',
+               '',  # The source and git args are ignored.
+               custom_sync=SyncLinuxSysroot)
+    ]
 
 
 def Clobber():
-  # Don't automatically clobber non-bot (local) work directories
-  if not buildbot.IsBot() and not options.clobber:
-    return
+    # Don't automatically clobber non-bot (local) work directories
+    if not buildbot.IsBot() and not options.clobber:
+        return
 
-  clobber = options.clobber or buildbot.ShouldClobber()
-  clobber_file = GetBuildDir('clobber_version.txt')
-  if not clobber:
-    if not os.path.exists(clobber_file):
-      print('Clobber file %s does not exist.' % clobber_file)
-      clobber = True
+    clobber = options.clobber or buildbot.ShouldClobber()
+    clobber_file = GetBuildDir('clobber_version.txt')
+    if not clobber:
+        if not os.path.exists(clobber_file):
+            print('Clobber file %s does not exist.' % clobber_file)
+            clobber = True
+        else:
+            existing_tag = int(open(clobber_file).read().strip())
+            if existing_tag != CLOBBER_BUILD_TAG:
+                print('Clobber file %s has tag %s.' %
+                      (clobber_file, existing_tag))
+                clobber = True
+
+    if not clobber:
+        return
+
+    buildbot.Step('Clobbering work dir')
+    if buildbot.IsEmscriptenReleasesBot() or not buildbot.IsBot():
+        # Never clear source dirs locally.
+        # On emscripten-releases, depot_tools and the recipe clear the rest.
+        dirs = [work_dirs.GetBuild()]
     else:
-      existing_tag = int(open(clobber_file).read().strip())
-      if existing_tag != CLOBBER_BUILD_TAG:
-        print('Clobber file %s has tag %s.' % (clobber_file, existing_tag))
-        clobber = True
-
-  if not clobber:
-    return
-
-  buildbot.Step('Clobbering work dir')
-  if buildbot.IsEmscriptenReleasesBot() or not buildbot.IsBot():
-    # Never clear source dirs locally.
-    # On emscripten-releases, depot_tools and the recipe clear the rest.
-    dirs = [work_dirs.GetBuild()]
-  else:
-    dirs = work_dirs.GetAll()
-  for work_dir in dirs:
-    Remove(work_dir)
-    Mkdir(work_dir)
-  # Also clobber v8
-  v8_dir = os.path.join(work_dirs.GetV8(), V8_BUILD_SUBDIR)
-  Remove(v8_dir)
-  with open(clobber_file, 'w') as f:
-    f.write('%s\n' % CLOBBER_BUILD_TAG)
+        dirs = work_dirs.GetAll()
+    for work_dir in dirs:
+        Remove(work_dir)
+        Mkdir(work_dir)
+    # Also clobber v8
+    v8_dir = os.path.join(work_dirs.GetV8(), V8_BUILD_SUBDIR)
+    Remove(v8_dir)
+    with open(clobber_file, 'w') as f:
+        f.write('%s\n' % CLOBBER_BUILD_TAG)
 
 
 def SyncRepos(filter, sync_lkgr=False):
-  if not filter.Any():
-    return
-  buildbot.Step('Sync Repos')
+    if not filter.Any():
+        return
+    buildbot.Step('Sync Repos')
 
-  good_hashes = None
-  if sync_lkgr:
-    lkgr_file = GetBuildDir('lkgr.json')
-    cloud.Download('%s/lkgr.json' % BuilderPlatformName(), lkgr_file)
-    lkgr = json.loads(open(lkgr_file).read())
-    good_hashes = {}
-    for k, v in lkgr['repositories'].iteritems():
-      good_hashes[k] = v.get('hash') if v else None
+    good_hashes = None
+    if sync_lkgr:
+        lkgr_file = GetBuildDir('lkgr.json')
+        cloud.Download('%s/lkgr.json' % BuilderPlatformName(), lkgr_file)
+        lkgr = json.loads(open(lkgr_file).read())
+        good_hashes = {}
+        for k, v in lkgr['repositories'].iteritems():
+            good_hashes[k] = v.get('hash') if v else None
 
-  for repo in filter.Apply(AllSources()):
-    repo.Sync(good_hashes)
+    for repo in filter.Apply(AllSources()):
+        repo.Sync(good_hashes)
 
 
 def GetRepoInfo():
-  """Collect a readable form of all repo information here, preventing the
+    """Collect a readable form of all repo information here, preventing the
   summary from getting out of sync with the actual list of repos."""
-  info = {}
-  for r in AllSources():
-    info[r.name] = r.CurrentGitInfo()
-  return info
+    info = {}
+    for r in AllSources():
+        info[r.name] = r.CurrentGitInfo()
+    return info
 
 
 # Build rules
 
 def OverrideCMakeCompiler():
-  if not host_toolchains.ShouldForceHostClang():
-    return []
-  cc = 'clang-cl' if IsWindows() else 'clang'
-  cxx = 'clang-cl' if IsWindows() else 'clang++'
-  return ['-DCMAKE_C_COMPILER=' + Executable(GetPrebuiltClang(cc)),
-          '-DCMAKE_CXX_COMPILER=' + Executable(GetPrebuiltClang(cxx))]
+    if not host_toolchains.ShouldForceHostClang():
+        return []
+    cc = 'clang-cl' if IsWindows() else 'clang'
+    cxx = 'clang-cl' if IsWindows() else 'clang++'
+    return [
+        '-DCMAKE_C_COMPILER=' + Executable(GetPrebuiltClang(cc)),
+        '-DCMAKE_CXX_COMPILER=' + Executable(GetPrebuiltClang(cxx))
+    ]
 
 
 def CMakeCommandBase():
-  command = [PrebuiltCMakeBin(), '-G', 'Ninja']
-  # Python's location could change, so always update CMake's cache
-  command.append('-DPYTHON_EXECUTABLE=%s' % sys.executable)
-  command.append('-DCMAKE_EXPORT_COMPILE_COMMANDS=ON')
-  command.append('-DCMAKE_BUILD_TYPE=Release')
-  if IsMac():
-    # Target macOS Seirra (10.12)
-    command.append('-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12')
-  elif IsWindows():
-    # CMake's usual logic fails to find LUCI's git on Windows
-    git_exe = proc.Which('git')
-    command.append('-DGIT_EXECUTABLE=%s' % git_exe)
-  return command
+    command = [PrebuiltCMakeBin(), '-G', 'Ninja']
+    # Python's location could change, so always update CMake's cache
+    command.append('-DPYTHON_EXECUTABLE=%s' % sys.executable)
+    command.append('-DCMAKE_EXPORT_COMPILE_COMMANDS=ON')
+    command.append('-DCMAKE_BUILD_TYPE=Release')
+    if IsMac():
+        # Target macOS Seirra (10.12)
+        command.append('-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12')
+    elif IsWindows():
+        # CMake's usual logic fails to find LUCI's git on Windows
+        git_exe = proc.Which('git')
+        command.append('-DGIT_EXECUTABLE=%s' % git_exe)
+    return command
 
 
 def CMakeCommandNative(args):
-  command = CMakeCommandBase()
-  command.append('-DCMAKE_INSTALL_PREFIX=%s' % GetInstallDir())
-  if IsLinux() and host_toolchains.ShouldUseSysroot():
-    command.append('-DCMAKE_SYSROOT=%s' % GetPrebuilt(LINUX_SYSROOT))
-    command.extend(['-DCMAKE_%s_LINKER_FLAGS=-static-libstdc++' % l for l in
-                    ['EXE', 'SHARED']])
+    command = CMakeCommandBase()
+    command.append('-DCMAKE_INSTALL_PREFIX=%s' % GetInstallDir())
+    if IsLinux() and host_toolchains.ShouldUseSysroot():
+        command.append('-DCMAKE_SYSROOT=%s' % GetPrebuilt(LINUX_SYSROOT))
+        command.extend('-DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++')
+        command.extend('-DCMAKE_SHARED_LINKER_FLAGS=-static-libstdc++')
 
-  if host_toolchains.ShouldForceHostClang():
-    command.extend(OverrideCMakeCompiler())
-    # Goma doesn't have MSVC in its cache, so don't use it in this case
-    command.extend(host_toolchains.CMakeLauncherFlags())
-  command.extend(args)
-  # On Windows, CMake chokes on paths containing backslashes that come from the
-  # command line. Probably they just need to be escaped, but using '/' instead
-  # is easier and works just as well.
-  return [arg.replace('\\', '/') for arg in command]
+    if host_toolchains.ShouldForceHostClang():
+        command.extend(OverrideCMakeCompiler())
+        # Goma doesn't have MSVC in its cache, so don't use it in this case
+        command.extend(host_toolchains.CMakeLauncherFlags())
+    command.extend(args)
+    # On Windows, CMake chokes on paths containing backslashes that come from
+    # the command line. Probably they just need to be escaped, but using '/'
+    # instead is easier and works just as well.
+    return [arg.replace('\\', '/') for arg in command]
 
 
 def CMakeCommandWasi(args):
-  command = CMakeCommandBase()
-  command.append('-DCMAKE_TOOLCHAIN_FILE=%s' %
-                 GetInstallDir(CMAKE_TOOLCHAIN_FILE))
-  command.extend(args)
-  return command
+    command = CMakeCommandBase()
+    command.append('-DCMAKE_TOOLCHAIN_FILE=%s' %
+                   GetInstallDir(CMAKE_TOOLCHAIN_FILE))
+    command.extend(args)
+    return command
 
 
 def CopyLLVMTools(build_dir, prefix=''):
-  # The following aren't useful for now, and take up space.
-  # DLLs are in bin/ on Windows but in lib/ on posix.
-  for unneeded_tool in ('clang-check', 'clang-cl', 'clang-cpp',
-                        'clang-extdef-mapping', 'clang-format',
-                        'clang-func-mapping', 'clang-import-test',
-                        'clang-offload-bundler', 'clang-refactor',
-                        'clang-rename', 'clang-scan-deps', 'libclang.dll',
-                        'lld-link', 'ld.lld', 'lld64.lld', 'llvm-lib'):
-    Remove(GetInstallDir(prefix, 'bin', Executable(unneeded_tool)))
+    # The following aren't useful for now, and take up space.
+    # DLLs are in bin/ on Windows but in lib/ on posix.
+    for unneeded_tool in ('clang-check', 'clang-cl', 'clang-cpp',
+                          'clang-extdef-mapping', 'clang-format',
+                          'clang-func-mapping', 'clang-import-test',
+                          'clang-offload-bundler', 'clang-refactor',
+                          'clang-rename', 'clang-scan-deps', 'libclang.dll',
+                          'lld-link', 'ld.lld', 'lld64.lld', 'llvm-lib'):
+        Remove(GetInstallDir(prefix, 'bin', Executable(unneeded_tool)))
 
-  for lib in ['libclang.%s' for suffix in ('so.*', 'dylib')]:
-    Remove(GetInstallDir(prefix, 'lib', lib))
+    for lib in ['libclang.%s' for suffix in ('so.*', 'dylib')]:
+        Remove(GetInstallDir(prefix, 'lib', lib))
 
-  # The following are useful, LLVM_INSTALL_TOOLCHAIN_ONLY did away with them.
-  extra_bins = map(Executable,
-                   ['FileCheck', 'llc', 'llvm-as', 'llvm-dis',
-                    'llvm-link', 'llvm-mc', 'llvm-nm', 'llvm-objdump',
-                    'llvm-readobj', 'llvm-size', 'opt', 'llvm-dwarfdump'])
-  for p in [glob.glob(os.path.join(build_dir, 'bin', b)) for b in
-            extra_bins]:
-    for e in p:
-      CopyBinaryToArchive(os.path.join(build_dir, 'bin', e), prefix)
+    # The following are useful, LLVM_INSTALL_TOOLCHAIN_ONLY did away with them.
+    extra_bins = map(Executable, [
+        'FileCheck', 'llc', 'llvm-as', 'llvm-dis', 'llvm-link', 'llvm-mc',
+        'llvm-nm', 'llvm-objdump', 'llvm-readobj', 'llvm-size', 'opt',
+        'llvm-dwarfdump'
+    ])
+    for p in [
+            glob.glob(os.path.join(build_dir, 'bin', b)) for b in extra_bins
+    ]:
+        for e in p:
+            CopyBinaryToArchive(os.path.join(build_dir, 'bin', e), prefix)
 
 
-def BuildEnv(build_dir, use_gnuwin32=False, bin_subdir=False,
+def BuildEnv(build_dir,
+             use_gnuwin32=False,
+             bin_subdir=False,
              runtime='Release'):
-  if not IsWindows():
-    return None
-  cc_env = host_toolchains.SetUpVSEnv(build_dir)
-  if use_gnuwin32:
-    cc_env['PATH'] = cc_env['PATH'] + os.pathsep + GetSrcDir('gnuwin32', 'bin')
-  bin_dir = build_dir if not bin_subdir else os.path.join(build_dir, 'bin')
-  Mkdir(bin_dir)
-  assert runtime in ['Release', 'Debug']
-  host_toolchains.CopyDlls(bin_dir, runtime)
-  return cc_env
+    if not IsWindows():
+        return None
+    cc_env = host_toolchains.SetUpVSEnv(build_dir)
+    if use_gnuwin32:
+        cc_env['PATH'] = cc_env['PATH'] + os.pathsep + GetSrcDir(
+            'gnuwin32', 'bin')
+    bin_dir = build_dir if not bin_subdir else os.path.join(build_dir, 'bin')
+    Mkdir(bin_dir)
+    assert runtime in ['Release', 'Debug']
+    host_toolchains.CopyDlls(bin_dir, runtime)
+    return cc_env
 
 
 def LLVM():
-  buildbot.Step('LLVM')
-  build_dir = os.path.join(work_dirs.GetBuild(), 'llvm-out')
-  Mkdir(build_dir)
-  cc_env = BuildEnv(build_dir, bin_subdir=True)
-  build_dylib = 'ON' if not IsWindows() else 'OFF'
-  command = CMakeCommandNative([
-      GetLLVMSrcDir('llvm'),
-      '-DCMAKE_CXX_FLAGS=-Wno-nonportable-include-path',
-      '-DLLVM_ENABLE_LIBXML2=OFF',
-      '-DLLVM_INCLUDE_EXAMPLES=OFF',
-      '-DCOMPILER_RT_BUILD_XRAY=OFF',
-      '-DCOMPILER_RT_INCLUDE_TESTS=OFF',
-      '-DCOMPILER_RT_ENABLE_IOS=OFF',
-      '-DLLVM_BUILD_LLVM_DYLIB=%s' % build_dylib,
-      '-DLLVM_LINK_LLVM_DYLIB=%s' % build_dylib,
-      # Our mac bot's toolchain's ld64 is too old for trunk libLTO.
-      '-DLLVM_TOOL_LTO_BUILD=OFF',
-      '-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON',
-      '-DLLVM_ENABLE_ASSERTIONS=ON',
-      '-DLLVM_TARGETS_TO_BUILD=X86;WebAssembly',
-      '-DLLVM_ENABLE_PROJECTS=lld;clang',
-      # linking libtinfo dynamically causes problems on some linuxes,
-      # https://github.com/emscripten-core/emsdk/issues/252
-      '-DLLVM_ENABLE_TERMINFO=%d' % (not IsLinux()),
-  ])
+    buildbot.Step('LLVM')
+    build_dir = os.path.join(work_dirs.GetBuild(), 'llvm-out')
+    Mkdir(build_dir)
+    cc_env = BuildEnv(build_dir, bin_subdir=True)
+    build_dylib = 'ON' if not IsWindows() else 'OFF'
+    command = CMakeCommandNative([
+        GetLLVMSrcDir('llvm'),
+        '-DCMAKE_CXX_FLAGS=-Wno-nonportable-include-path',
+        '-DLLVM_ENABLE_LIBXML2=OFF',
+        '-DLLVM_INCLUDE_EXAMPLES=OFF',
+        '-DCOMPILER_RT_BUILD_XRAY=OFF',
+        '-DCOMPILER_RT_INCLUDE_TESTS=OFF',
+        '-DCOMPILER_RT_ENABLE_IOS=OFF',
+        '-DLLVM_BUILD_LLVM_DYLIB=%s' % build_dylib,
+        '-DLLVM_LINK_LLVM_DYLIB=%s' % build_dylib,
+        # Our mac bot's toolchain's ld64 is too old for trunk libLTO.
+        '-DLLVM_TOOL_LTO_BUILD=OFF',
+        '-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON',
+        '-DLLVM_ENABLE_ASSERTIONS=ON',
+        '-DLLVM_TARGETS_TO_BUILD=X86;WebAssembly',
+        '-DLLVM_ENABLE_PROJECTS=lld;clang',
+        # linking libtinfo dynamically causes problems on some linuxes,
+        # https://github.com/emscripten-core/emsdk/issues/252
+        '-DLLVM_ENABLE_TERMINFO=%d' % (not IsLinux()),
+    ])
 
-  jobs = host_toolchains.NinjaJobs()
+    jobs = host_toolchains.NinjaJobs()
 
-  proc.check_call(command, cwd=build_dir, env=cc_env)
-  proc.check_call(['ninja', '-v'] + jobs, cwd=build_dir, env=cc_env)
-  proc.check_call(['ninja', 'install'] + jobs, cwd=build_dir, env=cc_env)
-  CopyLLVMTools(build_dir)
-  install_bin = GetInstallDir('bin')
-  for target in ('clang', 'clang++'):
-    for link in 'wasm32-', 'wasm32-wasi-':
-      link = os.path.join(install_bin, link + target)
-      if not IsWindows():
-        if not os.path.islink(Executable(link)):
-          os.symlink(Executable(target), Executable(link))
-      else:
-        # Windows has no symlinks (at least not from python). Also clang won't
-        # work as a native compiler anyway, so just install it as
-        # wasm32-wasi-clang
-        shutil.copy2(Executable(os.path.join(install_bin, target)),
-                     Executable(link))
+    proc.check_call(command, cwd=build_dir, env=cc_env)
+    proc.check_call(['ninja', '-v'] + jobs, cwd=build_dir, env=cc_env)
+    proc.check_call(['ninja', 'install'] + jobs, cwd=build_dir, env=cc_env)
+    CopyLLVMTools(build_dir)
+    install_bin = GetInstallDir('bin')
+    for target in ('clang', 'clang++'):
+        for link in 'wasm32-', 'wasm32-wasi-':
+            link = os.path.join(install_bin, link + target)
+            if not IsWindows():
+                if not os.path.islink(Executable(link)):
+                    os.symlink(Executable(target), Executable(link))
+            else:
+                # Windows has no symlinks (at least not from python). Also
+                # clang won't work as a native compiler anyway, so just install
+                # it as wasm32-wasi-clang
+                shutil.copy2(Executable(os.path.join(install_bin, target)),
+                             Executable(link))
 
 
 def LLVMTestDepends():
-  buildbot.Step('LLVM Test Dependencies')
-  build_dir = os.path.join(work_dirs.GetBuild(), 'llvm-out')
-  proc.check_call(
-      ['ninja', '-v', 'test-depends'] + host_toolchains.NinjaJobs(),
-      cwd=build_dir, env=BuildEnv(build_dir, bin_subdir=True))
+    buildbot.Step('LLVM Test Dependencies')
+    build_dir = os.path.join(work_dirs.GetBuild(), 'llvm-out')
+    proc.check_call(['ninja', '-v', 'test-depends'] +
+                    host_toolchains.NinjaJobs(),
+                    cwd=build_dir,
+                    env=BuildEnv(build_dir, bin_subdir=True))
 
 
 def TestLLVMRegression():
-  build_dir = os.path.join(work_dirs.GetBuild(), 'llvm-out')
-  cc_env = BuildEnv(build_dir, bin_subdir=True)
-  if not os.path.isdir(build_dir):
-    print('LLVM Build dir %s does not exist' % build_dir)
-    buildbot.Fail()
-    return
+    build_dir = os.path.join(work_dirs.GetBuild(), 'llvm-out')
+    cc_env = BuildEnv(build_dir, bin_subdir=True)
+    if not os.path.isdir(build_dir):
+        print('LLVM Build dir %s does not exist' % build_dir)
+        buildbot.Fail()
+        return
 
-  def RunWithUnixUtils(cmd, **kwargs):
-    if IsWindows():
-      return proc.check_call(['git', 'bash'] + cmd, **kwargs)
-    else:
-      return proc.check_call(cmd, **kwargs)
+    def RunWithUnixUtils(cmd, **kwargs):
+        if IsWindows():
+            return proc.check_call(['git', 'bash'] + cmd, **kwargs)
+        else:
+            return proc.check_call(cmd, **kwargs)
 
-  try:
-    buildbot.Step('LLVM regression tests')
-    RunWithUnixUtils(['ninja', 'check-all'], cwd=build_dir, env=cc_env)
-  except proc.CalledProcessError:
-    buildbot.FailUnless(lambda: IsWindows())
+    try:
+        buildbot.Step('LLVM regression tests')
+        RunWithUnixUtils(['ninja', 'check-all'], cwd=build_dir, env=cc_env)
+    except proc.CalledProcessError:
+        buildbot.FailUnless(lambda: IsWindows())
 
 
 def V8():
-  buildbot.Step('V8')
-  src_dir = work_dirs.GetV8()
-  out_dir = os.path.join(src_dir, V8_BUILD_SUBDIR)
-  vpython = 'vpython' + ('.bat' if IsWindows() else '')
+    buildbot.Step('V8')
+    src_dir = work_dirs.GetV8()
+    out_dir = os.path.join(src_dir, V8_BUILD_SUBDIR)
+    vpython = 'vpython' + ('.bat' if IsWindows() else '')
 
-  # Generate and write a GN args file.
-  gn_args = 'is_debug = false\ntarget_cpu = "x64"\n'
-  if host_toolchains.UsingGoma():
-    gn_args += 'use_goma = true\n'
-    gn_args += 'goma_dir = "%s"\n' % host_toolchains.GomaDir()
-  Mkdir(out_dir)
-  with open(os.path.join(out_dir, 'args.gn'), 'w') as f:
-    f.write(gn_args)
-  # Invoke GN to generate. We need to use vpython as the script interpreter
-  # since GN's scripts seem to require python2. Hence we need to invoke GN
-  # directly rather than using one of V8's GN wrapper scripts (e.g. mb.py).
-  # But because V8 has a different directory layout from Chrome, we can't just
-  # use the GN wrapper in depot_tools, we have to invoke the one in the V8
-  # buildtools dir directly.
-  gn_platform = 'linux64' if IsLinux() else 'mac' if IsMac() else 'win'
-  gn_exe = Executable(os.path.join(src_dir, 'buildtools', gn_platform, 'gn'))
-  proc.check_call([gn_exe, 'gen', out_dir, '--script-executable=' + vpython],
-                  cwd=src_dir)
+    # Generate and write a GN args file.
+    gn_args = 'is_debug = false\ntarget_cpu = "x64"\n'
+    if host_toolchains.UsingGoma():
+        gn_args += 'use_goma = true\n'
+        gn_args += 'goma_dir = "%s"\n' % host_toolchains.GomaDir()
+    Mkdir(out_dir)
+    with open(os.path.join(out_dir, 'args.gn'), 'w') as f:
+        f.write(gn_args)
+    # Invoke GN to generate. We need to use vpython as the script interpreter
+    # since GN's scripts seem to require python2. Hence we need to invoke GN
+    # directly rather than using one of V8's GN wrapper scripts (e.g. mb.py).
+    # But because V8 has a different directory layout from Chrome, we can't
+    # just use the GN wrapper in depot_tools, we have to invoke the one in the
+    # V8 buildtools dir directly.
+    gn_platform = 'linux64' if IsLinux() else 'mac' if IsMac() else 'win'
+    gn_exe = Executable(os.path.join(src_dir, 'buildtools', gn_platform, 'gn'))
+    proc.check_call([gn_exe, 'gen', out_dir, '--script-executable=' + vpython],
+                    cwd=src_dir)
 
-  jobs = host_toolchains.NinjaJobs()
-  proc.check_call(['ninja', '-v', '-C', out_dir, 'd8', 'unittests'] + jobs,
-                  cwd=src_dir)
-  # Copy the V8 snapshot as well as the ICU data file for timezone data.
-  # icudtl.dat is the little-endian version, which goes with x64.
-  to_archive = [Executable('d8'), 'snapshot_blob.bin', 'icudtl.dat']
-  for a in to_archive:
-    CopyBinaryToArchive(os.path.join(out_dir, a))
+    jobs = host_toolchains.NinjaJobs()
+    proc.check_call(['ninja', '-v', '-C', out_dir, 'd8', 'unittests'] + jobs,
+                    cwd=src_dir)
+    # Copy the V8 snapshot as well as the ICU data file for timezone data.
+    # icudtl.dat is the little-endian version, which goes with x64.
+    to_archive = [Executable('d8'), 'snapshot_blob.bin', 'icudtl.dat']
+    for a in to_archive:
+        CopyBinaryToArchive(os.path.join(out_dir, a))
 
 
 def Jsvu():
-  buildbot.Step('jsvu')
-  jsvu_dir = os.path.join(work_dirs.GetBuild(), 'jsvu')
-  Mkdir(jsvu_dir)
+    buildbot.Step('jsvu')
+    jsvu_dir = os.path.join(work_dirs.GetBuild(), 'jsvu')
+    Mkdir(jsvu_dir)
 
-  if IsWindows():
-    # jsvu OS identifiers:
-    # https://github.com/GoogleChromeLabs/jsvu#supported-engines
-    os_id = 'windows64'
-    js_engines = 'chakra'
-  elif IsMac():
-    os_id = 'mac64'
-    js_engines = 'javascriptcore,v8'
-  else:
-    os_id = 'linux64'
-    js_engines = 'javascriptcore'
+    if IsWindows():
+        # jsvu OS identifiers:
+        # https://github.com/GoogleChromeLabs/jsvu#supported-engines
+        os_id = 'windows64'
+        js_engines = 'chakra'
+    elif IsMac():
+        os_id = 'mac64'
+        js_engines = 'javascriptcore,v8'
+    else:
+        os_id = 'linux64'
+        js_engines = 'javascriptcore'
 
-  try:
-    # https://github.com/GoogleChromeLabs/jsvu#installation
-    # ...except we install it locally instead of globally.
-    proc.check_call(['npm', 'install', 'jsvu'], cwd=jsvu_dir)
+    try:
+        # https://github.com/GoogleChromeLabs/jsvu#installation
+        # ...except we install it locally instead of globally.
+        proc.check_call(['npm', 'install', 'jsvu'], cwd=jsvu_dir)
 
-    jsvu_bin = Executable(os.path.join(
-        jsvu_dir, 'node_modules', 'jsvu', 'cli.js'))
-    # https://github.com/GoogleChromeLabs/jsvu#integration-with-non-interactive-environments
-    proc.check_call([jsvu_bin,
-                     '--os=%s' % os_id,
-                     '--engines=%s' % js_engines])
+        jsvu_bin = Executable(
+            os.path.join(jsvu_dir, 'node_modules', 'jsvu', 'cli.js'))
+        # https://github.com/GoogleChromeLabs/jsvu#integration-with-non-interactive-environments
+        proc.check_call(
+            [jsvu_bin,
+             '--os=%s' % os_id,
+             '--engines=%s' % js_engines])
 
-    # $HOME/.jsvu/chakra is now available on Windows.
-    # $HOME/.jsvu/javascriptcore is now available on Mac.
+        # $HOME/.jsvu/chakra is now available on Windows.
+        # $HOME/.jsvu/javascriptcore is now available on Mac.
 
-    # TODO: Install the JSC binary in the output package, and add the version
-    # info to the repo info JSON file (currently in GetRepoInfo)
-  except proc.CalledProcessError:
-    buildbot.Warn()
+        # TODO: Install the JSC binary in the output package, and add the
+        # version info to the repo info JSON file (currently in GetRepoInfo)
+    except proc.CalledProcessError:
+        buildbot.Warn()
 
 
 def Wabt():
-  buildbot.Step('WABT')
-  out_dir = os.path.join(work_dirs.GetBuild(), 'wabt-out')
-  Mkdir(out_dir)
-  cc_env = BuildEnv(out_dir)
+    buildbot.Step('WABT')
+    out_dir = os.path.join(work_dirs.GetBuild(), 'wabt-out')
+    Mkdir(out_dir)
+    cc_env = BuildEnv(out_dir)
 
-  proc.check_call(CMakeCommandNative([
-      GetSrcDir('wabt'),
-      '-DBUILD_TESTS=OFF'
-  ]), cwd=out_dir, env=cc_env)
+    cmd = CMakeCommandNative([GetSrcDir('wabt'), '-DBUILD_TESTS=OFF'])
+    proc.check_call(cmd, cwd=out_dir, env=cc_env)
 
-  proc.check_call(['ninja', '-v'], cwd=out_dir, env=cc_env)
-  proc.check_call(['ninja', 'install'], cwd=out_dir, env=cc_env)
+    proc.check_call(['ninja', '-v'], cwd=out_dir, env=cc_env)
+    proc.check_call(['ninja', 'install'], cwd=out_dir, env=cc_env)
 
 
 def Binaryen():
-  buildbot.Step('binaryen')
-  out_dir = os.path.join(work_dirs.GetBuild(), 'binaryen-out')
-  Mkdir(out_dir)
-  # Currently it's a bad idea to do a non-asserts build of Binaryen
-  cc_env = BuildEnv(out_dir, bin_subdir=True, runtime='Debug')
+    buildbot.Step('binaryen')
+    out_dir = os.path.join(work_dirs.GetBuild(), 'binaryen-out')
+    Mkdir(out_dir)
+    # Currently it's a bad idea to do a non-asserts build of Binaryen
+    cc_env = BuildEnv(out_dir, bin_subdir=True, runtime='Debug')
 
-  proc.check_call(CMakeCommandNative([
-      GetSrcDir('binaryen'),
-  ]), cwd=out_dir, env=cc_env)
-  proc.check_call(['ninja', '-v'], cwd=out_dir, env=cc_env)
-  proc.check_call(['ninja', 'install'], cwd=out_dir, env=cc_env)
+    proc.check_call(CMakeCommandNative([GetSrcDir('binaryen')]),
+                    cwd=out_dir,
+                    env=cc_env)
+    proc.check_call(['ninja', '-v'], cwd=out_dir, env=cc_env)
+    proc.check_call(['ninja', 'install'], cwd=out_dir, env=cc_env)
 
 
 def Fastcomp():
-  buildbot.Step('fastcomp')
-  build_dir = os.path.join(work_dirs.GetBuild(), 'fastcomp-out')
-  Mkdir(build_dir)
-  install_dir = GetInstallDir('fastcomp')
-  build_dylib = 'ON' if not IsWindows() else 'OFF'
-  cc_env = BuildEnv(build_dir, bin_subdir=True)
-  command = CMakeCommandNative([
-      GetSrcDir('emscripten-fastcomp'),
-      '-DCMAKE_CXX_FLAGS=-Wno-nonportable-include-path',
-      '-DLLVM_ENABLE_LIBXML2=OFF',
-      '-DLLVM_INCLUDE_TESTS=OFF',
-      '-DLLVM_INCLUDE_EXAMPLES=OFF',
-      '-DLLVM_BUILD_LLVM_DYLIB=%s' % build_dylib,
-      '-DLLVM_LINK_LLVM_DYLIB=%s' % build_dylib,
-      '-DCMAKE_INSTALL_PREFIX=%s' % install_dir,
-      '-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON',
-      '-DLLVM_TARGETS_TO_BUILD=X86;JSBackend',
-      '-DLLVM_ENABLE_ASSERTIONS=ON',
-      # linking libtinfo dynamically causes problems on some linuxes,
-      # https://github.com/emscripten-core/emsdk/issues/252
-      '-DLLVM_ENABLE_TERMINFO=%d' % (not IsLinux()),
-      ('-DLLVM_EXTERNAL_CLANG_SOURCE_DIR=%s' %
-       GetSrcDir('emscripten-fastcomp-clang'))
-  ])
+    buildbot.Step('fastcomp')
+    build_dir = os.path.join(work_dirs.GetBuild(), 'fastcomp-out')
+    Mkdir(build_dir)
+    install_dir = GetInstallDir('fastcomp')
+    build_dylib = 'ON' if not IsWindows() else 'OFF'
+    cc_env = BuildEnv(build_dir, bin_subdir=True)
+    command = CMakeCommandNative([
+        GetSrcDir('emscripten-fastcomp'),
+        '-DCMAKE_CXX_FLAGS=-Wno-nonportable-include-path',
+        '-DLLVM_ENABLE_LIBXML2=OFF',
+        '-DLLVM_INCLUDE_TESTS=OFF',
+        '-DLLVM_INCLUDE_EXAMPLES=OFF',
+        '-DLLVM_BUILD_LLVM_DYLIB=%s' % build_dylib,
+        '-DLLVM_LINK_LLVM_DYLIB=%s' % build_dylib,
+        '-DCMAKE_INSTALL_PREFIX=%s' % install_dir,
+        '-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON',
+        '-DLLVM_TARGETS_TO_BUILD=X86;JSBackend',
+        '-DLLVM_ENABLE_ASSERTIONS=ON',
+        # linking libtinfo dynamically causes problems on some linuxes,
+        # https://github.com/emscripten-core/emsdk/issues/252
+        '-DLLVM_ENABLE_TERMINFO=%d' % (not IsLinux()),
+        ('-DLLVM_EXTERNAL_CLANG_SOURCE_DIR=%s' %
+         GetSrcDir('emscripten-fastcomp-clang'))
+    ])
 
-  proc.check_call(command, cwd=build_dir, env=cc_env)
+    proc.check_call(command, cwd=build_dir, env=cc_env)
 
-  proc.check_call(['ninja', '-v'] + host_toolchains.NinjaJobs(),
-                  cwd=build_dir, env=cc_env)
-  proc.check_call(['ninja', 'install'], cwd=build_dir, env=cc_env)
-  # Fastcomp has a different install location than the rest of the tools
-  BuildEnv(install_dir, bin_subdir=True)
-  CopyLLVMTools(build_dir, 'fastcomp')
+    proc.check_call(['ninja', '-v'] + host_toolchains.NinjaJobs(),
+                    cwd=build_dir,
+                    env=cc_env)
+    proc.check_call(['ninja', 'install'], cwd=build_dir, env=cc_env)
+    # Fastcomp has a different install location than the rest of the tools
+    BuildEnv(install_dir, bin_subdir=True)
+    CopyLLVMTools(build_dir, 'fastcomp')
 
 
 def BuildEmscriptenOptimizer():
-  # Remove cached library builds (e.g. libc, libc++) to force them to be
-  # rebuilt in the step below.
-  buildbot.Step('emscripten (optimizer)')
-  Remove(EMSCRIPTEN_CACHE_DIR)
-  src_dir = GetSrcDir('emscripten')
-  em_install_dir = GetInstallDir('emscripten')
-  Remove(em_install_dir)
-  print('Copying directory %s to %s' % (src_dir, em_install_dir))
-  shutil.copytree(src_dir,
-                  em_install_dir,
-                  symlinks=True,
-                  # Ignore the big git blob so it doesn't get archived.
-                  ignore=shutil.ignore_patterns('.git'))
+    # Remove cached library builds (e.g. libc, libc++) to force them to be
+    # rebuilt in the step below.
+    buildbot.Step('emscripten (optimizer)')
+    Remove(EMSCRIPTEN_CACHE_DIR)
+    src_dir = GetSrcDir('emscripten')
+    em_install_dir = GetInstallDir('emscripten')
+    Remove(em_install_dir)
+    print('Copying directory %s to %s' % (src_dir, em_install_dir))
+    shutil.copytree(src_dir,
+                    em_install_dir,
+                    symlinks=True,
+                    # Ignore the big git blob so it doesn't get archived.
+                    ignore=shutil.ignore_patterns('.git'))
 
-  # Manually build the native asm.js optimizer (the cmake build in embuilder
-  # doesn't work on the waterfall)
-  optimizer_out_dir = GetBuildDir('em-optimizer-out')
-  Mkdir(optimizer_out_dir)
-  cc_env = BuildEnv(optimizer_out_dir)
-  command = CMakeCommandNative([
-      os.path.join(src_dir, 'tools', 'optimizer'),
-      '-DCMAKE_BUILD_TYPE=Release'
-  ])
-  proc.check_call(command, cwd=optimizer_out_dir, env=cc_env)
-  proc.check_call(['ninja'] + host_toolchains.NinjaJobs(),
-                  cwd=optimizer_out_dir, env=cc_env)
-  CopyBinaryToArchive(Executable(os.path.join(optimizer_out_dir, 'optimizer')))
+    # Manually build the native asm.js optimizer (the cmake build in embuilder
+    # doesn't work on the waterfall)
+    optimizer_out_dir = GetBuildDir('em-optimizer-out')
+    Mkdir(optimizer_out_dir)
+    cc_env = BuildEnv(optimizer_out_dir)
+    command = CMakeCommandNative([
+        os.path.join(src_dir, 'tools', 'optimizer'),
+        '-DCMAKE_BUILD_TYPE=Release'
+    ])
+    proc.check_call(command, cwd=optimizer_out_dir, env=cc_env)
+    proc.check_call(['ninja'] + host_toolchains.NinjaJobs(),
+                    cwd=optimizer_out_dir,
+                    env=cc_env)
+    CopyBinaryToArchive(
+        Executable(os.path.join(optimizer_out_dir, 'optimizer')))
 
 
 def Emscripten(variant):
-  if variant == 'upstream':
-    # This work is only done once (not per-variant), so only do it if the
-    # variant is 'upstream'. This means that the upstream variant does
-    # need to go first.
-    BuildEmscriptenOptimizer()
+    if variant == 'upstream':
+        # This work is only done once (not per-variant), so only do it if the
+        # variant is 'upstream'. This means that the upstream variant does
+        # need to go first.
+        BuildEmscriptenOptimizer()
 
-  def WriteEmscriptenConfig(infile, outfile):
-    with open(infile) as config:
-      text = config.read().replace('{{WASM_INSTALL}}',
-                                   WindowsFSEscape(GetInstallDir()))
-      text = text.replace('{{PREBUILT_NODE}}', WindowsFSEscape(NodeBin()))
-      text = text.replace('{{PREBUILT_JAVA}}', WindowsFSEscape(JavaBin()))
-    with open(outfile, 'w') as config:
-      config.write(text)
+    def WriteEmscriptenConfig(infile, outfile):
+        with open(infile) as config:
+            text = config.read().replace('{{WASM_INSTALL}}',
+                                         WindowsFSEscape(GetInstallDir()))
+            text = text.replace('{{PREBUILT_NODE}}',
+                                WindowsFSEscape(NodeBin()))
+            text = text.replace('{{PREBUILT_JAVA}}',
+                                WindowsFSEscape(JavaBin()))
+        with open(outfile, 'w') as config:
+            config.write(text)
 
-  # We don't bundle every single file in the cache, since there are a lot and
-  # it would bloat our downloads. But some are useful to bundle:
-  #   * libc is large and slow to build (many tiny files).
-  #   * generated_struct_info.json is generated in a boostrapping operation
-  #     that is confusing to debug if the user has a broken setup.
-  #   * optimizer.2.exe takes a while to build and also requires a local
-  #     compiler environment for native executables.
-  configs = {
-      'fastcomp': (GetInstallDir(EMSCRIPTEN_CONFIG_FASTCOMP),
-                   'asmjs', ('libc.bc', 'generated_struct_info.json')),
-      'upstream': (GetInstallDir(EMSCRIPTEN_CONFIG_UPSTREAM),
-                   'wasm', ('libc.a', 'generated_struct_info.json'))
-  }
+    # We don't bundle every single file in the cache, since there are a lot and
+    # it would bloat our downloads. But some are useful to bundle:
+    #   * libc is large and slow to build (many tiny files).
+    #   * generated_struct_info.json is generated in a boostrapping operation
+    #     that is confusing to debug if the user has a broken setup.
+    #   * optimizer.2.exe takes a while to build and also requires a local
+    #     compiler environment for native executables.
+    configs = {
+        'fastcomp': (GetInstallDir(EMSCRIPTEN_CONFIG_FASTCOMP), 'asmjs',
+                     ('libc.bc', 'generated_struct_info.json')),
+        'upstream': (GetInstallDir(EMSCRIPTEN_CONFIG_UPSTREAM), 'wasm',
+                     ('libc.a', 'generated_struct_info.json'))
+    }
 
-  config, cache_subdir, cache_libs = configs[variant]
+    config, cache_subdir, cache_libs = configs[variant]
 
-  # Set up the emscripten config and compile the libraries for the specified
-  # variant
-  buildbot.Step('emscripten (%s)' % variant)
-  print('Config file: ', config)
-  src_config = os.path.join(SCRIPT_DIR, os.path.basename(config))
-  WriteEmscriptenConfig(src_config, config)
+    # Set up the emscripten config and compile the libraries for the specified
+    # variant
+    buildbot.Step('emscripten (%s)' % variant)
+    print('Config file: ', config)
+    src_config = os.path.join(SCRIPT_DIR, os.path.basename(config))
+    WriteEmscriptenConfig(src_config, config)
 
-  os.environ['EM_CONFIG'] = config
-  try:
-    # Use emscripten's embuilder to prebuild the system libraries.
-    # This depends on binaryen already being built and installed into the
-    # archive/install dir.
-    proc.check_call([sys.executable,
-                     os.path.join(GetInstallDir('emscripten'), 'embuilder.py'),
-                     'build', 'SYSTEM'])
+    os.environ['EM_CONFIG'] = config
+    try:
+        # Use emscripten's embuilder to prebuild the system libraries.
+        # This depends on binaryen already being built and installed into the
+        # archive/install dir.
+        proc.check_call([
+            sys.executable,
+            os.path.join(GetInstallDir('emscripten'), 'embuilder.py'), 'build',
+            'SYSTEM'
+        ])
 
-  except proc.CalledProcessError:
-    # Note the failure but allow the build to continue.
-    buildbot.Fail()
-  finally:
-    del os.environ['EM_CONFIG']
+    except proc.CalledProcessError:
+        # Note the failure but allow the build to continue.
+        buildbot.Fail()
+    finally:
+        del os.environ['EM_CONFIG']
 
-  # Copy the main system libraries so users don't need to themselves.
-  packaging_dir = GetInstallDir('lib', cache_subdir)
-  if not os.path.isdir(packaging_dir):
-    os.makedirs(packaging_dir)
-  for name in cache_libs:
-    shutil.copy2(os.path.join(EMSCRIPTEN_CACHE_DIR, cache_subdir, name),
-                 os.path.join(packaging_dir, name))
+    # Copy the main system libraries so users don't need to themselves.
+    packaging_dir = GetInstallDir('lib', cache_subdir)
+    if not os.path.isdir(packaging_dir):
+        os.makedirs(packaging_dir)
+    for name in cache_libs:
+        shutil.copy2(os.path.join(EMSCRIPTEN_CACHE_DIR, cache_subdir, name),
+                     os.path.join(packaging_dir, name))
 
 
 def CompilerRT():
-  # TODO(sbc): Figure out how to do this step as part of the llvm build.
-  # I suspect that this can be done using the llvm/runtimes directory but
-  # have yet to make it actually work this way.
-  buildbot.Step('compiler-rt')
+    # TODO(sbc): Figure out how to do this step as part of the llvm build.
+    # I suspect that this can be done using the llvm/runtimes directory but
+    # have yet to make it actually work this way.
+    buildbot.Step('compiler-rt')
 
-  build_dir = os.path.join(work_dirs.GetBuild(), 'compiler-rt-out')
-  # TODO(sbc): Remove this.
-  # The compiler-rt doesn't currently rebuild libraries when a new -DCMAKE_AR
-  # value is specified.
-  if os.path.isdir(build_dir):
-    Remove(build_dir)
+    build_dir = os.path.join(work_dirs.GetBuild(), 'compiler-rt-out')
+    # TODO(sbc): Remove this.
+    # The compiler-rt doesn't currently rebuild libraries when a new -DCMAKE_AR
+    # value is specified.
+    if os.path.isdir(build_dir):
+        Remove(build_dir)
 
-  Mkdir(build_dir)
-  src_dir = GetLLVMSrcDir('compiler-rt')
-  cc_env = BuildEnv(src_dir, bin_subdir=True)
-  command = CMakeCommandWasi([
-      os.path.join(src_dir, 'lib', 'builtins'),
-      '-DCMAKE_C_COMPILER_WORKS=ON',
-      '-DCOMPILER_RT_BAREMETAL_BUILD=On',
-      '-DCOMPILER_RT_BUILD_XRAY=OFF',
-      '-DCOMPILER_RT_INCLUDE_TESTS=OFF',
-      '-DCOMPILER_RT_ENABLE_IOS=OFF',
-      '-DCOMPILER_RT_DEFAULT_TARGET_ONLY=On',
-      '-DLLVM_CONFIG_PATH=' +
-      Executable(os.path.join(work_dirs.GetBuild(),
-                              'llvm-out', 'bin', 'llvm-config')),
-      '-DCMAKE_INSTALL_PREFIX=' +
-      GetInstallDir('lib', 'clang', LLVM_VERSION)
-  ])
+    Mkdir(build_dir)
+    src_dir = GetLLVMSrcDir('compiler-rt')
+    cc_env = BuildEnv(src_dir, bin_subdir=True)
+    command = CMakeCommandWasi([
+        os.path.join(src_dir, 'lib', 'builtins'),
+        '-DCMAKE_C_COMPILER_WORKS=ON', '-DCOMPILER_RT_BAREMETAL_BUILD=On',
+        '-DCOMPILER_RT_BUILD_XRAY=OFF', '-DCOMPILER_RT_INCLUDE_TESTS=OFF',
+        '-DCOMPILER_RT_ENABLE_IOS=OFF', '-DCOMPILER_RT_DEFAULT_TARGET_ONLY=On',
+        '-DLLVM_CONFIG_PATH=' + Executable(
+            os.path.join(work_dirs.GetBuild(), 'llvm-out', 'bin',
+                         'llvm-config')),
+        '-DCMAKE_INSTALL_PREFIX=' + GetInstallDir('lib', 'clang', LLVM_VERSION)
+    ])
 
-  proc.check_call(command, cwd=build_dir, env=cc_env)
-  proc.check_call(['ninja', '-v'], cwd=build_dir, env=cc_env)
-  proc.check_call(['ninja', 'install'], cwd=build_dir, env=cc_env)
+    proc.check_call(command, cwd=build_dir, env=cc_env)
+    proc.check_call(['ninja', '-v'], cwd=build_dir, env=cc_env)
+    proc.check_call(['ninja', 'install'], cwd=build_dir, env=cc_env)
 
 
 def LibCXX():
-  buildbot.Step('libcxx')
-  build_dir = os.path.join(work_dirs.GetBuild(), 'libcxx-out')
-  if os.path.isdir(build_dir):
-    Remove(build_dir)
-  Mkdir(build_dir)
-  src_dir = GetLLVMSrcDir('libcxx')
-  cc_env = BuildEnv(src_dir, bin_subdir=True)
-  command = CMakeCommandWasi([
-      src_dir,
-      '-DCMAKE_EXE_LINKER_FLAGS=-nostdlib++',
-      '-DLIBCXX_ENABLE_THREADS=OFF',
-      '-DLIBCXX_ENABLE_SHARED=OFF',
-      '-DLIBCXX_ENABLE_FILESYSTEM=OFF',
-      '-DLIBCXX_HAS_MUSL_LIBC=ON',
-      '-DLIBCXX_CXX_ABI=libcxxabi',
-      '-DLIBCXX_LIBDIR_SUFFIX=/wasm32-wasi',
-      '-DLIBCXX_CXX_ABI_INCLUDE_PATHS=' +
-      GetLLVMSrcDir('libcxxabi', 'include'),
-      '-DLLVM_PATH=' + GetLLVMSrcDir('llvm'),
-  ])
+    buildbot.Step('libcxx')
+    build_dir = os.path.join(work_dirs.GetBuild(), 'libcxx-out')
+    if os.path.isdir(build_dir):
+        Remove(build_dir)
+    Mkdir(build_dir)
+    src_dir = GetLLVMSrcDir('libcxx')
+    cc_env = BuildEnv(src_dir, bin_subdir=True)
+    command = CMakeCommandWasi([
+        src_dir,
+        '-DCMAKE_EXE_LINKER_FLAGS=-nostdlib++',
+        '-DLIBCXX_ENABLE_THREADS=OFF',
+        '-DLIBCXX_ENABLE_SHARED=OFF',
+        '-DLIBCXX_ENABLE_FILESYSTEM=OFF',
+        '-DLIBCXX_HAS_MUSL_LIBC=ON',
+        '-DLIBCXX_CXX_ABI=libcxxabi',
+        '-DLIBCXX_LIBDIR_SUFFIX=/wasm32-wasi',
+        '-DLIBCXX_CXX_ABI_INCLUDE_PATHS=' +
+        GetLLVMSrcDir('libcxxabi', 'include'),
+        '-DLLVM_PATH=' + GetLLVMSrcDir('llvm'),
+    ])
 
-  proc.check_call(command, cwd=build_dir, env=cc_env)
-  proc.check_call(['ninja', '-v'], cwd=build_dir, env=cc_env)
-  proc.check_call(['ninja', 'install'], cwd=build_dir, env=cc_env)
+    proc.check_call(command, cwd=build_dir, env=cc_env)
+    proc.check_call(['ninja', '-v'], cwd=build_dir, env=cc_env)
+    proc.check_call(['ninja', 'install'], cwd=build_dir, env=cc_env)
 
 
 def LibCXXABI():
-  buildbot.Step('libcxxabi')
-  build_dir = os.path.join(work_dirs.GetBuild(), 'libcxxabi-out')
-  if os.path.isdir(build_dir):
-    Remove(build_dir)
-  Mkdir(build_dir)
-  src_dir = GetLLVMSrcDir('libcxxabi')
-  cc_env = BuildEnv(src_dir, bin_subdir=True)
-  command = CMakeCommandWasi([
-      src_dir,
-      '-DCMAKE_EXE_LINKER_FLAGS=-nostdlib++',
-      '-DLIBCXXABI_ENABLE_PIC=OFF',
-      '-DLIBCXXABI_ENABLE_SHARED=OFF',
-      '-DLIBCXXABI_ENABLE_THREADS=OFF',
-      '-DLIBCXXABI_LIBDIR_SUFFIX=/wasm32-wasi',
-      '-DLIBCXXABI_LIBCXX_PATH=' + GetLLVMSrcDir('libcxx'),
-      '-DLIBCXXABI_LIBCXX_INCLUDES=' +
-      GetInstallDir('sysroot', 'include', 'c++', 'v1'),
-      '-DLLVM_PATH=' + GetLLVMSrcDir('llvm'),
-  ])
+    buildbot.Step('libcxxabi')
+    build_dir = os.path.join(work_dirs.GetBuild(), 'libcxxabi-out')
+    if os.path.isdir(build_dir):
+        Remove(build_dir)
+    Mkdir(build_dir)
+    src_dir = GetLLVMSrcDir('libcxxabi')
+    cc_env = BuildEnv(src_dir, bin_subdir=True)
+    command = CMakeCommandWasi([
+        src_dir,
+        '-DCMAKE_EXE_LINKER_FLAGS=-nostdlib++',
+        '-DLIBCXXABI_ENABLE_PIC=OFF',
+        '-DLIBCXXABI_ENABLE_SHARED=OFF',
+        '-DLIBCXXABI_ENABLE_THREADS=OFF',
+        '-DLIBCXXABI_LIBDIR_SUFFIX=/wasm32-wasi',
+        '-DLIBCXXABI_LIBCXX_PATH=' + GetLLVMSrcDir('libcxx'),
+        '-DLIBCXXABI_LIBCXX_INCLUDES=' +
+        GetInstallDir('sysroot', 'include', 'c++', 'v1'),
+        '-DLLVM_PATH=' + GetLLVMSrcDir('llvm'),
+    ])
 
-  proc.check_call(command, cwd=build_dir, env=cc_env)
-  proc.check_call(['ninja', '-v'], cwd=build_dir, env=cc_env)
-  proc.check_call(['ninja', 'install'], cwd=build_dir, env=cc_env)
-  CopyLibraryToSysroot(os.path.join(SCRIPT_DIR, 'libc++abi.imports'))
+    proc.check_call(command, cwd=build_dir, env=cc_env)
+    proc.check_call(['ninja', '-v'], cwd=build_dir, env=cc_env)
+    proc.check_call(['ninja', 'install'], cwd=build_dir, env=cc_env)
+    CopyLibraryToSysroot(os.path.join(SCRIPT_DIR, 'libc++abi.imports'))
 
 
 def WasiLibc():
-  buildbot.Step('Wasi')
-  build_dir = os.path.join(work_dirs.GetBuild(), 'wasi-libc-out')
-  if os.path.isdir(build_dir):
-    Remove(build_dir)
-  cc_env = BuildEnv(build_dir, use_gnuwin32=True)
-  src_dir = GetSrcDir('wasi-libc')
-  proc.check_call([proc.Which('make'),
-                   '-j%s' % NPROC,
-                   'SYSROOT=' + build_dir,
-                   'WASM_CC=' + GetInstallDir('bin', 'clang')],
-                  env=cc_env,
-                  cwd=src_dir)
-  CopyTree(build_dir, GetInstallDir('sysroot'))
+    buildbot.Step('Wasi')
+    build_dir = os.path.join(work_dirs.GetBuild(), 'wasi-libc-out')
+    if os.path.isdir(build_dir):
+        Remove(build_dir)
+    cc_env = BuildEnv(build_dir, use_gnuwin32=True)
+    src_dir = GetSrcDir('wasi-libc')
+    cmd = [
+        proc.Which('make'),
+        '-j%s' % NPROC, 'SYSROOT=' + build_dir,
+        'WASM_CC=' + GetInstallDir('bin', 'clang')
+    ]
+    proc.check_call(cmd, env=cc_env, cwd=src_dir)
+    CopyTree(build_dir, GetInstallDir('sysroot'))
 
-  # We add the cmake toolchain file and out JS polyfill script to make using
-  # the wasi toolchain easier.
-  shutil.copy2(os.path.join(SCRIPT_DIR, CMAKE_TOOLCHAIN_FILE),
-               GetInstallDir(CMAKE_TOOLCHAIN_FILE))
-  Remove(GetInstallDir('cmake'))
-  shutil.copytree(os.path.join(SCRIPT_DIR, 'cmake'),
-                  GetInstallDir('cmake'))
+    # We add the cmake toolchain file and out JS polyfill script to make using
+    # the wasi toolchain easier.
+    shutil.copy2(os.path.join(SCRIPT_DIR, CMAKE_TOOLCHAIN_FILE),
+                 GetInstallDir(CMAKE_TOOLCHAIN_FILE))
+    Remove(GetInstallDir('cmake'))
+    shutil.copytree(os.path.join(SCRIPT_DIR, 'cmake'), GetInstallDir('cmake'))
 
-  shutil.copy2(os.path.join(SCRIPT_DIR, 'wasi.js'), GetInstallDir())
+    shutil.copy2(os.path.join(SCRIPT_DIR, 'wasi.js'), GetInstallDir())
 
 
 def ArchiveBinaries():
-  buildbot.Step('Archive binaries')
-  if not buildbot.IsUploadingBot():
-    return
-  # All relevant binaries were copied to the LLVM directory.
-  UploadArchive(
-      'binaries', Archive(GetInstallDir(), print_content=buildbot.IsBot()))
+    buildbot.Step('Archive binaries')
+    if not buildbot.IsUploadingBot():
+        return
+    # All relevant binaries were copied to the LLVM directory.
+    UploadArchive('binaries',
+                  Archive(GetInstallDir(), print_content=buildbot.IsBot()))
 
 
 def DebianPackage():
-  if not (IsLinux() and buildbot.IsBot()):
-    return
+    if not (IsLinux() and buildbot.IsBot()):
+        return
 
-  buildbot.Step('Debian package')
-  top_dir = os.path.dirname(SCRIPT_DIR)
-  try:
-    if buildbot.BuildNumber():
-      message = ('Automatic build %s produced on http://wasm-stat.us' %
-                 buildbot.BuildNumber())
-      version = '0.1.' + buildbot.BuildNumber()
-      proc.check_call(['dch', '-D', 'unstable', '-v', version, message],
-                      cwd=top_dir)
-    proc.check_call(['debuild', '--no-lintian', '-i', '-us', '-uc', '-b'],
-                    cwd=top_dir)
-    if buildbot.BuildNumber():
-      proc.check_call(['git', 'checkout', 'debian/changelog'], cwd=top_dir)
+    buildbot.Step('Debian package')
+    top_dir = os.path.dirname(SCRIPT_DIR)
+    try:
+        if buildbot.BuildNumber():
+            message = ('Automatic build %s produced on http://wasm-stat.us' %
+                       buildbot.BuildNumber())
+            version = '0.1.' + buildbot.BuildNumber()
+            proc.check_call(['dch', '-D', 'unstable', '-v', version, message],
+                            cwd=top_dir)
+        proc.check_call(['debuild', '--no-lintian', '-i', '-us', '-uc', '-b'],
+                        cwd=top_dir)
+        if buildbot.BuildNumber():
+            proc.check_call(['git', 'checkout', 'debian/changelog'],
+                            cwd=top_dir)
 
-      debfile = os.path.join(os.path.dirname(top_dir),
-                             'wasm-toolchain_%s_amd64.deb' % version)
-      UploadFile(debfile, os.path.basename(debfile))
-  except proc.CalledProcessError:
-    # Note the failure but allow the build to continue.
-    buildbot.Fail()
-    return
+            debfile = os.path.join(os.path.dirname(top_dir),
+                                   'wasm-toolchain_%s_amd64.deb' % version)
+            UploadFile(debfile, os.path.basename(debfile))
+    except proc.CalledProcessError:
+        # Note the failure but allow the build to continue.
+        buildbot.Fail()
+        return
 
 
 def CompileLLVMTorture(outdir, opt):
-  name = 'Compile LLVM Torture (%s)' % opt
-  buildbot.Step(name)
-  install_bin = GetInstallDir('bin')
-  cc = Executable(os.path.join(install_bin, 'wasm32-wasi-clang'))
-  cxx = Executable(os.path.join(install_bin, 'wasm32-wasi-clang++'))
-  Remove(outdir)
-  Mkdir(outdir)
-  unexpected_result_count = compile_torture_tests.run(
-      cc=cc, cxx=cxx, testsuite=GccTestDir(),
-      sysroot_dir=GetInstallDir('sysroot'),
-      fails=[GetLLVMSrcDir('llvm', 'lib', 'Target',
-                           'WebAssembly', IT_IS_KNOWN)],
-      exclusions=LLVM_TORTURE_EXCLUSIONS,
-      out=outdir,
-      config='clang',
-      opt=opt)
-  if 0 != unexpected_result_count:
-    buildbot.Fail()
+    name = 'Compile LLVM Torture (%s)' % opt
+    buildbot.Step(name)
+    install_bin = GetInstallDir('bin')
+    cc = Executable(os.path.join(install_bin, 'wasm32-wasi-clang'))
+    cxx = Executable(os.path.join(install_bin, 'wasm32-wasi-clang++'))
+    Remove(outdir)
+    Mkdir(outdir)
+    unexpected_result_count = compile_torture_tests.run(
+        cc=cc,
+        cxx=cxx,
+        testsuite=GccTestDir(),
+        sysroot_dir=GetInstallDir('sysroot'),
+        fails=[
+            GetLLVMSrcDir('llvm', 'lib', 'Target', 'WebAssembly', IT_IS_KNOWN)
+        ],
+        exclusions=LLVM_TORTURE_EXCLUSIONS,
+        out=outdir,
+        config='clang',
+        opt=opt)
+    if 0 != unexpected_result_count:
+        buildbot.Fail()
 
 
 def CompileLLVMTortureEmscripten(name, em_config, outdir, fails, opt):
-  buildbot.Step('Compile LLVM Torture (%s, %s)' % (name, opt))
-  os.environ['EM_CONFIG'] = em_config
-  cc = Executable(GetInstallDir('emscripten', 'emcc'), '.bat')
-  cxx = Executable(GetInstallDir('emscripten', 'em++'), '.bat')
-  Remove(outdir)
-  Mkdir(outdir)
-  unexpected_result_count = compile_torture_tests.run(
-      cc=cc, cxx=cxx, testsuite=GccTestDir(),
-      sysroot_dir=GetInstallDir('sysroot'),
-      fails=fails,
-      exclusions=LLVM_TORTURE_EXCLUSIONS,
-      out=outdir,
-      config='emscripten',
-      opt=opt)
+    buildbot.Step('Compile LLVM Torture (%s, %s)' % (name, opt))
+    os.environ['EM_CONFIG'] = em_config
+    cc = Executable(GetInstallDir('emscripten', 'emcc'), '.bat')
+    cxx = Executable(GetInstallDir('emscripten', 'em++'), '.bat')
+    Remove(outdir)
+    Mkdir(outdir)
+    unexpected_result_count = compile_torture_tests.run(
+        cc=cc,
+        cxx=cxx,
+        testsuite=GccTestDir(),
+        sysroot_dir=GetInstallDir('sysroot'),
+        fails=fails,
+        exclusions=LLVM_TORTURE_EXCLUSIONS,
+        out=outdir,
+        config='emscripten',
+        opt=opt)
 
-  if 0 != unexpected_result_count:
-    buildbot.Fail()
-
-
-def LinkLLVMTorture(name, linker, fails, indir, outdir, extension,
-                    opt, args=None):
-  buildbot.Step('Link LLVM Torture (%s, %s)' % (name, opt))
-  assert os.path.isfile(linker), 'Cannot find linker at %s' % linker
-  Remove(outdir)
-  Mkdir(outdir)
-  input_pattern = os.path.join(indir, '*.' + extension)
-  unexpected_result_count = link_assembly_files.run(
-      linker=linker, files=input_pattern, fails=fails, attributes=[opt],
-      out=outdir, args=args)
-  if 0 != unexpected_result_count:
-    buildbot.Fail()
+    if 0 != unexpected_result_count:
+        buildbot.Fail()
 
 
-def ExecuteLLVMTorture(name, runner, indir, fails, attributes, extension, opt,
-                       outdir='', wasmjs='', extra_files=None,
+def LinkLLVMTorture(name,
+                    linker,
+                    fails,
+                    indir,
+                    outdir,
+                    extension,
+                    opt,
+                    args=None):
+    buildbot.Step('Link LLVM Torture (%s, %s)' % (name, opt))
+    assert os.path.isfile(linker), 'Cannot find linker at %s' % linker
+    Remove(outdir)
+    Mkdir(outdir)
+    input_pattern = os.path.join(indir, '*.' + extension)
+    unexpected_result_count = link_assembly_files.run(linker=linker,
+                                                      files=input_pattern,
+                                                      fails=fails,
+                                                      attributes=[opt],
+                                                      out=outdir,
+                                                      args=args)
+    if 0 != unexpected_result_count:
+        buildbot.Fail()
+
+
+def ExecuteLLVMTorture(name,
+                       runner,
+                       indir,
+                       fails,
+                       attributes,
+                       extension,
+                       opt,
+                       outdir='',
+                       wasmjs='',
+                       extra_files=None,
                        warn_only=False):
-  extra_files = [] if extra_files is None else extra_files
+    extra_files = [] if extra_files is None else extra_files
 
-  buildbot.Step('Execute LLVM Torture (%s, %s)' % (name, opt))
-  if not indir:
-    print('Step skipped: no input')
-    buildbot.Warn()
-    return None
-  assert os.path.isfile(runner), 'Cannot find runner at %s' % runner
-  files = os.path.join(indir, '*.%s' % extension)
-  if len(glob.glob(files)) == 0:
-    print("No files found by", files)
-    buildbot.Fail()
-    return
-  unexpected_result_count = execute_files.run(
-      runner=runner,
-      files=files,
-      fails=fails,
-      attributes=attributes + [opt],
-      out=outdir,
-      wasmjs=wasmjs,
-      extra_files=extra_files)
-  if 0 != unexpected_result_count:
-    buildbot.FailUnless(lambda: warn_only)
+    buildbot.Step('Execute LLVM Torture (%s, %s)' % (name, opt))
+    if not indir:
+        print('Step skipped: no input')
+        buildbot.Warn()
+        return None
+    assert os.path.isfile(runner), 'Cannot find runner at %s' % runner
+    files = os.path.join(indir, '*.%s' % extension)
+    if len(glob.glob(files)) == 0:
+        print("No files found by", files)
+        buildbot.Fail()
+        return
+    unexpected_result_count = execute_files.run(runner=runner,
+                                                files=files,
+                                                fails=fails,
+                                                attributes=attributes + [opt],
+                                                out=outdir,
+                                                wasmjs=wasmjs,
+                                                extra_files=extra_files)
+    if 0 != unexpected_result_count:
+        buildbot.FailUnless(lambda: warn_only)
 
 
 def ValidateLLVMTorture(indir, ext, opt):
-  validate = Executable(os.path.join(GetInstallDir('bin'), 'wasm-validate'))
-  # Object files contain a DataCount section, so enable bulk memory
-  ExecuteLLVMTorture(name='validate',
-                     runner=validate,
-                     indir=indir,
-                     fails=None,
-                     attributes=[opt],
-                     extension=ext,
-                     opt=opt)
+    validate = Executable(os.path.join(GetInstallDir('bin'), 'wasm-validate'))
+    # Object files contain a DataCount section, so enable bulk memory
+    ExecuteLLVMTorture(name='validate',
+                       runner=validate,
+                       indir=indir,
+                       fails=None,
+                       attributes=[opt],
+                       extension=ext,
+                       opt=opt)
 
 
 class Build(object):
-  def __init__(self, name_, runnable_, os_filter=None, is_default=True,
-               *args, **kwargs):
-    self.name = name_
-    self.runnable = runnable_
-    self.os_filter = os_filter
-    self.is_deafult = is_default
-    self.args = args
-    self.kwargs = kwargs
+    def __init__(self,
+                 name_,
+                 runnable_,
+                 os_filter=None,
+                 is_default=True,
+                 *args,
+                 **kwargs):
+        self.name = name_
+        self.runnable = runnable_
+        self.os_filter = os_filter
+        self.is_deafult = is_default
+        self.args = args
+        self.kwargs = kwargs
 
-  def Run(self):
-    if self.os_filter and not self.os_filter.Check(BuilderPlatformName()):
-      print("Skipping %s: Doesn't work on %s" % (self.runnable.__name__,
-                                                 BuilderPlatformName()))
-      return
-    self.runnable(*self.args, **self.kwargs)
+    def Run(self):
+        if self.os_filter and not self.os_filter.Check(BuilderPlatformName()):
+            print("Skipping %s: Doesn't work on %s" %
+                  (self.runnable.__name__, BuilderPlatformName()))
+            return
+        self.runnable(*self.args, **self.kwargs)
 
 
 def Summary():
-  buildbot.Step('Summary')
+    buildbot.Step('Summary')
 
-  # Emscripten-releases bots run the stages separately so LKGR has no way of
-  # knowing whether everything passed or not.
-  should_upload = (buildbot.IsUploadingBot() and not
-                   buildbot.IsEmscriptenReleasesBot())
+    # Emscripten-releases bots run the stages separately so LKGR has no way of
+    # knowing whether everything passed or not.
+    should_upload = (buildbot.IsUploadingBot() and
+                     not buildbot.IsEmscriptenReleasesBot())
 
-  if should_upload:
-    info = {'repositories': GetRepoInfo()}
-    info['build'] = buildbot.BuildNumber()
-    info['scheduler'] = buildbot.Scheduler()
-    info_file = GetInstallDir('buildinfo.json')
-    info_json = json.dumps(info, indent=2)
-    print(info_json)
-
-    with open(info_file, 'w+') as f:
-      f.write(info_json)
-      f.write('\n')
-
-  print('Failed steps: %s.' % buildbot.Failed())
-  for step in buildbot.FailedList():
-    print('    %s' % step)
-  print('Warned steps: %s.' % buildbot.Warned())
-  for step in buildbot.WarnedList():
-    print('    %s' % step)
-
-  if should_upload:
-    latest_file = '%s/%s' % (buildbot.BuilderName(), 'latest.json')
-    buildbot.Link('latest.json', cloud.Upload(info_file, latest_file))
-
-  if buildbot.Failed():
-    buildbot.Fail()
-  else:
     if should_upload:
-      lkgr_file = '%s/%s' % (buildbot.BuilderName(), 'lkgr.json')
-      buildbot.Link('lkgr.json', cloud.Upload(info_file, lkgr_file))
+        info = {'repositories': GetRepoInfo()}
+        info['build'] = buildbot.BuildNumber()
+        info['scheduler'] = buildbot.Scheduler()
+        info_file = GetInstallDir('buildinfo.json')
+        info_json = json.dumps(info, indent=2)
+        print(info_json)
+
+        with open(info_file, 'w+') as f:
+            f.write(info_json)
+            f.write('\n')
+
+    print('Failed steps: %s.' % buildbot.Failed())
+    for step in buildbot.FailedList():
+        print('    %s' % step)
+    print('Warned steps: %s.' % buildbot.Warned())
+    for step in buildbot.WarnedList():
+        print('    %s' % step)
+
+    if should_upload:
+        latest_file = '%s/%s' % (buildbot.BuilderName(), 'latest.json')
+        buildbot.Link('latest.json', cloud.Upload(info_file, latest_file))
+
+    if buildbot.Failed():
+        buildbot.Fail()
+    else:
+        if should_upload:
+            lkgr_file = '%s/%s' % (buildbot.BuilderName(), 'lkgr.json')
+            buildbot.Link('lkgr.json', cloud.Upload(info_file, lkgr_file))
 
 
 def AllBuilds():
-  return [
-      # Host tools
-      Build('llvm', LLVM),
-      Build('llvm-test-depends', LLVMTestDepends),
-      Build('v8', V8, os_filter=Filter(exclude=['mac'])),
-      Build('jsvu', Jsvu, os_filter=Filter(exclude=['windows'])),
-      Build('wabt', Wabt),
-      Build('binaryen', Binaryen),
-      Build('fastcomp', Fastcomp),
-      Build('emscripten-upstream', Emscripten, None, True, 'upstream'),
-      Build('emscripten-fastcomp', Emscripten, None, True, 'fastcomp'),
-      # Target libs
-      # TODO: re-enable wasi on windows, see #517
-      Build('wasi-libc', WasiLibc, os_filter=Filter(exclude=['windows'])),
-      Build('compiler-rt', CompilerRT, os_filter=Filter(exclude=['windows'])),
-      Build('libcxx', LibCXX, os_filter=Filter(exclude=['windows'])),
-      Build('libcxxabi', LibCXXABI, os_filter=Filter(exclude=['windows'])),
-      # Archive
-      Build('archive', ArchiveBinaries),
-      Build('debian', DebianPackage),
-  ]
+    return [
+        # Host tools
+        Build('llvm', LLVM),
+        Build('llvm-test-depends', LLVMTestDepends),
+        Build('v8', V8, os_filter=Filter(exclude=['mac'])),
+        Build('jsvu', Jsvu, os_filter=Filter(exclude=['windows'])),
+        Build('wabt', Wabt),
+        Build('binaryen', Binaryen),
+        Build('fastcomp', Fastcomp),
+        Build('emscripten-upstream', Emscripten, None, True, 'upstream'),
+        Build('emscripten-fastcomp', Emscripten, None, True, 'fastcomp'),
+        # Target libs
+        # TODO: re-enable wasi on windows, see #517
+        Build('wasi-libc', WasiLibc, os_filter=Filter(exclude=['windows'])),
+        Build('compiler-rt', CompilerRT,
+              os_filter=Filter(exclude=['windows'])),
+        Build('libcxx', LibCXX, os_filter=Filter(exclude=['windows'])),
+        Build('libcxxabi', LibCXXABI, os_filter=Filter(exclude=['windows'])),
+        # Archive
+        Build('archive', ArchiveBinaries),
+        Build('debian', DebianPackage),
+    ]
 
 
 # For now, just the builds used to test WASI and emscripten torture tests
 # on wasm-stat.us
-DEFAULT_BUILDS = ['llvm', 'v8', 'jsvu', 'wabt', 'binaryen', 'fastcomp',
-                  'emscripten-upstream', 'emscripten-fastcomp', 'wasi-libc',
-                  'compiler-rt', 'libcxx', 'libcxxabi']
+DEFAULT_BUILDS = [
+    'llvm', 'v8', 'jsvu', 'wabt', 'binaryen', 'fastcomp',
+    'emscripten-upstream', 'emscripten-fastcomp', 'wasi-libc', 'compiler-rt',
+    'libcxx', 'libcxxabi'
+]
 
 
 def BuildRepos(filter):
-  for rule in filter.Apply(AllBuilds()):
-    rule.Run()
+    for rule in filter.Apply(AllBuilds()):
+        rule.Run()
 
 
 class Test(object):
-  def __init__(self, name_, runnable_, os_filter=None):
-    self.name = name_
-    self.runnable = runnable_
-    self.os_filter = os_filter
+    def __init__(self, name_, runnable_, os_filter=None):
+        self.name = name_
+        self.runnable = runnable_
+        self.os_filter = os_filter
 
-  def Test(self):
-    if self.os_filter and not self.os_filter.Check(BuilderPlatformName()):
-      print("Skipping %s: Doesn't work on %s" % (self.name,
-                                                 BuilderPlatformName()))
-      return
-    self.runnable()
+    def Test(self):
+        if self.os_filter and not self.os_filter.Check(BuilderPlatformName()):
+            print("Skipping %s: Doesn't work on %s" %
+                  (self.name, BuilderPlatformName()))
+            return
+        self.runnable()
 
 
 def GetTortureDir(name, opt):
-  dirs = {
-      'asm2wasm': GetTestDir('asm2wasm-torture-out', opt),
-      'emwasm': GetTestDir('emwasm-torture-out', opt),
-  }
-  if name in dirs:
-    return dirs[name]
-  return GetTestDir('torture-' + name, opt)
+    dirs = {
+        'asm2wasm': GetTestDir('asm2wasm-torture-out', opt),
+        'emwasm': GetTestDir('emwasm-torture-out', opt),
+    }
+    if name in dirs:
+        return dirs[name]
+    return GetTestDir('torture-' + name, opt)
 
 
 def TestBare():
-  # Compile
-  for opt in BARE_TEST_OPT_FLAGS:
-    CompileLLVMTorture(GetTortureDir('o', opt), opt)
-    ValidateLLVMTorture(GetTortureDir('o', opt), 'o', opt)
-
-  # Link/Assemble
-  for opt in BARE_TEST_OPT_FLAGS:
-    LinkLLVMTorture(
-        name='lld',
-        linker=Executable(GetInstallDir('bin', 'wasm32-wasi-clang++')),
-        fails=LLD_KNOWN_TORTURE_FAILURES,
-        indir=GetTortureDir('o', opt),
-        outdir=GetTortureDir('lld', opt),
-        extension='o',
-        opt=opt)
-
-  # Execute
-  common_attrs = ['bare']
-  common_attrs += ['win'] if IsWindows() else ['posix']
-
-  # Avoid d8 execution on windows because of flakiness,
-  # https://bugs.chromium.org/p/v8/issues/detail?id=8211
-  if not IsWindows():
+    # Compile
     for opt in BARE_TEST_OPT_FLAGS:
-      ExecuteLLVMTorture(
-          name='d8',
-          runner=D8Bin(),
-          indir=GetTortureDir('lld', opt),
-          fails=RUN_KNOWN_TORTURE_FAILURES,
-          attributes=common_attrs + ['d8', 'lld', opt],
-          extension='wasm',
-          opt=opt,
-          wasmjs=os.path.join(SCRIPT_DIR, 'wasi.js'))
+        CompileLLVMTorture(GetTortureDir('o', opt), opt)
+        ValidateLLVMTorture(GetTortureDir('o', opt), 'o', opt)
 
-  if IsMac() and not buildbot.DidStepFailOrWarn('jsvu'):
+    # Link/Assemble
     for opt in BARE_TEST_OPT_FLAGS:
-      ExecuteLLVMTorture(
-          name='jsc',
-          runner=os.path.join(JSVU_OUT_DIR, 'jsc'),
-          indir=GetTortureDir('lld', opt),
-          fails=RUN_KNOWN_TORTURE_FAILURES,
-          attributes=common_attrs + ['jsc', 'lld'],
-          extension='wasm',
-          opt=opt,
-          warn_only=True,
-          wasmjs=os.path.join(SCRIPT_DIR, 'wasi.js'))
+        LinkLLVMTorture(name='lld',
+                        linker=Executable(
+                            GetInstallDir('bin', 'wasm32-wasi-clang++')),
+                        fails=LLD_KNOWN_TORTURE_FAILURES,
+                        indir=GetTortureDir('o', opt),
+                        outdir=GetTortureDir('lld', opt),
+                        extension='o',
+                        opt=opt)
+
+    # Execute
+    common_attrs = ['bare']
+    common_attrs += ['win'] if IsWindows() else ['posix']
+
+    # Avoid d8 execution on windows because of flakiness,
+    # https://bugs.chromium.org/p/v8/issues/detail?id=8211
+    if not IsWindows():
+        for opt in BARE_TEST_OPT_FLAGS:
+            ExecuteLLVMTorture(name='d8',
+                               runner=D8Bin(),
+                               indir=GetTortureDir('lld', opt),
+                               fails=RUN_KNOWN_TORTURE_FAILURES,
+                               attributes=common_attrs + ['d8', 'lld', opt],
+                               extension='wasm',
+                               opt=opt,
+                               wasmjs=os.path.join(SCRIPT_DIR, 'wasi.js'))
+
+    if IsMac() and not buildbot.DidStepFailOrWarn('jsvu'):
+        for opt in BARE_TEST_OPT_FLAGS:
+            ExecuteLLVMTorture(name='jsc',
+                               runner=os.path.join(JSVU_OUT_DIR, 'jsc'),
+                               indir=GetTortureDir('lld', opt),
+                               fails=RUN_KNOWN_TORTURE_FAILURES,
+                               attributes=common_attrs + ['jsc', 'lld'],
+                               extension='wasm',
+                               opt=opt,
+                               warn_only=True,
+                               wasmjs=os.path.join(SCRIPT_DIR, 'wasi.js'))
 
 
 def TestAsm():
-  for opt in EMSCRIPTEN_TEST_OPT_FLAGS:
-    CompileLLVMTortureEmscripten(
-        'asm2wasm',
-        GetInstallDir(EMSCRIPTEN_CONFIG_FASTCOMP),
-        GetTortureDir('asm2wasm', opt),
-        ASM2WASM_KNOWN_TORTURE_COMPILE_FAILURES,
-        opt)
-
-  # Avoid d8 execution on windows because of flakiness,
-  # https://bugs.chromium.org/p/v8/issues/detail?id=8211
-  if not IsWindows():
     for opt in EMSCRIPTEN_TEST_OPT_FLAGS:
-      ExecuteLLVMTorture(
-          name='asm2wasm',
-          runner=D8Bin(),
-          indir=GetTortureDir('asm2wasm', opt),
-          fails=RUN_KNOWN_TORTURE_FAILURES,
-          attributes=['asm2wasm', 'd8'],
-          extension='c.js',
-          opt=opt,
-          # emscripten's wasm.js expects all files in cwd.
-          outdir=GetTortureDir('asm2wasm', opt))
+        CompileLLVMTortureEmscripten('asm2wasm',
+                                     GetInstallDir(EMSCRIPTEN_CONFIG_FASTCOMP),
+                                     GetTortureDir('asm2wasm', opt),
+                                     ASM2WASM_KNOWN_TORTURE_COMPILE_FAILURES,
+                                     opt)
+
+    # Avoid d8 execution on windows because of flakiness,
+    # https://bugs.chromium.org/p/v8/issues/detail?id=8211
+    if not IsWindows():
+        for opt in EMSCRIPTEN_TEST_OPT_FLAGS:
+            ExecuteLLVMTorture(
+                name='asm2wasm',
+                runner=D8Bin(),
+                indir=GetTortureDir('asm2wasm', opt),
+                fails=RUN_KNOWN_TORTURE_FAILURES,
+                attributes=['asm2wasm', 'd8'],
+                extension='c.js',
+                opt=opt,
+                # emscripten's wasm.js expects all files in cwd.
+                outdir=GetTortureDir('asm2wasm', opt))
 
 
 def TestEmwasm():
-  for opt in EMSCRIPTEN_TEST_OPT_FLAGS:
-    CompileLLVMTortureEmscripten(
-        'emwasm',
-        GetInstallDir(EMSCRIPTEN_CONFIG_UPSTREAM),
-        GetTortureDir('emwasm', opt),
-        EMWASM_KNOWN_TORTURE_COMPILE_FAILURES,
-        opt)
-
-  # Avoid d8 execution on windows because of flakiness,
-  # https://bugs.chromium.org/p/v8/issues/detail?id=8211
-  if not IsWindows():
     for opt in EMSCRIPTEN_TEST_OPT_FLAGS:
-      ExecuteLLVMTorture(
-          name='emwasm',
-          runner=D8Bin(),
-          indir=GetTortureDir('emwasm', opt),
-          fails=RUN_KNOWN_TORTURE_FAILURES,
-          attributes=['emwasm', 'lld', 'd8'],
-          extension='c.js',
-          opt=opt,
-          outdir=GetTortureDir('emwasm', opt))
+        CompileLLVMTortureEmscripten('emwasm',
+                                     GetInstallDir(EMSCRIPTEN_CONFIG_UPSTREAM),
+                                     GetTortureDir('emwasm', opt),
+                                     EMWASM_KNOWN_TORTURE_COMPILE_FAILURES,
+                                     opt)
+
+    # Avoid d8 execution on windows because of flakiness,
+    # https://bugs.chromium.org/p/v8/issues/detail?id=8211
+    if not IsWindows():
+        for opt in EMSCRIPTEN_TEST_OPT_FLAGS:
+            ExecuteLLVMTorture(name='emwasm',
+                               runner=D8Bin(),
+                               indir=GetTortureDir('emwasm', opt),
+                               fails=RUN_KNOWN_TORTURE_FAILURES,
+                               attributes=['emwasm', 'lld', 'd8'],
+                               extension='c.js',
+                               opt=opt,
+                               outdir=GetTortureDir('emwasm', opt))
 
 
 def ExecuteEmscriptenTestSuite(name, tests, config, outdir, warn_only=False):
-  buildbot.Step('Execute emscripten testsuite (%s)' % name)
-  Mkdir(outdir)
-  try:
-    proc.check_call(['npm', 'ci'], cwd=GetInstallDir('emscripten'))
-    proc.check_call(
-        [GetInstallDir('emscripten', 'tests', 'runner.py'),
-         '--em-config', config] + tests,
-        cwd=outdir)
-  except proc.CalledProcessError:
-    buildbot.FailUnless(lambda: warn_only)
+    buildbot.Step('Execute emscripten testsuite (%s)' % name)
+    Mkdir(outdir)
+    try:
+        proc.check_call(['npm', 'ci'], cwd=GetInstallDir('emscripten'))
+        cmd = [
+            GetInstallDir('emscripten', 'tests', 'runner.py'),
+            '--em-config', config
+        ] + tests
+        proc.check_call(cmd, cwd=outdir)
+    except proc.CalledProcessError:
+        buildbot.FailUnless(lambda: warn_only)
 
 
 def TestEmtest():
-  tests = options.test_params if options.test_params else ['wasm2', 'other']
-  ExecuteEmscriptenTestSuite(
-      'emwasm',
-      tests,
-      GetInstallDir(EMSCRIPTEN_CONFIG_UPSTREAM),
-      os.path.join(work_dirs.GetTest(), 'emtest-out'))
+    tests = options.test_params if options.test_params else ['wasm2', 'other']
+    ExecuteEmscriptenTestSuite('emwasm', tests,
+                               GetInstallDir(EMSCRIPTEN_CONFIG_UPSTREAM),
+                               os.path.join(work_dirs.GetTest(), 'emtest-out'))
 
 
 def TestEmtestAsm2Wasm():
-  tests = options.test_params if options.test_params else ['wasm2']
-  ExecuteEmscriptenTestSuite(
-      'asm2wasm',
-      tests,
-      GetInstallDir(EMSCRIPTEN_CONFIG_FASTCOMP),
-      os.path.join(work_dirs.GetTest(), 'emtest-asm2wasm-out'))
+    tests = options.test_params if options.test_params else ['wasm2']
+    ExecuteEmscriptenTestSuite(
+        'asm2wasm', tests, GetInstallDir(EMSCRIPTEN_CONFIG_FASTCOMP),
+        os.path.join(work_dirs.GetTest(), 'emtest-asm2wasm-out'))
 
 
 def TestLLVMTestSuite():
-  buildbot.Step('Execute LLVM TestSuite (emwasm)')
+    buildbot.Step('Execute LLVM TestSuite (emwasm)')
 
-  outdir = GetBuildDir('llvmtest-out')
-  # The compiler changes on every run, so incremental builds don't make sense.
-  Remove(outdir)
-  Mkdir(outdir)
-  # The C++ tests explicitly link libstdc++ for some reason, but we use libc++
-  # and it's unnecessary to link it anyway. So create an empty libstdc++.a
-  proc.check_call([GetInstallDir('bin', 'llvm-ar'), 'rc', 'libstdc++.a'],
-                  cwd=outdir)
-  # This has to be in the environment and not TEST_SUITE_EXTRA_C_FLAGS because
-  # CMake doesn't append the flags to the try-compiles.
-  os.environ['EM_CONFIG'] = GetInstallDir(EMSCRIPTEN_CONFIG_UPSTREAM)
-  command = [GetInstallDir('emscripten', 'emcmake')] + CMakeCommandBase() + [
-      GetSrcDir('llvm-test-suite'),
-      '-DCMAKE_C_COMPILER=' + GetInstallDir('emscripten', 'emcc'),
-      '-DCMAKE_CXX_COMPILER=' + GetInstallDir('emscripten', 'em++'),
-      '-DTEST_SUITE_RUN_UNDER=' + NodeBin(),
-      '-DTEST_SUITE_USER_MODE_EMULATION=ON',
-      '-DTEST_SUITE_SUBDIRS=SingleSource',
-      '-DTEST_SUITE_EXTRA_EXE_LINKER_FLAGS=' +
-      '-L %s -s TOTAL_MEMORY=1024MB' % outdir,
-      '-DTEST_SUITE_LLVM_SIZE=' + GetInstallDir('emscripten', 'emsize.py')]
+    outdir = GetBuildDir('llvmtest-out')
+    # The compiler changes on every run, so incremental builds don't make
+    # sense.
+    Remove(outdir)
+    Mkdir(outdir)
+    # The C++ tests explicitly link libstdc++ for some reason, but we use
+    # libc++ and it's unnecessary to link it anyway. So create an empty
+    # libstdc++.a
+    proc.check_call([GetInstallDir('bin', 'llvm-ar'), 'rc', 'libstdc++.a'],
+                    cwd=outdir)
+    # This has to be in the environment and not TEST_SUITE_EXTRA_C_FLAGS
+    # because CMake doesn't append the flags to the try-compiles.
+    os.environ['EM_CONFIG'] = GetInstallDir(EMSCRIPTEN_CONFIG_UPSTREAM)
+    command = [GetInstallDir('emscripten', 'emcmake')] + CMakeCommandBase() + [
+        GetSrcDir('llvm-test-suite'), '-DCMAKE_C_COMPILER=' +
+        GetInstallDir('emscripten', 'emcc'), '-DCMAKE_CXX_COMPILER=' +
+        GetInstallDir('emscripten', 'em++'), '-DTEST_SUITE_RUN_UNDER=' +
+        NodeBin(), '-DTEST_SUITE_USER_MODE_EMULATION=ON',
+        '-DTEST_SUITE_SUBDIRS=SingleSource',
+        '-DTEST_SUITE_EXTRA_EXE_LINKER_FLAGS=' +
+        '-L %s -s TOTAL_MEMORY=1024MB' % outdir,
+        '-DTEST_SUITE_LLVM_SIZE=' + GetInstallDir('emscripten', 'emsize.py')
+    ]
 
-  proc.check_call(command, cwd=outdir)
-  proc.check_call(['ninja', '-v'], cwd=outdir)
-  results_file = 'results.json'
-  proc.call([GetBuildDir('llvm-out', 'bin', 'llvm-lit'),
-             '-v', '-o', results_file, '.'], cwd=outdir)
+    proc.check_call(command, cwd=outdir)
+    proc.check_call(['ninja', '-v'], cwd=outdir)
+    results_file = 'results.json'
+    lit = GetBuildDir('llvm-out', 'bin', 'llvm-lit')
+    proc.call([lit, '-v', '-o', results_file, '.'], cwd=outdir)
 
-  with open(os.path.join(outdir, results_file)) as results_fd:
-    json_results = json.loads(results_fd.read())
+    with open(os.path.join(outdir, results_file)) as results_fd:
+        json_results = json.loads(results_fd.read())
 
-  def get_names(code):
-    # Strip the unneccessary spaces from the test name
-    return [r['name'].replace('test-suite :: ', '')
-            for r in json_results['tests'] if r['code'] == code]
+    def get_names(code):
+        # Strip the unneccessary spaces from the test name
+        return [
+            r['name'].replace('test-suite :: ', '')
+            for r in json_results['tests'] if r['code'] == code
+        ]
 
-  failures = get_names('FAIL')
-  successes = get_names('PASS')
+    failures = get_names('FAIL')
+    successes = get_names('PASS')
 
-  expected_failures = testing.parse_exclude_files(RUN_LLVM_TESTSUITE_FAILURES,
-                                                  [])
-  unexpected_failures = [f for f in failures if f not in expected_failures]
-  unexpected_successes = [f for f in successes if f in expected_failures]
+    expected_failures = testing.parse_exclude_files(
+        RUN_LLVM_TESTSUITE_FAILURES, [])
+    unexpected_failures = [f for f in failures if f not in expected_failures]
+    unexpected_successes = [f for f in successes if f in expected_failures]
 
-  if len(unexpected_failures) > 0:
-    print('Emscripten unexpected failures:')
-    for test in unexpected_failures:
-      print(test)
-  if len(unexpected_successes) > 0:
-    print('Emscripten unexpected successes:')
-    for test in unexpected_successes:
-      print(test)
+    if len(unexpected_failures) > 0:
+        print('Emscripten unexpected failures:')
+        for test in unexpected_failures:
+            print(test)
+    if len(unexpected_successes) > 0:
+        print('Emscripten unexpected successes:')
+        for test in unexpected_successes:
+            print(test)
 
-  if len(unexpected_failures) + len(unexpected_successes) > 0:
-    buildbot.Fail()
+    if len(unexpected_failures) + len(unexpected_successes) > 0:
+        buildbot.Fail()
 
 
 ALL_TESTS = [
@@ -1716,217 +1799,220 @@ DEFAULT_TESTS = ['bare', 'emwasm', 'llvmtest']
 
 
 def TextWrapNameList(prefix, items):
-  width = 80  # TODO(binji): better guess?
-  names = sorted(item.name for item in items)
-  return '%s%s' % (prefix, textwrap.fill(' '.join(names), width,
-                                         initial_indent='  ',
-                                         subsequent_indent='  '))
+    width = 80  # TODO(binji): better guess?
+    names = sorted(item.name for item in items)
+    return '%s%s' % (prefix,
+                     textwrap.fill(' '.join(names),
+                                   width,
+                                   initial_indent='  ',
+                                   subsequent_indent='  '))
 
 
 def ParseArgs():
-  def SplitComma(arg):
-    if not arg:
-      return None
-    return arg.split(',')
+    def SplitComma(arg):
+        if not arg:
+            return None
+        return arg.split(',')
 
-  epilog = '\n\n'.join([
-      TextWrapNameList('sync targets:\n', AllSources()),
-      TextWrapNameList('build targets:\n', AllBuilds()),
-      TextWrapNameList('test targets:\n', ALL_TESTS),
-  ])
+    epilog = '\n\n'.join([
+        TextWrapNameList('sync targets:\n', AllSources()),
+        TextWrapNameList('build targets:\n', AllBuilds()),
+        TextWrapNameList('test targets:\n', ALL_TESTS),
+    ])
 
-  parser = argparse.ArgumentParser(
-      description='Wasm waterfall top-level CI script',
-      formatter_class=argparse.RawDescriptionHelpFormatter,
-      epilog=epilog)
+    parser = argparse.ArgumentParser(
+        description='Wasm waterfall top-level CI script',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=epilog)
 
-  parser.add_argument(
-      '--sync-dir', dest='sync_dir', help='Directory for syncing sources')
-  parser.add_argument(
-      '--build-dir', dest='build_dir', help='Directory for build output')
-  parser.add_argument(
-      '--prebuilt-dir', dest='prebuilt_dir',
-      help='Directory for prebuilt output')
-  parser.add_argument(
-      '--v8-dir', dest='v8_dir',
-      help='Directory for V8 checkout/build')
-  parser.add_argument(
-      '--test-dir', dest='test_dir', help='Directory for test output')
-  parser.add_argument(
-      '--install-dir', dest='install_dir',
-      help='Directory for installed output')
+    parser.add_argument(
+        '--sync-dir', dest='sync_dir', help='Directory for syncing sources')
+    parser.add_argument(
+        '--build-dir', dest='build_dir', help='Directory for build output')
+    parser.add_argument(
+        '--prebuilt-dir', dest='prebuilt_dir',
+        help='Directory for prebuilt output')
+    parser.add_argument(
+        '--v8-dir', dest='v8_dir',
+        help='Directory for V8 checkout/build')
+    parser.add_argument(
+        '--test-dir', dest='test_dir', help='Directory for test output')
+    parser.add_argument(
+        '--install-dir', dest='install_dir',
+        help='Directory for installed output')
 
-  sync_grp = parser.add_mutually_exclusive_group()
-  sync_grp.add_argument(
-      '--no-sync', dest='sync', default=True, action='store_false',
-      help='Skip fetching and checking out source repos')
-  sync_grp.add_argument(
-      '--sync-include', dest='sync_include', default='', type=SplitComma,
-      help='Include only the comma-separated list of sync targets')
-  sync_grp.add_argument(
-      '--sync-exclude', dest='sync_exclude', default='', type=SplitComma,
-      help='Exclude the comma-separated list of sync targets')
+    sync_grp = parser.add_mutually_exclusive_group()
+    sync_grp.add_argument(
+        '--no-sync', dest='sync', default=True, action='store_false',
+        help='Skip fetching and checking out source repos')
+    sync_grp.add_argument(
+        '--sync-include', dest='sync_include', default='', type=SplitComma,
+        help='Include only the comma-separated list of sync targets')
+    sync_grp.add_argument(
+        '--sync-exclude', dest='sync_exclude', default='', type=SplitComma,
+        help='Exclude the comma-separated list of sync targets')
 
-  parser.add_argument(
-      '--sync-lkgr', dest='sync_lkgr', default=False, action='store_true',
-      help='When syncing, only sync up to the Last Known Good Revision '
-           'for each sync target')
+    parser.add_argument(
+        '--sync-lkgr', dest='sync_lkgr', default=False, action='store_true',
+        help='When syncing, only sync up to the Last Known Good Revision '
+             'for each sync target')
 
-  build_grp = parser.add_mutually_exclusive_group()
-  build_grp.add_argument(
-      '--no-build', dest='build', default=True, action='store_false',
-      help='Skip building source repos (also skips V8 and LLVM unit tests)')
-  build_grp.add_argument(
-      '--build-include', dest='build_include', default='', type=SplitComma,
-      help='Include only the comma-separated list of build targets')
-  build_grp.add_argument(
-      '--build-exclude', dest='build_exclude', default='', type=SplitComma,
-      help='Exclude the comma-separated list of build targets')
+    build_grp = parser.add_mutually_exclusive_group()
+    build_grp.add_argument(
+        '--no-build', dest='build', default=True, action='store_false',
+        help='Skip building source repos (also skips V8 and LLVM unit tests)')
+    build_grp.add_argument(
+        '--build-include', dest='build_include', default='', type=SplitComma,
+        help='Include only the comma-separated list of build targets')
+    build_grp.add_argument(
+        '--build-exclude', dest='build_exclude', default='', type=SplitComma,
+        help='Exclude the comma-separated list of build targets')
 
-  test_grp = parser.add_mutually_exclusive_group()
-  test_grp.add_argument(
-      '--no-test', dest='test', default=True, action='store_false',
-      help='Skip running tests')
-  test_grp.add_argument(
-      '--test-include', dest='test_include', default='', type=SplitComma,
-      help='Include only the comma-separated list of test targets')
-  test_grp.add_argument(
-      '--test-exclude', dest='test_exclude', default='', type=SplitComma,
-      help='Exclude the comma-separated list of test targets')
-  parser.add_argument(
-      '--test-params', dest='test_params', default='', type=SplitComma,
-      help='Test selector to pass through to emscripten testsuite runner')
+    test_grp = parser.add_mutually_exclusive_group()
+    test_grp.add_argument(
+        '--no-test', dest='test', default=True, action='store_false',
+        help='Skip running tests')
+    test_grp.add_argument(
+        '--test-include', dest='test_include', default='', type=SplitComma,
+        help='Include only the comma-separated list of test targets')
+    test_grp.add_argument(
+        '--test-exclude', dest='test_exclude', default='', type=SplitComma,
+        help='Exclude the comma-separated list of test targets')
+    parser.add_argument(
+        '--test-params', dest='test_params', default='', type=SplitComma,
+        help='Test selector to pass through to emscripten testsuite runner')
 
-  parser.add_argument(
-      '--no-threads', action='store_true',
-      help='Disable use of thread pool to building and testing')
-  parser.add_argument(
-      '--torture-filter',
-      help='Limit which torture tests are run by applying the given glob')
-  parser.add_argument(
-      '--git-status', dest='git_status', default=False, action='store_true',
-      help='Show git status for each sync target. '
-           "Doesn't sync, build, or test")
-  parser.add_argument(
-      '--no-host-clang', dest='host_clang', action='store_false',
-      help="Don't force chrome clang as the host compiler")
-  parser.add_argument(
-      '--no-sysroot', dest='use_sysroot', action='store_false',
-      help="Don't use the V8 sysroot to build on Linux")
-  parser.add_argument(
-      '--clobber', dest='clobber', default=False, action='store_true',
-      help="Delete working directories, forcing a clean build")
+    parser.add_argument(
+        '--no-threads', action='store_true',
+        help='Disable use of thread pool to building and testing')
+    parser.add_argument(
+        '--torture-filter',
+        help='Limit which torture tests are run by applying the given glob')
+    parser.add_argument(
+        '--git-status', dest='git_status', default=False, action='store_true',
+        help='Show git status for each sync target. '
+             "Doesn't sync, build, or test")
+    parser.add_argument(
+        '--no-host-clang', dest='host_clang', action='store_false',
+        help="Don't force chrome clang as the host compiler")
+    parser.add_argument(
+        '--no-sysroot', dest='use_sysroot', action='store_false',
+        help="Don't use the V8 sysroot to build on Linux")
+    parser.add_argument(
+        '--clobber', dest='clobber', default=False, action='store_true',
+        help="Delete working directories, forcing a clean build")
 
-  return parser.parse_args()
+    return parser.parse_args()
 
 
 def AddToPath(path):
-  print("adding to path: %s" % path)
-  os.environ['PATH'] = path + os.pathsep + os.environ['PATH']
+    print("adding to path: %s" % path)
+    os.environ['PATH'] = path + os.pathsep + os.environ['PATH']
 
 
 def run(sync_filter, build_filter, test_filter):
-  if options.git_status:
-    for s in AllSources():
-      s.PrintGitStatus()
-    return 0
+    if options.git_status:
+        for s in AllSources():
+            s.PrintGitStatus()
+        return 0
 
-  Clobber()
-  Chdir(SCRIPT_DIR)
-  for work_dir in work_dirs.GetAll():
-    Mkdir(work_dir)
-  SyncRepos(sync_filter, options.sync_lkgr)
-  if build_filter.All():
-    Remove(GetInstallDir())
-    Mkdir(GetInstallDir())
-    Mkdir(GetInstallDir('bin'))
-    Mkdir(GetInstallDir('lib'))
+    Clobber()
+    Chdir(SCRIPT_DIR)
+    for work_dir in work_dirs.GetAll():
+        Mkdir(work_dir)
+    SyncRepos(sync_filter, options.sync_lkgr)
+    if build_filter.All():
+        Remove(GetInstallDir())
+        Mkdir(GetInstallDir())
+        Mkdir(GetInstallDir('bin'))
+        Mkdir(GetInstallDir('lib'))
 
-  # Add prebuilt cmake to PATH so any subprocesses use a consistent cmake.
-  AddToPath(os.path.dirname(PrebuiltCMakeBin()))
+    # Add prebuilt cmake to PATH so any subprocesses use a consistent cmake.
+    AddToPath(os.path.dirname(PrebuiltCMakeBin()))
 
-  # `npm` uses whatever `node` is in `PATH`. To make sure it uses the
-  # Node.js version we want, we prepend the node bin dir to `PATH`.
-  AddToPath(NodeBinDir())
+    # `npm` uses whatever `node` is in `PATH`. To make sure it uses the
+    # Node.js version we want, we prepend the node bin dir to `PATH`.
+    AddToPath(NodeBinDir())
 
-  # TODO(dschuff): Figure out how to make these statically linked?
-  if IsWindows() and build_filter.Any():
-    host_toolchains.CopyDlls(GetInstallDir('bin'), 'Debug')
+    # TODO(dschuff): Figure out how to make these statically linked?
+    if IsWindows() and build_filter.Any():
+        host_toolchains.CopyDlls(GetInstallDir('bin'), 'Debug')
 
-  try:
-    BuildRepos(build_filter)
-  except Exception:
-    # If any exception reaches here, do not attempt to run the tests; just
-    # log the error for buildbot and exit
-    print("Exception thrown in build step.")
-    traceback.print_exc()
-    buildbot.Fail()
+    try:
+        BuildRepos(build_filter)
+    except Exception:
+        # If any exception reaches here, do not attempt to run the tests; just
+        # log the error for buildbot and exit
+        print("Exception thrown in build step.")
+        traceback.print_exc()
+        buildbot.Fail()
+        Summary()
+        return 1
+
+    # Override the default locale to use UTF-8 encoding for all files and stdio
+    # streams (see PEP540), since oure test files are encoded with UTF-8.
+    os.environ['PYTHONUTF8'] = '1'
+    for t in test_filter.Apply(ALL_TESTS):
+        t.Test()
+
+    # Keep the summary step last: it'll be marked as red if the return code is
+    # non-zero. Individual steps are marked as red with buildbot.Fail().
     Summary()
-    return 1
-
-  # Override the default locale to use UTF-8 encoding for all files and stdio
-  # streams (see PEP540), since oure test files are encoded with UTF-8.
-  os.environ['PYTHONUTF8'] = '1'
-  for t in test_filter.Apply(ALL_TESTS):
-    t.Test()
-
-  # Keep the summary step last: it'll be marked as red if the return code is
-  # non-zero. Individual steps are marked as red with buildbot.Fail().
-  Summary()
-  return buildbot.Failed()
+    return buildbot.Failed()
 
 
 def main():
-  global options
-  start = time.time()
-  options = ParseArgs()
-  print('Python version %s' % sys.version)
+    global options
+    start = time.time()
+    options = ParseArgs()
+    print('Python version %s' % sys.version)
 
-  if options.no_threads:
-    testing.single_threaded = True
-  if options.torture_filter:
-    compile_torture_tests.test_filter = options.torture_filter
+    if options.no_threads:
+        testing.single_threaded = True
+    if options.torture_filter:
+        compile_torture_tests.test_filter = options.torture_filter
 
-  if options.sync_dir:
-    work_dirs.SetSync(options.sync_dir)
-  if options.build_dir:
-    work_dirs.SetBuild(options.build_dir)
-  if options.v8_dir:
-    work_dirs.SetV8(options.v8_dir)
-  if options.test_dir:
-    work_dirs.SetTest(options.test_dir)
-  if options.install_dir:
-    work_dirs.SetInstall(options.install_dir)
-  if options.prebuilt_dir:
-    work_dirs.SetPrebuilt(options.prebuilt_dir)
-  if not options.host_clang:
-    host_toolchains.SetForceHostClang(False)
-  if not options.use_sysroot:
-    host_toolchains.SetUseSysroot(False)
+    if options.sync_dir:
+        work_dirs.SetSync(options.sync_dir)
+    if options.build_dir:
+        work_dirs.SetBuild(options.build_dir)
+    if options.v8_dir:
+        work_dirs.SetV8(options.v8_dir)
+    if options.test_dir:
+        work_dirs.SetTest(options.test_dir)
+    if options.install_dir:
+        work_dirs.SetInstall(options.install_dir)
+    if options.prebuilt_dir:
+        work_dirs.SetPrebuilt(options.prebuilt_dir)
+    if not options.host_clang:
+        host_toolchains.SetForceHostClang(False)
+    if not options.use_sysroot:
+        host_toolchains.SetUseSysroot(False)
 
-  sync_include = options.sync_include if options.sync else []
-  sync_filter = Filter('sync', sync_include, options.sync_exclude)
-  build_include = [] if not options.build else (
-      options.build_include if options.build_include else DEFAULT_BUILDS)
-  build_filter = Filter('build', build_include, options.build_exclude)
-  test_include = [] if not options.test else (
-      options.test_include if options.test_include else DEFAULT_TESTS)
-  test_filter = Filter('test', test_include, options.test_exclude)
+    sync_include = options.sync_include if options.sync else []
+    sync_filter = Filter('sync', sync_include, options.sync_exclude)
+    build_include = [] if not options.build else (
+        options.build_include if options.build_include else DEFAULT_BUILDS)
+    build_filter = Filter('build', build_include, options.build_exclude)
+    test_include = [] if not options.test else (
+        options.test_include if options.test_include else DEFAULT_TESTS)
+    test_filter = Filter('test', test_include, options.test_exclude)
 
-  try:
-    ret = run(sync_filter, build_filter, test_filter)
-    print('Completed in {}s'.format(time.time() - start))
-    return ret
-  except: # noqa
-    traceback.print_exc()
-    # If an except is raised during one of the steps we still need to
-    # print the @@@STEP_FAILURE@@@ annotation otherwise the annotator
-    # makes the failed stap as green:
-    # TODO(sbc): Remove this if the annotator is fixed: http://crbug.com/647357
-    if buildbot.current_step:
-      buildbot.Fail()
-    return 1
+    try:
+        ret = run(sync_filter, build_filter, test_filter)
+        print('Completed in {}s'.format(time.time() - start))
+        return ret
+    except:  # noqa
+        traceback.print_exc()
+        # If an except is raised during one of the steps we still need to
+        # print the @@@STEP_FAILURE@@@ annotation otherwise the annotator
+        # makes the failed stap as green:
+        # TODO(sbc): Remove this if the annotator is fixed:
+        # http://crbug.com/647357
+        if buildbot.current_step:
+            buildbot.Fail()
+        return 1
 
 
 if __name__ == '__main__':
-  sys.exit(main())
+    sys.exit(main())

--- a/src/build.py
+++ b/src/build.py
@@ -445,14 +445,9 @@ class Filter(object):
 
 class Source(object):
     """Metadata about a sync-able source repo on the waterfall"""
-    def __init__(self,
-                 name,
-                 src_dir,
-                 git_repo,
-                 checkout=RemoteBranch('master'),
-                 depth=None,
-                 custom_sync=None,
-                 os_filter=None):
+    def __init__(self, name, src_dir, git_repo,
+                 checkout=RemoteBranch('master'), depth=None,
+                 custom_sync=None, os_filter=None):
         self.name = name
         self.src_dir = src_dir
         self.git_repo = git_repo
@@ -536,9 +531,7 @@ class Source(object):
         print()
 
 
-def ChromiumFetchSync(name,
-                      work_dir,
-                      git_repo,
+def ChromiumFetchSync(name, work_dir, git_repo,
                       checkout=RemoteBranch('master')):
     """Some Chromium projects want to use gclient for clone and
     dependencies."""
@@ -684,43 +677,27 @@ def AllSources():
                EMSCRIPTEN_GIT_BASE + 'emscripten-fastcomp.git'),
         Source('fastcomp-clang', GetSrcDir('emscripten-fastcomp-clang'),
                EMSCRIPTEN_GIT_BASE + 'emscripten-fastcomp-clang.git'),
-        Source('gcc',
-               GetSrcDir('gcc'),
+        Source('gcc', GetSrcDir('gcc'),
                GIT_MIRROR_BASE + 'chromiumos/third_party/gcc.git',
-               checkout=GCC_REVISION,
-               depth=GCC_CLONE_DEPTH),
-        Source('v8',
-               work_dirs.GetV8(),
-               GIT_MIRROR_BASE + 'v8/v8.git',
+               checkout=GCC_REVISION, depth=GCC_CLONE_DEPTH),
+        Source('v8', work_dirs.GetV8(), GIT_MIRROR_BASE + 'v8/v8.git',
                custom_sync=ChromiumFetchSync),
-        Source('host-toolchain',
-               work_dirs.GetV8(),
-               '',
+        Source('host-toolchain', work_dirs.GetV8(), '',
                custom_sync=SyncToolchain),
-        Source('cmake',
-               '',
-               '',  # The source and git args are ignored.
+        Source('cmake', '', '',  # The source and git args are ignored.
                custom_sync=SyncPrebuiltCMake),
-        Source('nodejs',
-               '',
-               '',  # The source and git args are ignored.
+        Source('nodejs', '', '',  # The source and git args are ignored.
                custom_sync=SyncPrebuiltNodeJS),
-        Source('gnuwin32',
-               '',
-               '',  # The source and git args are ignored.
+        Source('gnuwin32', '', '',  # The source and git args are ignored.
                custom_sync=SyncGNUWin32),
         Source('wabt', GetSrcDir('wabt'), WASM_GIT_BASE + 'wabt.git'),
         Source('binaryen', GetSrcDir('binaryen'),
                WASM_GIT_BASE + 'binaryen.git'),
         Source('wasi-libc', GetSrcDir('wasi-libc'),
                'https://github.com/CraneStation/wasi-libc.git'),
-        Source('java',
-               '',
-               '',  # The source and git args are ignored.
+        Source('java', '', '',  # The source and git args are ignored.
                custom_sync=SyncPrebuiltJava),
-        Source('sysroot',
-               '',
-               '',  # The source and git args are ignored.
+        Source('sysroot', '', '',  # The source and git args are ignored.
                custom_sync=SyncLinuxSysroot)
     ]
 
@@ -873,9 +850,7 @@ def CopyLLVMTools(build_dir, prefix=''):
             CopyBinaryToArchive(os.path.join(build_dir, 'bin', e), prefix)
 
 
-def BuildEnv(build_dir,
-             use_gnuwin32=False,
-             bin_subdir=False,
+def BuildEnv(build_dir, use_gnuwin32=False, bin_subdir=False,
              runtime='Release'):
     if not IsWindows():
         return None
@@ -1399,14 +1374,8 @@ def CompileLLVMTortureEmscripten(name, em_config, outdir, fails, opt):
         buildbot.Fail()
 
 
-def LinkLLVMTorture(name,
-                    linker,
-                    fails,
-                    indir,
-                    outdir,
-                    extension,
-                    opt,
-                    args=None):
+def LinkLLVMTorture(name, linker, fails, indir, outdir, extension,
+                    opt, args=None):
     buildbot.Step('Link LLVM Torture (%s, %s)' % (name, opt))
     assert os.path.isfile(linker), 'Cannot find linker at %s' % linker
     Remove(outdir)
@@ -1422,16 +1391,8 @@ def LinkLLVMTorture(name,
         buildbot.Fail()
 
 
-def ExecuteLLVMTorture(name,
-                       runner,
-                       indir,
-                       fails,
-                       attributes,
-                       extension,
-                       opt,
-                       outdir='',
-                       wasmjs='',
-                       extra_files=None,
+def ExecuteLLVMTorture(name, runner, indir, fails, attributes, extension, opt,
+                       outdir='', wasmjs='', extra_files=None,
                        warn_only=False):
     extra_files = [] if extra_files is None else extra_files
 
@@ -1470,13 +1431,8 @@ def ValidateLLVMTorture(indir, ext, opt):
 
 
 class Build(object):
-    def __init__(self,
-                 name_,
-                 runnable_,
-                 os_filter=None,
-                 is_default=True,
-                 *args,
-                 **kwargs):
+    def __init__(self, name_, runnable_, os_filter=None, is_default=True,
+                 *args, **kwargs):
         self.name = name_
         self.runnable = runnable_
         self.os_filter = os_filter

--- a/src/build.py
+++ b/src/build.py
@@ -371,8 +371,8 @@ def UploadArchive(name, archive):
 def GitRemoteUrl(cwd, remote):
     """Get the URL of a remote."""
     return proc.check_output(
-        ['git', 'config', '--get',
-         'remote.%s.url' % remote], cwd=cwd).strip()
+        ['git', 'config', '--get', 'remote.%s.url' % remote],
+        cwd=cwd).strip()
 
 
 def RemoteBranch(branch):

--- a/src/buildbot.py
+++ b/src/buildbot.py
@@ -15,7 +15,6 @@
 import os
 import sys
 
-
 failed_steps = []
 warned_steps = []
 current_step = None
@@ -56,98 +55,98 @@ assert BUILDBOT_BUCKET in [None, CI_BUCKET, TRY_BUCKET], \
 
 
 def IsBot():
-  """Return True if we are running on bot, False otherwise."""
-  return BUILDBOT_BUILDNUMBER is not None
+    """Return True if we are running on bot, False otherwise."""
+    return BUILDBOT_BUILDNUMBER is not None
 
 
 def IsEmscriptenReleasesBot():
-  """Return true if running on the emscripten-releases builders,
+    """Return true if running on the emscripten-releases builders,
      False otherwise."""
-  return BUILDBOT_MASTERNAME == EMSCRIPTEN_RELEASES_BOT
+    return BUILDBOT_MASTERNAME == EMSCRIPTEN_RELEASES_BOT
 
 
 def BuildNumber():
-  if IsEmscriptenReleasesBot():
-    return BUILDBOT_REVISION
-  return BUILDBOT_BUILDNUMBER
+    if IsEmscriptenReleasesBot():
+        return BUILDBOT_REVISION
+    return BUILDBOT_BUILDNUMBER
 
 
 def IsUploadingBot():
-  """Return True if this is a bot that should upload builds."""
-  if not IsBot():
-    return False
-  if not IsEmscriptenReleasesBot():
-    # We are on the waterfall bot. None of these upload.
-    return False
-  else:
-    # We are on emscripten-releases. CI bots upload, but not try.
-    return BUILDBOT_BUCKET == CI_BUCKET
+    """Return True if this is a bot that should upload builds."""
+    if not IsBot():
+        return False
+    if not IsEmscriptenReleasesBot():
+        # We are on the waterfall bot. None of these upload.
+        return False
+    else:
+        # We are on emscripten-releases. CI bots upload, but not try.
+        return BUILDBOT_BUCKET == CI_BUCKET
 
 
 def ShouldClobber():
-  return os.environ.get('BUILDBOT_CLOBBER')
+    return os.environ.get('BUILDBOT_CLOBBER')
 
 
 def BuilderName():
-  return BUILDBOT_BUILDERNAME
+    return BUILDBOT_BUILDERNAME
 
 
 def Scheduler():
-  return BUILDBOT_SCHEDULER
+    return BUILDBOT_SCHEDULER
 
 
 # Magic annotations:
 # https://chromium.googlesource.com/chromium/tools/build/+/master/scripts/common/annotator.py
 def Step(name):
-  global current_step
-  current_step = name
-  sys.stdout.flush()
-  sys.stdout.write('\n@@@BUILD_STEP %s@@@\n' % name)
+    global current_step
+    current_step = name
+    sys.stdout.flush()
+    sys.stdout.write('\n@@@BUILD_STEP %s@@@\n' % name)
 
 
 def Link(label, url):
-  sys.stdout.write('@@@STEP_LINK@%s@%s@@@\n' % (label, url))
+    sys.stdout.write('@@@STEP_LINK@%s@%s@@@\n' % (label, url))
 
 
 def Fail():
-  """Mark one step as failing, but keep going."""
-  sys.stdout.flush()
-  sys.stdout.write('\n@@@STEP_FAILURE@@@\n')
-  global failed_steps
-  failed_steps.append(current_step)
+    """Mark one step as failing, but keep going."""
+    sys.stdout.flush()
+    sys.stdout.write('\n@@@STEP_FAILURE@@@\n')
+    global failed_steps
+    failed_steps.append(current_step)
 
 
 def Failed():
-  return len(failed_steps)
+    return len(failed_steps)
 
 
 def FailedList():
-  return list(failed_steps)
+    return list(failed_steps)
 
 
 def Warn():
-  """We mark this step as failing, but this step is flaky so we don't care
+    """We mark this step as failing, but this step is flaky so we don't care
   enough about this to make the bot red."""
-  sys.stdout.flush()
-  sys.stdout.write('\n@@@STEP_WARNINGS@@@\n')
-  global warned_steps
-  warned_steps.append(current_step)
+    sys.stdout.flush()
+    sys.stdout.write('\n@@@STEP_WARNINGS@@@\n')
+    global warned_steps
+    warned_steps.append(current_step)
 
 
 def Warned():
-  return len(warned_steps)
+    return len(warned_steps)
 
 
 def WarnedList():
-  return list(warned_steps)
+    return list(warned_steps)
 
 
 def DidStepFailOrWarn(step):
-  return step in failed_steps or step in warned_steps
+    return step in failed_steps or step in warned_steps
 
 
 def FailUnless(predicate):
-  if predicate():
-    Warn()
-  else:
-    Fail()
+    if predicate():
+        Warn()
+    else:
+        Fail()

--- a/src/cloud.py
+++ b/src/cloud.py
@@ -22,22 +22,21 @@ EMSCRIPTEN_RELEASES_CLOUD_STORAGE_PATH = \
 
 
 def GetCloudStoragePath():
-  if IsEmscriptenReleasesBot():
-    return EMSCRIPTEN_RELEASES_CLOUD_STORAGE_PATH
-  else:
-    return WATERFALL_CLOUD_STORAGE_PATH
+    if IsEmscriptenReleasesBot():
+        return EMSCRIPTEN_RELEASES_CLOUD_STORAGE_PATH
+    else:
+        return WATERFALL_CLOUD_STORAGE_PATH
 
 
 def Upload(local, remote):
-  """Upload file to Cloud Storage."""
-  if not IsUploadingBot():
-    return
-  remote = GetCloudStoragePath() + remote
-  proc.check_call(
-      ['gsutil.py', 'cp', local, 'gs://' + remote])
-  return CLOUD_STORAGE_BASE_URL + remote
+    """Upload file to Cloud Storage."""
+    if not IsUploadingBot():
+        return
+    remote = GetCloudStoragePath() + remote
+    proc.check_call(['gsutil.py', 'cp', local, 'gs://' + remote])
+    return CLOUD_STORAGE_BASE_URL + remote
 
 
 def Download(remote, local):
-  remote = GetCloudStoragePath() + remote
-  proc.check_call(['gsutil.py', 'cp', 'gs://' + remote, local])
+    remote = GetCloudStoragePath() + remote
+    proc.check_call(['gsutil.py', 'cp', 'gs://' + remote, local])

--- a/src/compile_torture_tests.py
+++ b/src/compile_torture_tests.py
@@ -29,128 +29,137 @@ test_filter = None
 
 
 def do_compile(infile, outfile, extras):
-  """Create the command-line for a C compiler invocation."""
-  if os.path.splitext(infile)[1] == '.C' or 'g++.dg' in infile:  # lol windows
-    return [extras['cxx'], infile, '-o', outfile] + extras['cxxflags']
-  else:
-    return [extras['cc'], infile, '-o', outfile] + extras['cflags']
+    """Create the command-line for a C compiler invocation."""
+    # its not enough to check only for capital `.C` extension because
+    # windows.
+    if os.path.splitext(infile)[1] == '.C' or 'g++.dg' in infile:
+        return [extras['cxx'], infile, '-o', outfile] + extras['cxxflags']
+    else:
+        return [extras['cc'], infile, '-o', outfile] + extras['cflags']
 
 
 def create_outname(outdir, infile, extras):
-  if os.path.splitext(infile)[1] == '.C':
-    parts = infile.split(os.path.sep)
-    parts = parts[parts.index('testsuite') + 2:]
-    basename = '__'.join(parts)
-  else:
-    basename = os.path.basename(infile)
-  rtn = os.path.join(outdir, basename + extras['suffix'])
-  if os.path.exists(rtn):
-    raise Exception("already exists: " + rtn)
-  return rtn
+    if os.path.splitext(infile)[1] == '.C':
+        parts = infile.split(os.path.sep)
+        parts = parts[parts.index('testsuite') + 2:]
+        basename = '__'.join(parts)
+    else:
+        basename = os.path.basename(infile)
+    rtn = os.path.join(outdir, basename + extras['suffix'])
+    if os.path.exists(rtn):
+        raise Exception("already exists: " + rtn)
+    return rtn
 
 
 def find_runnable_tests(directory, pattern):
-  results = []
-  for root, dirs, files in os.walk(directory):
-    if os.path.basename(root) == 'ext':
-      continue
-    for filename in files:
-      if fnmatch.fnmatch(filename, pattern):
-        fullname = os.path.join(root, filename)
-        with open(fullname, 'rb') as f:
-          header = f.read(1024)
-          # Some of these files really do have non-utf8 in them.
-          # TODO: open in text mode with the encoding kwarg when we drop py2.
-          header = header.decode('ISO8859-1')
-        if '{ dg-do run }' in header and 'dg-additional-sources' not in header:
-          results.append(fullname)
-  return results
+    results = []
+    for root, dirs, files in os.walk(directory):
+        if os.path.basename(root) == 'ext':
+            continue
+        for filename in files:
+            if fnmatch.fnmatch(filename, pattern):
+                fullname = os.path.join(root, filename)
+                with open(fullname, 'rb') as f:
+                    header = f.read(1024)
+                    # Some of these files really do have non-utf8 in them.
+                    # TODO: open in text mode with the encoding kwarg when we
+                    # drop py2.
+                    header = header.decode('ISO8859-1')
+                if ('{ dg-do run }' in header and
+                        'dg-additional-sources' not in header):
+                    results.append(fullname)
+    return results
 
 
 def run(cc, cxx, testsuite, sysroot_dir, fails, exclusions, out, config, opt):
-  """Compile all torture tests."""
-  script_dir = os.path.dirname(os.path.abspath(__file__))
-  pre_js = os.path.join(script_dir, 'em_pre.js')
+    """Compile all torture tests."""
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    pre_js = os.path.join(script_dir, 'em_pre.js')
 
-  cflags_common = ['-DSTACK_SIZE=524288', '-D_WASI_EMULATED_MMAN',
-                   '-w', '-Wno-implicit-function-declaration', '-' + opt]
-  cflags_c = ['--std=gnu89']
-  cflags_cxx = []
-  cflags_extra = {
-      'clang': ['-c', '--sysroot=%s' % sysroot_dir],
-      'emscripten': ['--pre-js', pre_js],
-  }
-  suffix = {
-      'clang': '.o',
-      'emscripten': '.js',
-  }[config]
+    cflags_common = [
+        '-DSTACK_SIZE=524288', '-D_WASI_EMULATED_MMAN', '-w',
+        '-Wno-implicit-function-declaration', '-' + opt
+    ]
+    cflags_c = ['--std=gnu89']
+    cflags_cxx = []
+    cflags_extra = {
+        'clang': ['-c', '--sysroot=%s' % sysroot_dir],
+        'emscripten': ['--pre-js', pre_js],
+    }
+    suffix = {
+        'clang': '.o',
+        'emscripten': '.js',
+    }[config]
 
-  assert os.path.isdir(out), 'Cannot find outdir %s' % out
-  assert os.path.isfile(cc), 'Cannot find C compiler at %s' % cc
-  assert os.path.isfile(cxx), 'Cannot find C++ compiler at %s' % cxx
-  assert os.path.isdir(testsuite), 'Cannot find testsuite at %s' % testsuite
+    assert os.path.isdir(out), 'Cannot find outdir %s' % out
+    assert os.path.isfile(cc), 'Cannot find C compiler at %s' % cc
+    assert os.path.isfile(cxx), 'Cannot find C++ compiler at %s' % cxx
+    assert os.path.isdir(testsuite), 'Cannot find testsuite at %s' % testsuite
 
-  # Currently we build the following parts of the gcc test suite:
-  #  - testsuite/gcc.c-torture/execute/*.c
-  #  - testsuite/g++.dg (all executable tests)
-  # TODO(sbc) Also more parts of the test suite
-  c_torture = os.path.join(testsuite, 'gcc.c-torture', 'execute')
-  assert os.path.isdir(c_torture), ('Cannot find C tests at %s' % c_torture)
-  test_files = glob.glob(os.path.join(c_torture, '*.c'))
+    # Currently we build the following parts of the gcc test suite:
+    #  - testsuite/gcc.c-torture/execute/*.c
+    #  - testsuite/g++.dg (all executable tests)
+    # TODO(sbc) Also more parts of the test suite
+    c_torture = os.path.join(testsuite, 'gcc.c-torture', 'execute')
+    assert os.path.isdir(c_torture), ('Cannot find C tests at %s' % c_torture)
+    test_files = glob.glob(os.path.join(c_torture, '*.c'))
 
-  if config == 'clang':
-    # Only build the C++ tests when linking with lld
-    cxx_test_dir = os.path.join(testsuite, 'g++.dg')
-    assert os.path.isdir(cxx_test_dir), ('Cannot find C++ tests at %s' %
-                                         cxx_test_dir)
-    test_files += find_runnable_tests(cxx_test_dir, '*.[Cc]')
+    if config == 'clang':
+        # Only build the C++ tests when linking with lld
+        cxx_test_dir = os.path.join(testsuite, 'g++.dg')
+        assert os.path.isdir(cxx_test_dir), ('Cannot find C++ tests at %s' %
+                                             cxx_test_dir)
+        test_files += find_runnable_tests(cxx_test_dir, '*.[Cc]')
 
-  cflags = cflags_common + cflags_c + cflags_extra[config]
-  cxxflags = cflags_common + cflags_cxx + cflags_extra[config]
+    cflags = cflags_common + cflags_c + cflags_extra[config]
+    cxxflags = cflags_common + cflags_cxx + cflags_extra[config]
 
-  if test_filter:
-    test_files = fnmatch.filter(test_files, test_filter)
+    if test_filter:
+        test_files = fnmatch.filter(test_files, test_filter)
 
-  result = testing.execute(
-      tester=testing.Tester(
-          command_ctor=do_compile,
-          outname_ctor=create_outname,
-          outdir=out,
-          extras={'cc': cc, 'cxx': cxx, 'cflags': cflags,
-                  'cxxflags': cxxflags, 'suffix': suffix}),
-      inputs=test_files,
-      fails=fails,
-      exclusions=exclusions,
-      attributes=[config, opt])
+    result = testing.execute(tester=testing.Tester(command_ctor=do_compile,
+                                                   outname_ctor=create_outname,
+                                                   outdir=out,
+                                                   extras={
+                                                       'cc': cc,
+                                                       'cxx': cxx,
+                                                       'cflags': cflags,
+                                                       'cxxflags': cxxflags,
+                                                       'suffix': suffix
+                                                   }),
+                             inputs=test_files,
+                             fails=fails,
+                             exclusions=exclusions,
+                             attributes=[config, opt])
 
-  return result
+    return result
 
 
 def main():
-  parser = argparse.ArgumentParser(description='Compile GCC torture tests.')
-  parser.add_argument('--cc', type=str, required=True,
-                      help='C compiler path')
-  parser.add_argument('--cxx', type=str, required=True,
-                      help='C++ compiler path')
-  parser.add_argument('--testsuite', type=str, required=True,
-                      help='GCC testsuite tests path')
-  parser.add_argument('--sysroot', type=str, required=True,
-                      help='Sysroot directory')
-  parser.add_argument('--fails', type=str, required=True,
-                      help='Expected failures')
-  parser.add_argument('--out', type=str, required=True,
-                      help='Output directory')
-  parser.add_argument('--config', type=str, required=True,
-                      help='configuration to use')
-  args = parser.parse_args()
-  return run(cc=args.cc,
-             cxx=args.cxx,
-             testsuite=args.testsuite,
-             sysroot_dir=args.sysroot,
-             fails=args.fails,
-             out=args.out,
-             config=args.config)
+    parser = argparse.ArgumentParser(description='Compile GCC torture tests.')
+    parser.add_argument('--cc', type=str, required=True,
+                        help='C compiler path')
+    parser.add_argument('--cxx', type=str, required=True,
+                        help='C++ compiler path')
+    parser.add_argument('--testsuite', type=str, required=True,
+                        help='GCC testsuite tests path')
+    parser.add_argument('--sysroot', type=str, required=True,
+                        help='Sysroot directory')
+    parser.add_argument('--fails', type=str, required=True,
+                        help='Expected failures')
+    parser.add_argument('--out', type=str, required=True,
+                        help='Output directory')
+    parser.add_argument('--config', type=str, required=True,
+                        help='configuration to use')
+    args = parser.parse_args()
+    return run(cc=args.cc,
+               cxx=args.cxx,
+               testsuite=args.testsuite,
+               sysroot_dir=args.sysroot,
+               fails=args.fails,
+               out=args.out,
+               config=args.config)
 
 
 if __name__ == '__main__':
-  sys.exit(main())
+    sys.exit(main())

--- a/src/execute_files.py
+++ b/src/execute_files.py
@@ -24,90 +24,91 @@ import testing
 
 
 def create_outname(outdir, infile, extras):
-  """Create the output file's name."""
-  basename = os.path.basename(infile)
-  outname = basename + '.out'
-  return os.path.join(outdir, outname)
+    """Create the output file's name."""
+    basename = os.path.basename(infile)
+    outname = basename + '.out'
+    return os.path.join(outdir, outname)
 
 
 def execute(infile, outfile, extras):
-  """Create the command-line for an execution."""
-  runner = extras['runner']
-  basename = os.path.splitext(os.path.basename(runner))[0]
-  if basename == 'v8':
-    # The d8 installed by JSVU is named 'v8'
-    basename = 'd8'
-  out_opt = ['-o', outfile] if outfile else []
-  extra_files = extras['extra_files']
-  config = basename
-  wasmjs = [extras['wasmjs']] if extras['wasmjs'] else []
-  if basename == 'd8' or basename == 'jsc':
-    config = basename + ('-wasm' if wasmjs else '-asm2wasm')
+    """Create the command-line for an execution."""
+    runner = extras['runner']
+    basename = os.path.splitext(os.path.basename(runner))[0]
+    if basename == 'v8':
+        # The d8 installed by JSVU is named 'v8'
+        basename = 'd8'
+    out_opt = ['-o', outfile] if outfile else []
+    extra_files = extras['extra_files']
+    config = basename
+    wasmjs = [extras['wasmjs']] if extras['wasmjs'] else []
+    if basename == 'd8' or basename == 'jsc':
+        config = basename + ('-wasm' if wasmjs else '-asm2wasm')
 
-  # TODO(jgravelle): Remove --no-wasm-async-compilation by adding
-  # testRunner.waitUntilDone()/.notifyDone(), as used in V8's mjsunit.js:
-  # https://cs.chromium.org/chromium/src/v8/test/mjsunit/mjsunit.js
-  commands = {
-      'wasm-shell': [runner, '--entry=main', infile] + out_opt,
-      'd8-wasm': [runner, '--experimental-wasm-bigint',
-                  '--no-wasm-async-compilation'] + wasmjs + [
-                      '--', infile] + extra_files,
-      'd8-asm2wasm': [runner, '--experimental-wasm-bigint',
-                      '--no-wasm-async-compilation', infile],
-      'jsc-wasm': [runner, '--useWebAssembly=1'] + wasmjs + [
-          '--', infile] + extra_files,
-      'jsc-asm2wasm': [runner, '--useWebAssembly=1', infile],
-      'wasm': [runner, infile],
-      'node': [runner] + wasmjs + [infile] + extra_files,
-      'wasm-validate': [runner, '--enable-bulk-memory', infile],
-  }
-  return commands[config]
+    # TODO(jgravelle): Remove --no-wasm-async-compilation by adding
+    # testRunner.waitUntilDone()/.notifyDone(), as used in V8's mjsunit.js:
+    # https://cs.chromium.org/chromium/src/v8/test/mjsunit/mjsunit.js
+    commands = {
+        'wasm-shell': [runner, '--entry=main', infile] + out_opt,
+        'd8-wasm': [runner, '--experimental-wasm-bigint',
+                    '--no-wasm-async-compilation'] + wasmjs + [
+                        '--', infile] + extra_files,
+        'd8-asm2wasm': [runner, '--experimental-wasm-bigint',
+                        '--no-wasm-async-compilation', infile],
+        'jsc-wasm': [runner, '--useWebAssembly=1'] + wasmjs + [
+            '--', infile] + extra_files,
+        'jsc-asm2wasm': [runner, '--useWebAssembly=1', infile],
+        'wasm': [runner, infile],
+        'node': [runner] + wasmjs + [infile] + extra_files,
+        'wasm-validate': [runner, '--enable-bulk-memory', infile],
+    }
+    return commands[config]
 
 
 def run(runner, files, fails, attributes, out, wasmjs='', extra_files=[]):
-  """Execute all files."""
-  assert os.path.isfile(runner), 'Cannot find runner at %s' % runner
-  if out:
-    assert os.path.isdir(out), 'Cannot find outdir %s' % out
-  if wasmjs:
-    assert os.path.isfile(wasmjs), 'Cannot find wasm.js %s' % wasmjs
-  executable_files = glob.glob(files)
-  if len(executable_files) == 0:
-    print('No files found by %s' % files)
-    return 1
-  return testing.execute(
-      tester=testing.Tester(
-          command_ctor=execute,
-          outname_ctor=create_outname,
-          outdir=out,
-          extras={
-              'runner': runner,
-              'wasmjs': wasmjs,
-              'extra_files': extra_files if extra_files else []
-          }),
-      inputs=executable_files,
-      fails=fails,
-      attributes=attributes)
+    """Execute all files."""
+    assert os.path.isfile(runner), 'Cannot find runner at %s' % runner
+    if out:
+        assert os.path.isdir(out), 'Cannot find outdir %s' % out
+    if wasmjs:
+        assert os.path.isfile(wasmjs), 'Cannot find wasm.js %s' % wasmjs
+    executable_files = glob.glob(files)
+    if len(executable_files) == 0:
+        print('No files found by %s' % files)
+        return 1
+    tester = testing.Tester(command_ctor=execute,
+                            outname_ctor=create_outname,
+                            outdir=out,
+                            extras={
+                                'runner': runner,
+                                'wasmjs': wasmjs,
+                                'extra_files':
+                                extra_files if extra_files else []
+                            }),
+    return testing.execute(tester=tester,
+                           inputs=executable_files,
+                           fails=fails,
+                           attributes=attributes)
 
 
 def main():
-  parser = argparse.ArgumentParser(description='Execute .wast or .wasm files.')
-  parser.add_argument('--runner', type=str, required=True,
-                      help='Runner path')
-  parser.add_argument('--files', type=str, required=True,
-                      help='Glob pattern for .wast / .wasm files')
-  parser.add_argument('--fails', type=str, required=True,
-                      help='Expected failures')
-  parser.add_argument('--out', type=str, required=False,
-                      help='Output directory')
-  parser.add_argument('--wasmjs', type=str, required=False,
-                      help='JavaScript support runtime for WebAssembly')
-  parser.add_argument('--extra', type=str, required=False, action='append',
-                      help='Extra files to pass to the runner')
-  args = parser.parse_args()
-  return run(args.runner, [args.files], args.fails, set(), args.out,
-             args.wasmjs, args.extra)
+    parser = argparse.ArgumentParser(
+        description='Execute .wast or .wasm files.')
+    parser.add_argument('--runner', type=str, required=True,
+                        help='Runner path')
+    parser.add_argument('--files', type=str, required=True,
+                        help='Glob pattern for .wast / .wasm files')
+    parser.add_argument('--fails', type=str, required=True,
+                        help='Expected failures')
+    parser.add_argument('--out', type=str, required=False,
+                        help='Output directory')
+    parser.add_argument('--wasmjs', type=str, required=False,
+                        help='JavaScript support runtime for WebAssembly')
+    parser.add_argument('--extra', type=str, required=False, action='append',
+                        help='Extra files to pass to the runner')
+    args = parser.parse_args()
+    return run(args.runner, [args.files], args.fails, set(), args.out,
+               args.wasmjs, args.extra)
 
 
 if __name__ == '__main__':
-  sys.exit(main())
+    sys.exit(main())

--- a/src/file_util.py
+++ b/src/file_util.py
@@ -25,69 +25,69 @@ import proc
 
 
 def Chdir(path):
-  print('Change directory to: %s' % path)
-  os.chdir(path)
+    print('Change directory to: %s' % path)
+    os.chdir(path)
 
 
 def Mkdir(path):
-  """Create a directory at a specified path.
+    """Create a directory at a specified path.
 
-  Creates all intermediate directories along the way.
-  e.g.: Mkdir('a/b/c') when 'a/' is an empty directory will
-        cause the creation of directories 'a/b/' and 'a/b/c/'.
+    Creates all intermediate directories along the way.
+    e.g.: Mkdir('a/b/c') when 'a/' is an empty directory will
+          cause the creation of directories 'a/b/' and 'a/b/c/'.
 
-  If the path already exists (and is already a directory), this does nothing.
-  """
-  try:
-    os.makedirs(path)
-  except OSError as e:
-    if not os.path.isdir(path):
-      raise Exception('Path %s is not a directory!' % path)
-    if not e.errno == errno.EEXIST:
-      raise e
+    If the path already exists (and is already a directory), this does nothing.
+    """
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if not os.path.isdir(path):
+            raise Exception('Path %s is not a directory!' % path)
+        if not e.errno == errno.EEXIST:
+            raise e
 
 
 def Remove(path):
-  """Remove file or directory if it exists, do nothing otherwise."""
-  if not os.path.exists(path):
-    return
-  print('Removing %s' % path)
-  if not os.path.isdir(path):
-    os.remove(path)
-    return
-  if sys.platform == 'win32':
-    # shutil.rmtree() may not work in Windows if a directory contains read-only
-    # files.
-    proc.check_call('rmdir /S /Q "%s"' % path, shell=True)
-  else:
-    shutil.rmtree(path)
+    """Remove file or directory if it exists, do nothing otherwise."""
+    if not os.path.exists(path):
+        return
+    print('Removing %s' % path)
+    if not os.path.isdir(path):
+        os.remove(path)
+        return
+    if sys.platform == 'win32':
+        # shutil.rmtree() may not work in Windows if a directory contains
+        # read-only files.
+        proc.check_call('rmdir /S /Q "%s"' % path, shell=True)
+    else:
+        shutil.rmtree(path)
 
 
 def CopyTree(src, dst):
-  """Recursively copy the items in the src directory to the dst directory.
+    """Recursively copy the items in the src directory to the dst directory.
 
-  Unlike shutil.copytree, the destination directory and any subdirectories and
-  files may exist. Existing directories are left untouched, and existing files
-  are removed and copied from the source using shutil.copy2. It is also not
-  symlink-aware.
+    Unlike shutil.copytree, the destination directory and any subdirectories
+    and files may exist. Existing directories are left untouched, and existing
+    files are removed and copied from the source using shutil.copy2. It is also
+    not symlink-aware.
 
-  Args:
-    src: Source. Must be an existing directory.
-    dst: Destination directory. If it exists, must be a directory. Otherwise it
-         will be created, along with parent directories.
-  """
-  print('Copying directory %s to %s' % (src, dst))
-  if not os.path.isdir(dst):
-    os.makedirs(dst)
-  for root, dirs, files in os.walk(src):
-    relroot = os.path.relpath(root, src)
-    dstroot = os.path.join(dst, relroot)
-    for d in dirs:
-      dstdir = os.path.join(dstroot, d)
-      if not os.path.isdir(dstdir):
-        os.mkdir(dstdir)
-    for f in files:
-      dstfile = os.path.join(dstroot, f)
-      if os.path.isfile(dstfile):
-        os.remove(dstfile)
-      shutil.copy2(os.path.join(root, f), dstfile)
+    Args:
+      src: Source. Must be an existing directory.
+      dst: Destination directory. If it exists, must be a directory. Otherwise
+           it will be created, along with parent directories.
+    """
+    print('Copying directory %s to %s' % (src, dst))
+    if not os.path.isdir(dst):
+        os.makedirs(dst)
+    for root, dirs, files in os.walk(src):
+        relroot = os.path.relpath(root, src)
+        dstroot = os.path.join(dst, relroot)
+        for d in dirs:
+            dstdir = os.path.join(dstroot, d)
+            if not os.path.isdir(dstdir):
+                os.mkdir(dstdir)
+        for f in files:
+            dstfile = os.path.join(dstroot, f)
+            if os.path.isfile(dstfile):
+                os.remove(dstfile)
+            shutil.copy2(os.path.join(root, f), dstfile)

--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -23,140 +23,147 @@ import file_util
 import proc
 import work_dirs
 
-
 force_host_clang = True
 use_sysroot = True
 
 
 def SetupToolchain():
-  return ['vpython.bat',
-          os.path.join(work_dirs.GetV8(), 'build', 'toolchain',
-                       'win', 'setup_toolchain.py')]
+    return [
+        'vpython.bat',
+        os.path.join(work_dirs.GetV8(), 'build', 'toolchain', 'win',
+                     'setup_toolchain.py')
+    ]
 
 
 def VSToolchainPy():
-  return ['vpython.bat',
-          os.path.join(work_dirs.GetV8(), 'build', 'vs_toolchain.py')]
+    return [
+        'vpython.bat',
+        os.path.join(work_dirs.GetV8(), 'build', 'vs_toolchain.py')
+    ]
 
 
 def WinToolchainJson():
-  return os.path.join(work_dirs.GetV8(), 'build', 'win_toolchain.json')
+    return os.path.join(work_dirs.GetV8(), 'build', 'win_toolchain.json')
 
 
 def SyncPrebuiltClang(name, src_dir):
-  """Update the prebuilt clang toolchain used by chromium bots"""
-  tools_clang = os.path.join(src_dir, 'tools', 'clang')
-  assert os.path.isdir(tools_clang)
-  proc.check_call(
-      [os.path.join(tools_clang, 'scripts', 'update.py')])
+    """Update the prebuilt clang toolchain used by chromium bots"""
+    tools_clang = os.path.join(src_dir, 'tools', 'clang')
+    assert os.path.isdir(tools_clang)
+    proc.check_call([os.path.join(tools_clang, 'scripts', 'update.py')])
 
 
 def SyncWinToolchain():
-  """Update the VS toolchain used by Chromium bots"""
-  proc.check_call(VSToolchainPy() + ['update'])
+    """Update the VS toolchain used by Chromium bots"""
+    proc.check_call(VSToolchainPy() + ['update'])
 
 
 def GetVSEnv(dir):
-  """Return the configured VS build environment block as a python dict."""
-  # The format is a list of nul-terminated strings of the form var=val
-  # where 'var' is the environment variable name, and 'val' is its value
-  env = os.environ.copy()
-  with open(os.path.join(dir, 'environment.x64'), 'rb') as f:
-    entries = f.read().decode().split('\0')
-    for e in entries:
-      if not e:
-        continue
-      var, val = e.split('=', 1)
-      env[var] = val
-      print('ENV: %s = %s' % (var, val))
+    """Return the configured VS build environment block as a python dict."""
+    # The format is a list of nul-terminated strings of the form var=val
+    # where 'var' is the environment variable name, and 'val' is its value
+    env = os.environ.copy()
+    with open(os.path.join(dir, 'environment.x64'), 'rb') as f:
+        entries = f.read().decode().split('\0')
+        for e in entries:
+            if not e:
+                continue
+            var, val = e.split('=', 1)
+            env[var] = val
+            print('ENV: %s = %s' % (var, val))
 
-  return env
+    return env
 
 
 def GetRuntimeDir():
-  # Get the chromium-packaged toolchain directory info in a JSON file
-  proc.check_call(VSToolchainPy() + ['get_toolchain_dir'])
-  with open(WinToolchainJson()) as f:
-    paths = json.load(f)
-  # Extract the 64-bit runtime path
-  return [path for path in paths['runtime_dirs'] if path.endswith('64')][0]
+    # Get the chromium-packaged toolchain directory info in a JSON file
+    proc.check_call(VSToolchainPy() + ['get_toolchain_dir'])
+    with open(WinToolchainJson()) as f:
+        paths = json.load(f)
+    # Extract the 64-bit runtime path
+    return [path for path in paths['runtime_dirs'] if path.endswith('64')][0]
 
 
 def SetUpVSEnv(outdir):
-  """Set up the VS build environment used by Chromium bots"""
+    """Set up the VS build environment used by Chromium bots"""
 
-  # Get the chromium-packaged toolchain directory info in a JSON file
-  proc.check_call(VSToolchainPy() + ['get_toolchain_dir'])
-  with open(WinToolchainJson()) as f:
-    paths = json.load(f)
+    # Get the chromium-packaged toolchain directory info in a JSON file
+    proc.check_call(VSToolchainPy() + ['get_toolchain_dir'])
+    with open(WinToolchainJson()) as f:
+        paths = json.load(f)
 
-  # Write path information (usable by a non-chromium build) into an environment
-  # block
-  runtime_dirs = os.pathsep.join(paths['runtime_dirs'])
-  proc.check_call(SetupToolchain() +
-                  ['foo', paths['win_sdk'], runtime_dirs,
-                   'win', 'x64', 'environment.x64'],
-                  cwd=outdir)
-  return GetVSEnv(outdir)
+    # Write path information (usable by a non-chromium build) into an
+    # environment block
+    runtime_dirs = os.pathsep.join(paths['runtime_dirs'])
+    proc.check_call(SetupToolchain() +
+                    ['foo', paths['win_sdk'], runtime_dirs, 'win', 'x64',
+                     'environment.x64'],
+                    cwd=outdir)
+    return GetVSEnv(outdir)
 
 
 def CopyDlls(dir, configuration):
-  """Copy MSVS Runtime dlls into a build directory"""
-  file_util.Mkdir(dir)
-  proc.check_call(VSToolchainPy() + ['copy_dlls', dir, configuration, 'x64'])
-  # LLD needs also concrt140.dll, which the Chromium copy_dlls doesn't include.
-  for dll in glob.glob(os.path.join(GetRuntimeDir(), 'concrt140*.dll')):
-    print('Copying %s to %s' % (dll, dir))
-    shutil.copy2(dll, dir)
+    """Copy MSVS Runtime dlls into a build directory"""
+    file_util.Mkdir(dir)
+    proc.check_call(VSToolchainPy() + ['copy_dlls', dir, configuration, 'x64'])
+    # LLD needs also concrt140.dll, which the Chromium copy_dlls doesn't
+    # include.
+    for dll in glob.glob(os.path.join(GetRuntimeDir(), 'concrt140*.dll')):
+        print('Copying %s to %s' % (dll, dir))
+        shutil.copy2(dll, dir)
 
 
 def UsingGoma():
-  return 'GOMA_DIR' in os.environ
+    return 'GOMA_DIR' in os.environ
 
 
 def GomaDir():
-  return os.environ['GOMA_DIR']
+    return os.environ['GOMA_DIR']
 
 
 def CMakeLauncherFlags():
-  flags = []
-  if UsingGoma():
-    compiler_launcher = os.path.join(GomaDir(), 'gomacc')
-  else:
-    try:
-      compiler_launcher = proc.Which('ccache')
-    except: # noqa
-      return flags
+    flags = []
+    if UsingGoma():
+        compiler_launcher = os.path.join(GomaDir(), 'gomacc')
+    else:
+        try:
+            compiler_launcher = proc.Which('ccache')
+        except:  # noqa
+            return flags
 
-    if ShouldForceHostClang():
-      # This flag is only present in clang.
-      flags.extend(['-DCMAKE_%s_FLAGS=-Qunused-arguments' %
-                    c for c in ['C', 'CXX']])
+        if ShouldForceHostClang():
+            # This flag is only present in clang.
+            flags.extend([
+                '-DCMAKE_%s_FLAGS=-Qunused-arguments' % c
+                for c in ['C', 'CXX']
+            ])
 
-  flags.extend(['-DCMAKE_%s_COMPILER_LAUNCHER=%s' %
-                (c, compiler_launcher) for c in ['C', 'CXX']])
-  return flags
+    flags.extend([
+        '-DCMAKE_%s_COMPILER_LAUNCHER=%s' % (c, compiler_launcher)
+        for c in ['C', 'CXX']
+    ])
+    return flags
 
 
 def NinjaJobs():
-  if UsingGoma() and force_host_clang:
-    return ['-j', '50']
-  return []
+    if UsingGoma() and force_host_clang:
+        return ['-j', '50']
+    return []
 
 
 def SetForceHostClang(force):
-  global force_host_clang
-  force_host_clang = force
+    global force_host_clang
+    force_host_clang = force
 
 
 def ShouldForceHostClang():
-  return force_host_clang
+    return force_host_clang
 
 
 def SetUseSysroot(use):
-  global use_sysroot
-  use_sysroot = use
+    global use_sysroot
+    use_sysroot = use
 
 
 def ShouldUseSysroot():
-  return use_sysroot
+    return use_sysroot

--- a/src/link_assembly_files.py
+++ b/src/link_assembly_files.py
@@ -24,57 +24,60 @@ import testing
 
 
 def create_outname(outdir, infile, extras):
-  """Create the output file's name."""
-  basename = os.path.basename(infile)
-  outname = basename + '.wasm'
-  return os.path.join(outdir, outname)
+    """Create the output file's name."""
+    basename = os.path.basename(infile)
+    outname = basename + '.wasm'
+    return os.path.join(outdir, outname)
 
 
 def link(infile, outfile, extras):
-  """Create the command-line for a linker invocation."""
-  linker = extras['linker']
-  install_root = os.path.dirname(os.path.dirname(linker))
-  sysroot_dir = os.path.join(install_root, 'sysroot')
-  command = [linker, '--sysroot=%s' % sysroot_dir, '-Wl,-zstack-size=1048576',
-             '-o', outfile, infile, '-lwasi-emulated-mman']
-  return command + extras['args']
+    """Create the command-line for a linker invocation."""
+    linker = extras['linker']
+    install_root = os.path.dirname(os.path.dirname(linker))
+    sysroot_dir = os.path.join(install_root, 'sysroot')
+    command = [
+        linker,
+        '--sysroot=%s' % sysroot_dir, '-Wl,-zstack-size=1048576', '-o',
+        outfile, infile, '-lwasi-emulated-mman'
+    ]
+    return command + extras['args']
 
 
 def run(linker, files, fails, attributes, out, args):
-  """Link all files."""
-  assert os.path.isfile(linker), 'Cannot find linker at %s' % linker
-  assert os.path.isdir(out), 'Cannot find outdir %s' % out
-  input_files = glob.glob(files)
-  if len(input_files) == 0:
-    print('No files found by %s' % files)
-    return 1
-  if not args:
-    args = []
-  return testing.execute(
-      tester=testing.Tester(
-          command_ctor=link,
-          outname_ctor=create_outname,
-          outdir=out,
-          extras={'linker': linker, 'args': args}),
-      inputs=input_files,
-      fails=fails,
-      attributes=attributes)
+    """Link all files."""
+    assert os.path.isfile(linker), 'Cannot find linker at %s' % linker
+    assert os.path.isdir(out), 'Cannot find outdir %s' % out
+    input_files = glob.glob(files)
+    if len(input_files) == 0:
+        print('No files found by %s' % files)
+        return 1
+    if not args:
+        args = []
+    return testing.execute(tester=testing.Tester(command_ctor=link,
+                                                 outname_ctor=create_outname,
+                                                 outdir=out,
+                                                 extras={
+                                                     'linker': linker,
+                                                     'args': args
+                                                 }),
+                           inputs=input_files,
+                           fails=fails,
+                           attributes=attributes)
 
 
 def main():
-  parser = argparse.ArgumentParser(
-      description='Link .o files into a .wasm.')
-  parser.add_argument('--linker', type=str, required=True,
-                      help='Linker path')
-  parser.add_argument('--files', type=str, required=True,
-                      help='Glob pattern for .s files')
-  parser.add_argument('--fails', type=str, required=True,
-                      help='Expected failures')
-  parser.add_argument('--out', type=str, required=True,
-                      help='Output directory')
-  args = parser.parse_args()
-  return run(args.linker, args.files, args.fails, args.out)
+    parser = argparse.ArgumentParser(description='Link .o files into a .wasm.')
+    parser.add_argument('--linker', type=str, required=True,
+                        help='Linker path')
+    parser.add_argument('--files', type=str, required=True,
+                        help='Glob pattern for .s files')
+    parser.add_argument('--fails', type=str, required=True,
+                        help='Expected failures')
+    parser.add_argument('--out', type=str, required=True,
+                        help='Output directory')
+    args = parser.parse_args()
+    return run(args.linker, args.files, args.fails, args.out)
 
 
 if __name__ == '__main__':
-  sys.exit(main())
+    sys.exit(main())

--- a/src/parallel_runner.py
+++ b/src/parallel_runner.py
@@ -18,65 +18,66 @@ import queue
 
 
 def g_testing_thread(test_function, work_queue, result_queue):
-  for test in iter(lambda: get_from_queue(work_queue), None):
-    result = None
-    try:
-      result = test_function(test)
-    except Exception as e:
-      print("Something went wrong", e, file=sys.stderr)
-      raise
-    result_queue.put(result)
+    for test in iter(lambda: get_from_queue(work_queue), None):
+        result = None
+        try:
+            result = test_function(test)
+        except Exception as e:
+            print("Something went wrong", e, file=sys.stderr)
+            raise
+        result_queue.put(result)
 
 
 class ParallelRunner(object):
-  def __init__(self):
-    self.processes = None
-    self.result_queue = None
+    def __init__(self):
+        self.processes = None
+        self.result_queue = None
 
-  def map(self, test_function, inputs):
-    test_queue = self.create_test_queue(inputs)
-    self.init_processes(test_function, test_queue)
-    results = self.collect_results()
-    return results
+    def map(self, test_function, inputs):
+        test_queue = self.create_test_queue(inputs)
+        self.init_processes(test_function, test_queue)
+        results = self.collect_results()
+        return results
 
-  def create_test_queue(self, inputs):
-    test_queue = multiprocessing.Queue()
-    for test in inputs:
-      test_queue.put(test)
-    return test_queue
+    def create_test_queue(self, inputs):
+        test_queue = multiprocessing.Queue()
+        for test in inputs:
+            test_queue.put(test)
+        return test_queue
 
-  def init_processes(self, test_function, test_queue):
-    self.processes = []
-    self.result_queue = multiprocessing.Queue()
-    for x in range(multiprocessing.cpu_count()):
-      p = multiprocessing.Process(
-          target=g_testing_thread,
-          args=(test_function, test_queue, self.result_queue))
-      p.start()
-      self.processes.append(p)
+    def init_processes(self, test_function, test_queue):
+        self.processes = []
+        self.result_queue = multiprocessing.Queue()
+        for x in range(multiprocessing.cpu_count()):
+            p = multiprocessing.Process(target=g_testing_thread,
+                                        args=(test_function, test_queue,
+                                              self.result_queue))
+            p.start()
+            self.processes.append(p)
 
-  def collect_results(self):
-    buffered_results = []
-    num = 0
-    while len(self.processes):
-      res = get_from_queue(self.result_queue)
-      if res is not None:
-        num += 1
-        # Print periodically to assure the bot monitor that we are still alive
-        if num % 10 == 0:
-          print('Got test results:', num)
-        buffered_results.append(res)
-      else:
-        self.clear_finished_processes()
-    return buffered_results
+    def collect_results(self):
+        buffered_results = []
+        num = 0
+        while len(self.processes):
+            res = get_from_queue(self.result_queue)
+            if res is not None:
+                num += 1
+                # Print periodically to assure the bot monitor that we are
+                # still alive
+                if num % 10 == 0:
+                    print('Got test results:', num)
+                buffered_results.append(res)
+            else:
+                self.clear_finished_processes()
+        return buffered_results
 
-  def clear_finished_processes(self):
-    self.processes = [p for p in self.processes if p.is_alive()]
+    def clear_finished_processes(self):
+        self.processes = [p for p in self.processes if p.is_alive()]
 
 
 def get_from_queue(q):
-  try:
-    return q.get(True, 0.1)
-  except queue.Empty:
-    pass
-  return None
+    try:
+        return q.get(True, 0.1)
+    except queue.Empty:
+        pass
+    return None

--- a/src/proc.py
+++ b/src/proc.py
@@ -24,75 +24,75 @@ import os
 import sys
 # Imports all of subprocess into the current namespace, effectively
 # re-exporting everything.
-from subprocess import * # noqa
+from subprocess import *  # noqa
 
 
 def Which(filename, cwd=None, is_executable=True):
-  if os.path.isabs(filename):
-    return filename
+    if os.path.isabs(filename):
+        return filename
 
-  to_search = os.environ.get('PATH', '').split(os.pathsep)
-  if cwd:
-    to_search.insert(0, cwd)
-  exe_suffixes = ['']
-  if sys.platform == 'win32' and is_executable:
-    exe_suffixes = ['.exe', '.bat', '.cmd'] + exe_suffixes
-  for path in to_search:
-    abs_path = os.path.abspath(os.path.join(path, filename))
-    for suffix in exe_suffixes:
-      full_path = abs_path + suffix
-      if (os.path.isfile(full_path) and
-              (not is_executable or os.access(full_path, os.X_OK))):
-        return full_path
-  raise Exception('File "%s" not found. (cwd=`%s`, PATH=`%s`' %
-                  (filename, cwd, os.environ['PATH']))
+    to_search = os.environ.get('PATH', '').split(os.pathsep)
+    if cwd:
+        to_search.insert(0, cwd)
+    exe_suffixes = ['']
+    if sys.platform == 'win32' and is_executable:
+        exe_suffixes = ['.exe', '.bat', '.cmd'] + exe_suffixes
+    for path in to_search:
+        abs_path = os.path.abspath(os.path.join(path, filename))
+        for suffix in exe_suffixes:
+            full_path = abs_path + suffix
+            if (os.path.isfile(full_path) and
+                    (not is_executable or os.access(full_path, os.X_OK))):
+                return full_path
+    raise Exception('File "%s" not found. (cwd=`%s`, PATH=`%s`' %
+                    (filename, cwd, os.environ['PATH']))
 
 
 def MungeExe(cmd, cwd):
-  exe = cmd[0]
-  if exe.endswith('.py'):
-    script = Which(exe, cwd, is_executable=False)
-    return [sys.executable, script] + cmd[1:]
-  if exe in ('git', 'npm', 'gclient'):
-    return [Which(exe, cwd)] + cmd[1:]
-  return cmd
+    exe = cmd[0]
+    if exe.endswith('.py'):
+        script = Which(exe, cwd, is_executable=False)
+        return [sys.executable, script] + cmd[1:]
+    if exe in ('git', 'npm', 'gclient'):
+        return [Which(exe, cwd)] + cmd[1:]
+    return cmd
 
 
 def MungeKwargs(kwargs):
-  should_log = True
-  if 'should_log' in kwargs:
-    should_log = kwargs['should_log']
-    del kwargs['should_log']
-  return should_log, kwargs
+    should_log = True
+    if 'should_log' in kwargs:
+        should_log = kwargs['should_log']
+        del kwargs['should_log']
+    return should_log, kwargs
 
 
 def LogCall(funcname, cmd, cwd):
-  if isinstance(cmd, str):
-    c = cmd
-  else:
-    c = ' '.join('"' + c + '"' if ' ' in c else c for c in cmd)
-  print('%s(`%s`, cwd=`%s`)' % (funcname, c, cwd))
+    if isinstance(cmd, str):
+        c = cmd
+    else:
+        c = ' '.join('"' + c + '"' if ' ' in c else c for c in cmd)
+    print('%s(`%s`, cwd=`%s`)' % (funcname, c, cwd))
 
 
 # Now we can override any parts of subprocess we want, while leaving the rest.
 def check_call(cmd, **kwargs):
-  cwd = kwargs.get('cwd', os.getcwd())
-  should_log, kwargs = MungeKwargs(kwargs)
-  cmd = MungeExe(cmd, cwd)
-  if should_log:
-    LogCall('subprocess.check_call', cmd, cwd)
-  sys.stdout.flush()
-  try:
-    subprocess.check_call(cmd, **kwargs)
-  finally:
+    cwd = kwargs.get('cwd', os.getcwd())
+    should_log, kwargs = MungeKwargs(kwargs)
+    cmd = MungeExe(cmd, cwd)
+    if should_log:
+        LogCall('subprocess.check_call', cmd, cwd)
     sys.stdout.flush()
+    try:
+        subprocess.check_call(cmd, **kwargs)
+    finally:
+        sys.stdout.flush()
 
 
 def check_output(cmd, **kwargs):
-  cwd = kwargs.get('cwd', os.getcwd())
-  should_log, kwargs = MungeKwargs(kwargs)
-  cmd = MungeExe(cmd, cwd)
-  if should_log:
-    LogCall('subprocess.check_output', cmd, cwd)
-  sys.stdout.flush()
-  return subprocess.check_output(cmd, **kwargs)
+    cwd = kwargs.get('cwd', os.getcwd())
+    should_log, kwargs = MungeKwargs(kwargs)
+    cmd = MungeExe(cmd, cwd)
+    if should_log:
+        LogCall('subprocess.check_output', cmd, cwd)
+    sys.stdout.flush()
+    return subprocess.check_output(cmd, **kwargs)

--- a/src/testing.py
+++ b/src/testing.py
@@ -26,327 +26,335 @@ single_threaded = False
 
 
 class Result:
-  """Result from a single test that was run."""
+    """Result from a single test that was run."""
+    def __init__(self, test, success, output):
+        self.test = test
+        self.success = success
+        self.output = output
 
-  def __init__(self, test, success, output):
-    self.test = test
-    self.success = success
-    self.output = output
+    def __str__(self):
+        return '%s %s%s%s' % ('SUCCEEDED' if self.success else 'FAILED',
+                              self.test, '\n' if self.output else '',
+                              self.output.decode('utf-8'))
 
-  def __str__(self):
-    return '%s %s%s%s' % ('SUCCEEDED' if self.success else 'FAILED',
-                          self.test, '\n' if self.output else '',
-                          self.output.decode('utf-8'))
+    def __bool__(self):
+        return self.success
 
-  def __bool__(self):
-    return self.success
+    # py2 compat
+    __nonzero__ = __bool__
 
-  # py2 compat
-  __nonzero__ = __bool__
+    def __lt__(self, other):
+        """Sort by test name so that the output files can be compared
+        easily."""
+        return self.test < other.test
 
-  def __lt__(self, other):
-    """Sort by test name so that the output files can be compared easily."""
-    return self.test < other.test
-
-  def similarity(self, other):
-    """Compare output similarity, returning a float in the range [0,1]."""
-    # Even quick_ratio is fairly slow on big inputs, capture just the start.
-    max_size = 1024
-    return difflib.SequenceMatcher(None, self.output[:max_size],
-                                   other.output[:max_size]).quick_ratio()
+    def similarity(self, other):
+        """Compare output similarity, returning a float in the range [0,1]."""
+        # Even quick_ratio is fairly slow on big inputs, capture just the
+        # start.
+        max_size = 1024
+        return difflib.SequenceMatcher(None, self.output[:max_size],
+                                       other.output[:max_size]).quick_ratio()
 
 
 class Tester(object):
-  """Test runner."""
+    """Test runner."""
+    def __init__(self, command_ctor, outname_ctor, outdir, extras):
+        """Command-line constructor accepting input and output file names."""
+        if outdir:
+            assert os.path.isdir(
+                outdir), 'Expected output directory %s' % outdir
+        self.command_ctor = command_ctor
+        self.outname_ctor = outname_ctor
+        self.outdir = outdir
+        self.extras = extras
 
-  def __init__(self, command_ctor, outname_ctor, outdir, extras):
-    """Command-line constructor accepting input and output file names."""
-    if outdir:
-      assert os.path.isdir(outdir), 'Expected output directory %s' % outdir
-    self.command_ctor = command_ctor
-    self.outname_ctor = outname_ctor
-    self.outdir = outdir
-    self.extras = extras
+    @staticmethod
+    def setlimits():
+        # Set maximum CPU time to 90 seconds in child process
+        try:
+            import resource
+            resource.setrlimit(resource.RLIMIT_CPU, (90, 90))
+        except:  # noqa
+            pass
 
-  @staticmethod
-  def setlimits():
-    # Set maximum CPU time to 90 seconds in child process
-    try:
-      import resource
-      resource.setrlimit(resource.RLIMIT_CPU, (90, 90))
-    except: # noqa
-      pass
+    def __call__(self, test_file):
+        """Execute a single test."""
+        basename = os.path.basename(test_file)
+        if self.outdir:
+            outfile = self.outname_ctor(self.outdir, test_file, self.extras)
+        else:
+            outfile = ''
+        should_log = sys.platform != 'darwin'
+        try:
 
-  def __call__(self, test_file):
-    """Execute a single test."""
-    basename = os.path.basename(test_file)
-    if self.outdir:
-      outfile = self.outname_ctor(self.outdir, test_file, self.extras)
-    else:
-      outfile = ''
-    should_log = sys.platform != 'darwin'
-    try:
-
-      output = proc.check_output(
-          self.command_ctor(test_file, outfile, self.extras),
-          stderr=proc.STDOUT, cwd=self.outdir or os.getcwd(),
-          # preexec_fn is not supported on Windows
-          preexec_fn=Tester.setlimits if sys.platform != 'win32' else None,
-          should_log=should_log)
-      return Result(test=basename, success=True, output=output)
-    except proc.CalledProcessError as e:
-      return Result(test=basename, success=False, output=e.output)
+            output = proc.check_output(
+                self.command_ctor(test_file, outfile, self.extras),
+                stderr=proc.STDOUT,
+                cwd=self.outdir or os.getcwd(),
+                # preexec_fn is not supported on Windows
+                preexec_fn=Tester.setlimits
+                if sys.platform != 'win32' else None,
+                should_log=should_log)
+            return Result(test=basename, success=True, output=output)
+        except proc.CalledProcessError as e:
+            return Result(test=basename, success=False, output=e.output)
 
 
 def parse_exclude_files(fails, config_attributes):
-  """ Returns a sorted list  of exclusions which match the attributes.
+    """ eturns a sorted list  of exclusions which match the attributes.
 
-  Parse the files containing tests to exclude (i.e. expected fails).
-  * Each line may contain a comma-separated list of attributes restricting
-    the test configurations which are expected to fail. (e.g. JS engine
-    or optimization level).
-  * A test is only excluded if the configuration has all the attributes
-    specified in the exclude line.
-  * Lines which have no attributes will match everything
-  * Lines which specify only one attribute (e.g. engine) will match all
-    configurations with that attribute (e.g. both opt levels with that engine).
-  For more details and example, see test/run_known_gcc_test_failures.txt
-  """
-  excludes = {}  # maps name of excluded test to file from whence it came
-  config_attributes = set(config_attributes) if config_attributes else set()
+    Parse the files containing tests to exclude (i.e. expected fails).
+    * Each line may contain a comma-separated list of attributes restricting
+      the test configurations which are expected to fail. (e.g. JS engine
+      or optimization level).
+    * A test is only excluded if the configuration has all the attributes
+      specified in the exclude line.
+    * Lines which have no attributes will match everything
+    * Lines which specify only one attribute (e.g. engine) will match all
+      configurations with that attribute (e.g. both opt levels with that
+      engine).
+    For more details and example, see test/run_known_gcc_test_failures.txt
+    """
+    excludes = {}  # maps name of excluded test to file from whence it came
+    config_attributes = set(config_attributes) if config_attributes else set()
 
-  def parse_line(line):
-    line = line.strip()
-    if '#' in line:
-      line = line[:line.index('#')].strip()
-    tokens = line.split()
-    return tokens
+    def parse_line(line):
+        line = line.strip()
+        if '#' in line:
+            line = line[:line.index('#')].strip()
+        tokens = line.split()
+        return tokens
 
-  for excludefile in fails:
-    f = open(excludefile)
-    for line in f:
-      tokens = parse_line(line)
-      if not tokens:
-        continue
-      if len(tokens) > 1:
-        attributes = set(tokens[1].split(','))
-        if not attributes.issubset(config_attributes):
-          continue
-      test = tokens[0]
+    for excludefile in fails:
+        f = open(excludefile)
+        for line in f:
+            tokens = parse_line(line)
+            if not tokens:
+                continue
+            if len(tokens) > 1:
+                attributes = set(tokens[1].split(','))
+                if not attributes.issubset(config_attributes):
+                    continue
+            test = tokens[0]
 
-      if test in excludes:
-        print('ERROR: duplicate exclude: [%s]' % line)
-        print('Files: %s and %s' % (excludes[test], excludefile))
-        sys.exit(1)
-      excludes[test] = excludefile
-    f.close()
-  return sorted(excludes.keys())
+            if test in excludes:
+                print('ERROR: duplicate exclude: [%s]' % line)
+                print('Files: %s and %s' % (excludes[test], excludefile))
+                sys.exit(1)
+            excludes[test] = excludefile
+        f.close()
+    return sorted(excludes.keys())
 
 
 class TriangularArray:
-  """Indexed with two commutable keys."""
+    """Indexed with two commutable keys."""
+    def __init__(self):
+        self.arr = {}
 
-  def __init__(self):
-    self.arr = {}
+    def canonicalize(self, key):
+        return (min(key[0], key[1]), max(key[0], key[1]))
 
-  def canonicalize(self, key):
-    return (min(key[0], key[1]), max(key[0], key[1]))
+    def __getitem__(self, key):
+        return self.arr[self.canonicalize(key)]
 
-  def __getitem__(self, key):
-    return self.arr[self.canonicalize(key)]
+    def __setitem__(self, key, value):
+        k = self.canonicalize(key)
+        # Support single-insertion only, the intended usage would be a bug if
+        # there were multiple insertions of the same key.
+        assert k not in self.arr, 'Double insertion of key %s' % str(k)
+        self.arr[k] = value
 
-  def __setitem__(self, key, value):
-    k = self.canonicalize(key)
-    # Support single-insertion only, the intended usage would be a bug if there
-    # were multiple insertions of the same key.
-    assert k not in self.arr, 'Double insertion of key %s' % str(k)
-    self.arr[k] = value
-
-  def __iter__(self):
-    return iter(self.arr.items())
+    def __iter__(self):
+        return iter(self.arr.items())
 
 
 class SimilarityGroup:
-  """Group of similar results."""
-  def __init__(self, tests, similarities):
-    self.tests = sorted(tests)
-    self.similarities = [100. * s for s in similarities]
-    self.average = (sum(self.similarities) / len(self.similarities)
-                    if self.similarities else 0.)
-    squared_diffs = [(s - self.average) ** 2 for s in self.similarities]
-    self.stddev = (math.sqrt(sum(squared_diffs) / len(squared_diffs))
-                   if self.similarities else 0.)
+    """Group of similar results."""
+    def __init__(self, tests, similarities):
+        self.tests = sorted(tests)
+        self.similarities = [100. * s for s in similarities]
+        self.average = (sum(self.similarities) /
+                        len(self.similarities) if self.similarities else 0.)
+        squared_diffs = [(s - self.average)**2 for s in self.similarities]
+        self.stddev = (math.sqrt(sum(squared_diffs) / len(squared_diffs))
+                       if self.similarities else 0.)
 
 
 def similarity(results, cutoff):
-  """List of lists of result test names with similar outputs."""
-  similarities = TriangularArray()
-  for x in range(0, len(results)):
-    for y in range(x + 1, len(results)):
-      rx = results[x]
-      ry = results[y]
-      similarities[(rx.test, ry.test)] = rx.similarity(ry)
-  # A maximum clique would be better suited to group similarities, but this
-  # silly traversal is simpler and seems to do the job pretty well.
-  similar_groups = []
-  worklist = set()
-  for k, v in similarities:
-    if v > cutoff:
-      worklist.add(k[0])
-      worklist.add(k[1])
-  for result in results:
-    test = result.test
-    if test in worklist:
-      worklist.remove(test)
-      group_tests = [test]
-      group_similarities = []
-      for other_result in results:
-        other_test = other_result.test
-        if other_test in worklist:
-          similar = similarities[(test, other_test)]
-          if similar > cutoff:
-            worklist.remove(other_test)
-            group_tests.append(other_test)
-            group_similarities.append(similar)
-      if len(group_tests) > 1:
-        # Some tests could have similar matches which were more similar to
-        # other tests, leaving this group with a single entry.
-        similar_groups.append(SimilarityGroup(tests=group_tests,
-                                              similarities=group_similarities))
-  assert len(worklist) == 0, 'Failed emptying worklist %s' % worklist
-  # Put all the ungrouped tests into their own group.
-  grouped = set()
-  for group in similar_groups:
-    for test in group.tests:
-      grouped.add(test)
-  uniques = list(set([r.test for r in results]) - grouped)
-  if uniques:
-    s = [similarities[(uniques[0], u)] for u in uniques[1:]]
-    similar_groups.append(SimilarityGroup(tests=uniques, similarities=s))
-  return similar_groups
+    """List of lists of result test names with similar outputs."""
+    similarities = TriangularArray()
+    for x in range(0, len(results)):
+        for y in range(x + 1, len(results)):
+            rx = results[x]
+            ry = results[y]
+            similarities[(rx.test, ry.test)] = rx.similarity(ry)
+    # A maximum clique would be better suited to group similarities, but this
+    # silly traversal is simpler and seems to do the job pretty well.
+    similar_groups = []
+    worklist = set()
+    for k, v in similarities:
+        if v > cutoff:
+            worklist.add(k[0])
+            worklist.add(k[1])
+    for result in results:
+        test = result.test
+        if test in worklist:
+            worklist.remove(test)
+            group_tests = [test]
+            group_similarities = []
+            for other_result in results:
+                other_test = other_result.test
+                if other_test in worklist:
+                    similar = similarities[(test, other_test)]
+                    if similar > cutoff:
+                        worklist.remove(other_test)
+                        group_tests.append(other_test)
+                        group_similarities.append(similar)
+            if len(group_tests) > 1:
+                # Some tests could have similar matches which were more similar
+                # to other tests, leaving this group with a single entry.
+                similar_groups.append(
+                    SimilarityGroup(tests=group_tests,
+                                    similarities=group_similarities))
+    assert len(worklist) == 0, 'Failed emptying worklist %s' % worklist
+    # Put all the ungrouped tests into their own group.
+    grouped = set()
+    for group in similar_groups:
+        for test in group.tests:
+            grouped.add(test)
+    uniques = list(set([r.test for r in results]) - grouped)
+    if uniques:
+        s = [similarities[(uniques[0], u)] for u in uniques[1:]]
+        similar_groups.append(SimilarityGroup(tests=uniques, similarities=s))
+    return similar_groups
 
 
 def make_blocking(fileno):
-  try:
-    from fcntl import fcntl, F_GETFL, F_SETFL
-    fd = sys.stdout.fileno()
-    flags = fcntl(fd, F_GETFL)
-    if flags & os.O_NONBLOCK:
-      fcntl(fd, F_SETFL, flags & ~os.O_NONBLOCK)
-    print('make_blocking old flags %s' % hex(flags))
-  except ImportError:
-    pass
+    try:
+        from fcntl import fcntl, F_GETFL, F_SETFL
+        fd = sys.stdout.fileno()
+        flags = fcntl(fd, F_GETFL)
+        if flags & os.O_NONBLOCK:
+            fcntl(fd, F_SETFL, flags & ~os.O_NONBLOCK)
+        print('make_blocking old flags %s' % hex(flags))
+    except ImportError:
+        pass
 
 
 def execute(tester, inputs, fails, exclusions=None, attributes=None):
-  """Execute tests in parallel, output results, return failure count."""
-  if exclusions:
-    input_exclusions = parse_exclude_files(exclusions, None)
-    inputs = [i for i in inputs if os.path.basename(i) not in input_exclusions]
-  sys.stdout.write('Executing tests.\n')
-  if single_threaded:
-    results = map(tester, inputs)
-  else:
-    runner = parallel_runner.ParallelRunner()
-    results = runner.map(tester, inputs)
+    """Execute tests in parallel, output results, return failure count."""
+    if exclusions:
+        input_exclusions = parse_exclude_files(exclusions, None)
+        inputs = [
+            i for i in inputs if os.path.basename(i) not in input_exclusions
+        ]
+    sys.stdout.write('Executing tests.\n')
+    if single_threaded:
+        results = map(tester, inputs)
+    else:
+        runner = parallel_runner.ParallelRunner()
+        results = runner.map(tester, inputs)
 
-  sys.stdout.flush()
-  sys.stdout.write('Done.\n')
-
-  results = sorted(results)
-  successes = [r for r in results if r]
-  failures = [r for r in results if not r]
-
-  # For some reason it's always here.
-  make_blocking(sys.stdout.fileno())
-  make_blocking(sys.stderr.fileno())
-
-  sys.stdout.write('\nResults:\n')
-  for result in results:
     sys.stdout.flush()
-    sys.stdout.write(str(result) + '\n\n')
+    sys.stdout.write('Done.\n')
 
-  if not fails:
-    sys.stdout.write(
-        '\n'.join(['Ran %s tests.' % len(results),
-                   'Got %s successes.' % len(successes),
-                   'Got %s failures.' % len(failures)]) + '\n')
-    if failures:
-      sys.stdout.write('Unexpected failures:\n')
-      for f in failures:
-        sys.stdout.write('\t%s\n' % f.test)
-    return len(failures)
+    results = sorted(results)
+    successes = [r for r in results if r]
+    failures = [r for r in results if not r]
 
-  input_expected_failures = parse_exclude_files(fails, attributes)
-  expected_failures = [t for t in failures
-                       if t.test in input_expected_failures]
-  unexpected_failures = [t for t in failures
-                         if t.test not in input_expected_failures]
-  unexpected_successes = [t for t in successes
-                          if t.test in input_expected_failures]
+    # For some reason it's always here.
+    make_blocking(sys.stdout.fileno())
+    make_blocking(sys.stderr.fileno())
 
-  similarity_cutoff = 0.9
-  # Calculating similarity is pretty expensive. If too many tests are failing,
-  # it can take minutes, and most of them are probably failing for the same
-  # fundamental reason. Skip in that case.
-  failure_cutoff = 0.5
-  max_failure_count = max(1, len(inputs) * failure_cutoff)
+    sys.stdout.write('\nResults:\n')
+    for result in results:
+        sys.stdout.flush()
+        sys.stdout.write(str(result) + '\n\n')
 
-  def similar_failures(label, failures):
-    if len(failures) > max_failure_count:
-      print('Too many %s failures to show similarity' % label)
-      return []
-    return similarity(failures, similarity_cutoff)
+    if not fails:
+        sys.stdout.write('\n'.join([
+            'Ran %s tests.' % len(results),
+            'Got %s successes.' % len(successes),
+            'Got %s failures.' % len(failures)
+        ]) + '\n')
+        if failures:
+            sys.stdout.write('Unexpected failures:\n')
+            for f in failures:
+                sys.stdout.write('\t%s\n' % f.test)
+        return len(failures)
 
-  similar_expected_failures = similar_failures('expected', expected_failures)
-  similar_unexpected_failures = similar_failures('unexpected',
-                                                 unexpected_failures)
+    input_expected_failures = parse_exclude_files(fails, attributes)
+    expected_failures = [
+        t for t in failures if t.test in input_expected_failures
+    ]
+    unexpected_failures = [
+        t for t in failures if t.test not in input_expected_failures
+    ]
+    unexpected_successes = [
+        t for t in successes if t.test in input_expected_failures
+    ]
 
-  def show_similar_failures(label, similar, failures):
-    for s in similar:
-      tests = ' '.join(s.tests)
-      if s.average >= similarity_cutoff * 100.:
-        sys.stdout.write(('\nSimilar %s failures, '
-                          'average %s%% similarity with stddev %s: '
-                          '%s\n') % (label, s.average, s.stddev, tests))
-        sample = [f for f in failures if f.test == s.tests[0]][0]
-        sys.stdout.write('Sample failure: %s\n' % sample)
-      else:
-        sys.stdout.write(('\nUngrouped %s failures, '
-                          'average %s%% similarity with stddev %s: '
-                          '%s\n') % (label, s.average, s.stddev, tests))
+    similarity_cutoff = 0.9
+    # Calculating similarity is pretty expensive. If too many tests are
+    # failing, it can take minutes, and most of them are probably failing for
+    # the same fundamental reason. Skip in that case.
+    failure_cutoff = 0.5
+    max_failure_count = max(1, len(inputs) * failure_cutoff)
 
-  show_similar_failures('expected',
-                        similar_expected_failures,
-                        expected_failures)
-  show_similar_failures('unexpected',
-                        similar_unexpected_failures,
-                        unexpected_failures)
+    def similar_failures(label, failures):
+        if len(failures) > max_failure_count:
+            print('Too many %s failures to show similarity' % label)
+            return []
+        return similarity(failures, similarity_cutoff)
 
-  if expected_failures:
-    sys.stdout.write('Expected failures:\n')
-    for f in expected_failures:
-      sys.stdout.write('\t%s\n' % f.test)
-  if unexpected_failures:
-    sys.stdout.write('Unexpected failures:\n')
-    for f in unexpected_failures:
-      sys.stdout.write('\t%s\n' % f.test)
-  if unexpected_successes:
-    sys.stdout.write('Unexpected successes:\n')
-    for f in unexpected_successes:
-      sys.stdout.write('\t%s\n' % f.test)
-  sys.stdout.write(
-      '\n'.join(['\n',
-                 'Ran %s tests.' % len(results),
-                 'Got %s successes.' % len(successes),
-                 'Got %s failures.' % len(failures),
-                 'Expected %s failures.' % len(input_expected_failures),
-                 'Got %s expected failures in %s similarity groups.' % (
-                     len(expected_failures),
-                     len(similar_expected_failures)),
-                 'Got %s unexpected failures in %s similarity groups.' % (
-                     len(unexpected_failures),
-                     len(similar_unexpected_failures)),
-                 'Got %s unexpected successes.' % len(unexpected_successes),
-                 '\n']))
-  return len(unexpected_failures) + len(unexpected_successes)
+    similar_expected_failures = similar_failures('expected', expected_failures)
+    similar_unexpected_failures = similar_failures('unexpected',
+                                                   unexpected_failures)
+
+    def show_similar_failures(label, similar, failures):
+        for s in similar:
+            tests = ' '.join(s.tests)
+            if s.average >= similarity_cutoff * 100.:
+                sys.stdout.write(
+                    ('\nSimilar %s failures, '
+                     'average %s%% similarity with stddev %s: '
+                     '%s\n') % (label, s.average, s.stddev, tests))
+                sample = [f for f in failures if f.test == s.tests[0]][0]
+                sys.stdout.write('Sample failure: %s\n' % sample)
+            else:
+                sys.stdout.write(
+                    ('\nUngrouped %s failures, '
+                     'average %s%% similarity with stddev %s: '
+                     '%s\n') % (label, s.average, s.stddev, tests))
+
+    show_similar_failures('expected', similar_expected_failures,
+                          expected_failures)
+    show_similar_failures('unexpected', similar_unexpected_failures,
+                          unexpected_failures)
+
+    if expected_failures:
+        sys.stdout.write('Expected failures:\n')
+        for f in expected_failures:
+            sys.stdout.write('\t%s\n' % f.test)
+    if unexpected_failures:
+        sys.stdout.write('Unexpected failures:\n')
+        for f in unexpected_failures:
+            sys.stdout.write('\t%s\n' % f.test)
+    if unexpected_successes:
+        sys.stdout.write('Unexpected successes:\n')
+        for f in unexpected_successes:
+            sys.stdout.write('\t%s\n' % f.test)
+    sys.stdout.write('\n'.join([
+        '\n',
+        'Ran %s tests.' % len(results),
+        'Got %s successes.' % len(successes),
+        'Got %s failures.' % len(failures),
+        'Expected %s failures.' % len(input_expected_failures),
+        'Got %s expected failures in %s similarity groups.' %
+        (len(expected_failures), len(similar_expected_failures)),
+        'Got %s unexpected failures in %s similarity groups.' %
+        (len(unexpected_failures), len(similar_unexpected_failures)),
+        'Got %s unexpected successes.' % len(unexpected_successes), '\n'
+    ]))
+    return len(unexpected_failures) + len(unexpected_successes)

--- a/src/testing.py
+++ b/src/testing.py
@@ -102,7 +102,7 @@ class Tester(object):
 
 
 def parse_exclude_files(fails, config_attributes):
-    """ eturns a sorted list  of exclusions which match the attributes.
+    """Returns a sorted list  of exclusions which match the attributes.
 
     Parse the files containing tests to exclude (i.e. expected fails).
     * Each line may contain a comma-separated list of attributes restricting

--- a/src/work_dirs.py
+++ b/src/work_dirs.py
@@ -16,7 +16,6 @@
 
 import os
 
-
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_WORK_DIR = os.path.join(os.path.dirname(SCRIPT_DIR), 'src', 'work')
 
@@ -31,15 +30,15 @@ dirs = {}
 
 
 def MakeGetterSetter(path_type, default):
-  def getter():
-    return dirs.get(path_type, default)
+    def getter():
+        return dirs.get(path_type, default)
 
-  def setter(dir):
-    if path_type in dirs:
-      raise Exception('Path %s set more than once' % path_type)
-    dirs[path_type] = os.path.abspath(dir)
+    def setter(dir):
+        if path_type in dirs:
+            raise Exception('Path %s set more than once' % path_type)
+        dirs[path_type] = os.path.abspath(dir)
 
-  return getter, setter
+    return getter, setter
 
 
 GetSync, SetSync = MakeGetterSetter('sync', DEFAULT_SYNC_DIR)
@@ -51,4 +50,4 @@ GetInstall, SetInstall = MakeGetterSetter('install', DEFAULT_INSTALL_DIR)
 
 
 def GetAll():
-  return [GetSync(), GetBuild(), GetTest(), GetInstall()]
+    return [GetSync(), GetBuild(), GetTest(), GetInstall()]


### PR DESCRIPTION
First attempt was in #617.

Again I used yapf as a base for this change, with the following manual
tweaks:

1. Manually reflow long comment lines
2. Manually indent multi-line doc strings
3. Revert some of the argparse.add_argument changes that split args onto one per line
4. Overwride yapf for certain cases that involve nestsed function
   calls.  e.g.

For example yaml seem to want to turn this:

```
    proc.check_call(SetupToolchain() +
                    ['foo', paths['win_sdk'], runtime_dirs, 'win', 'x64',
                     'environment.x64'],
                    cwd=outdir)
```

This:

```
    proc.check_call(SetupToolchain() + [
        'foo', paths['win_sdk'], runtime_dirs, 'win', 'x64', 'environment.x64'
    ],
                    cwd=outdir)
```

Choosing to go back out to column zero here in the middle of the
indented arguement list seems objectively wrong.