### PR TITLE
Update to Node LTS 12.18.1

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -145,7 +145,7 @@ def WindowsFSEscape(path):
 
 
 # Use prebuilt Node.js because the buildbots don't have node preinstalled
-NODE_VERSION = '12.9.1'
+NODE_VERSION = '12.18.1'
 NODE_BASE_NAME = 'node-v' + NODE_VERSION + '-'
 
 


### PR DESCRIPTION
This version has V8 v7.8, and in particular includes support for the wasm
fence instruction.