### PR TITLE
Inject EMTEST_LACKS_NATIVE_CLANG into env for emscripten tests on bots

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1651,7 +1651,7 @@ def ExecuteEmscriptenTestSuite(name, tests, config, outdir, warn_only=False):
     try:
         test_env = os.environ.copy()
         if buildbot.IsBot() and IsWindows():
-            test_env['EMTEST_NO_NATIVE_CLANG'] = '1'
+            test_env['EMTEST_LACKS_NATIVE_CLANG'] = '1'
         proc.check_call(cmd, cwd=outdir, env=test_env)
     except proc.CalledProcessError:
         buildbot.FailUnless(lambda: warn_only)

--- a/src/build.py
+++ b/src/build.py
@@ -1649,7 +1649,10 @@ def ExecuteEmscriptenTestSuite(name, tests, config, outdir, warn_only=False):
         '--em-config', config
     ] + tests
     try:
-        proc.check_call(cmd, cwd=outdir)
+        test_env = os.environ.copy()
+        if buildbot.IsBot() and IsWindows():
+            test_env['EMTEST_NO_NATIVE_CLANG'] = '1'
+        proc.check_call(cmd, cwd=outdir, env=test_env)
     except proc.CalledProcessError:
         buildbot.FailUnless(lambda: warn_only)
 


### PR DESCRIPTION
The bots don't have the proper environment vars that are needed.