### PR TITLE
Run `npm ci` before trying to use emscripten

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1583,7 +1583,15 @@ def TestBare():
                                wasmjs=os.path.join(SCRIPT_DIR, 'wasi.js'))
 
 
+def ActivateEmscripten():
+    em_install_dir = GetInstallDir('emscripten')
+    if not os.path.exists(em_install_dir, 'node_module'):
+        proc.check_call(['npm', 'ci'], cwd=em_install_dir)
+
+
 def TestAsm():
+    ActivateEmscripten()
+
     for opt in EMSCRIPTEN_TEST_OPT_FLAGS:
         CompileLLVMTortureEmscripten('asm2wasm',
                                      GetInstallDir(EMSCRIPTEN_CONFIG_FASTCOMP),
@@ -1608,6 +1616,8 @@ def TestAsm():
 
 
 def TestEmwasm():
+    ActivateEmscripten()
+
     for opt in EMSCRIPTEN_TEST_OPT_FLAGS:
         CompileLLVMTortureEmscripten('emwasm',
                                      GetInstallDir(EMSCRIPTEN_CONFIG_UPSTREAM),
@@ -1632,13 +1642,12 @@ def TestEmwasm():
 def ExecuteEmscriptenTestSuite(name, tests, config, outdir, warn_only=False):
     buildbot.Step('Execute emscripten testsuite (%s)' % name)
     Mkdir(outdir)
+    ActivateEmscripten()
 
     # Before we can run the tests we prepare the installed emscripten
-    # directory by installing any needed npm packages, and also copying
-    # of some test data which is otherwise excluded by emscripten install
-    # script (tools/install.py).
+    # directory by copying of some test data which is otherwise excluded by
+    # emscripten install script (tools/install.py).
     em_install_dir = GetInstallDir('emscripten')
-    proc.check_call(['npm', 'ci'], cwd=em_install_dir)
     installed_tests = os.path.join(em_install_dir, 'tests', 'third_party')
     if not os.path.exists(installed_tests):
         src_dir = GetSrcDir('emscripten', 'tests', 'third_party')


### PR DESCRIPTION
We recently started depending more on the result on `npm ci` because
we now get acorn compiler via npm.