### PR TITLE
Revert "Use emscripten's install.py to copy emscripten (#631)"

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1050,21 +1050,20 @@ def Fastcomp():
   CopyLLVMTools(build_dir, 'fastcomp')
 
 
-def InstallEmscripten():
-  src_dir = GetSrcDir('emscripten')
-  em_install_dir = GetInstallDir('emscripten')
-  Remove(em_install_dir)
-  print('Installing emscripten into %s' % em_install_dir)
-  proc.check_call([os.path.join('tools', 'install.py'), em_install_dir],
-                  cwd=src_dir)
-
-
 def BuildEmscriptenOptimizer():
   # Remove cached library builds (e.g. libc, libc++) to force them to be
   # rebuilt in the step below.
   buildbot.Step('emscripten (optimizer)')
   Remove(EMSCRIPTEN_CACHE_DIR)
   src_dir = GetSrcDir('emscripten')
+  em_install_dir = GetInstallDir('emscripten')
+  Remove(em_install_dir)
+  print('Copying directory %s to %s' % (src_dir, em_install_dir))
+  shutil.copytree(src_dir,
+                  em_install_dir,
+                  symlinks=True,
+                  # Ignore the big git blob so it doesn't get archived.
+                  ignore=shutil.ignore_patterns('.git'))
 
   # Manually build the native asm.js optimizer (the cmake build in embuilder
   # doesn't work on the waterfall)
@@ -1086,7 +1085,6 @@ def Emscripten(variant):
     # This work is only done once (not per-variant), so only do it if the
     # variant is 'upstream'. This means that the upstream variant does
     # need to go first.
-    InstallEmscripten()
     BuildEmscriptenOptimizer()
 
   def WriteEmscriptenConfig(infile, outfile):


### PR DESCRIPTION
This reverts commit e958c36835f8c91c0bee30bba32ec4448e27727a.

The test suite currently runs in the installed copy and it needs all the tests in order to run. Before relanding, we'll either run the test suite from the checkout instead, or further decouple the
test runner from the rest of emscripten.