### PR TITLE
Cleanup emscripten config files

### DIFF
--- a/src/emscripten_config_fastcomp
+++ b/src/emscripten_config_fastcomp
@@ -1,62 +1,19 @@
-
-# Note: If you put paths relative to the home directory, do not forget os.path.expanduser
-
-# Note: On Windows, remember to escape backslashes! I.e. EMSCRIPTEN_ROOT='c:\emscripten\' is not valid, but EMSCRIPTEN_ROOT='c:\\emscripten\\' and EMSCRIPTEN_ROOT='c:/emscripten/' are.
-
 import os
 
 WASM_INSTALL = '{{WASM_INSTALL}}'
-
 # this helps projects using emscripten find it
-EMSCRIPTEN_ROOT = os.path.join(WASM_INSTALL, 'emscripten') # directory
-LLVM_ROOT = os.path.join(WASM_INSTALL, 'fastcomp', 'bin') # directory
-BINARYEN_ROOT = os.path.join(WASM_INSTALL) # directory
+EMSCRIPTEN_ROOT = os.path.join(WASM_INSTALL, 'emscripten')
+LLVM_ROOT = os.path.join(WASM_INSTALL, 'fastcomp', 'bin')
+BINARYEN_ROOT = os.path.join(WASM_INSTALL)
 
-# If not specified, defaults to sys.executable.
-#PYTHON = 'python'
-
-# Add this if you have manually built the JS optimizer executable (in Emscripten/tools/optimizer) and want to run it from a custom location.
-# Alternatively, you can set this as the environment variable EMSCRIPTEN_NATIVE_OPTIMIZER.
 EMSCRIPTEN_NATIVE_OPTIMIZER=os.path.join(WASM_INSTALL, 'bin', 'optimizer')
 
-# See below for notes on which JS engine(s) you need
 prebuilt_node = '{{PREBUILT_NODE}}'
 if not os.path.isfile(prebuilt_node):
    prebuilt_node = None
+NODE_JS = os.path.expanduser(os.getenv('NODE') or prebuilt_node or '/usr/bin/nodejs')
+JAVA = '{{PREBUILT_JAVA}}'
 
-NODE_JS = os.path.expanduser(os.getenv('NODE') or prebuilt_node  or '/usr/bin/nodejs') # executable
-SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY') or 'js')] # executable
-V8_ENGINE = os.path.join(WASM_INSTALL, 'bin', 'd8') # executable
-
-JAVA = '{{PREBUILT_JAVA}}' # executable
-
-TEMP_DIR = '/tmp'
-
-CRUNCH = os.path.expanduser(os.getenv('CRUNCH') or 'crunch') # executable
-
-#CLOSURE_COMPILER = '..' # define this to not use the bundled version
-
-########################################################################################################
-
-
-# Pick the JS engine to use for running the compiler. This engine must exist, or
-# nothing can be compiled.
-#
-# Recommendation: If you already have node installed, use that. Otherwise, build v8 or
-#                 spidermonkey from source. Any of these three is fine, as long as it's
-#                 a recent version (especially for v8 and spidermonkey).
-
-COMPILER_ENGINE = NODE_JS
-#COMPILER_ENGINE = V8_ENGINE
-#COMPILER_ENGINE = SPIDERMONKEY_ENGINE
-
-
-# All JS engines to use when running the automatic tests. Not all the engines in this list
-# must exist (if they don't, they will be skipped in the test runner).
-#
-# Recommendation: If you already have node installed, use that. If you can, also build
-#                 spidermonkey from source as well to get more test coverage (node can't
-#                 run all the tests due to node issue 1669). v8 is currently not recommended
-#                 here because of v8 issue 1822.
-
-JS_ENGINES = [NODE_JS] # add this if you have spidermonkey installed too, SPIDERMONKEY_ENGINE]
+# For testing only
+V8_ENGINE = os.path.join(WASM_INSTALL, 'bin', 'd8')
+JS_ENGINES = [NODE_JS]

--- a/src/emscripten_config_upstream
+++ b/src/emscripten_config_upstream
@@ -1,62 +1,17 @@
-
-# Note: If you put paths relative to the home directory, do not forget os.path.expanduser
-
-# Note: On Windows, remember to escape backslashes! I.e. EMSCRIPTEN_ROOT='c:\emscripten\' is not valid, but EMSCRIPTEN_ROOT='c:\\emscripten\\' and EMSCRIPTEN_ROOT='c:/emscripten/' are.
-
 import os
 
 WASM_INSTALL = '{{WASM_INSTALL}}'
-
 # this helps projects using emscripten find it
-EMSCRIPTEN_ROOT = os.path.join(WASM_INSTALL, 'emscripten') # directory
-LLVM_ROOT = os.path.join(WASM_INSTALL, 'bin') # directory
-BINARYEN_ROOT = os.path.join(WASM_INSTALL) # directory
+EMSCRIPTEN_ROOT = os.path.join(WASM_INSTALL, 'emscripten')
+LLVM_ROOT = os.path.join(WASM_INSTALL, 'bin')
+BINARYEN_ROOT = os.path.join(WASM_INSTALL)
 
-# If not specified, defaults to sys.executable.
-#PYTHON = 'python'
-
-# Add this if you have manually built the JS optimizer executable (in Emscripten/tools/optimizer) and want to run it from a custom location.
-# Alternatively, you can set this as the environment variable EMSCRIPTEN_NATIVE_OPTIMIZER.
-# EMSCRIPTEN_NATIVE_OPTIMIZER='/path/to/custom/optimizer(.exe)'
-
-# See below for notes on which JS engine(s) you need
 prebuilt_node = '{{PREBUILT_NODE}}'
 if not os.path.isfile(prebuilt_node):
    prebuilt_node = None
+NODE_JS = os.path.expanduser(os.getenv('NODE') or prebuilt_node or '/usr/bin/nodejs')
+JAVA = '{{PREBUILT_JAVA}}'
 
-NODE_JS = os.path.expanduser(os.getenv('NODE') or prebuilt_node or '/usr/bin/nodejs') # executable
-SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY') or 'js')] # executable
-V8_ENGINE = os.path.join(WASM_INSTALL, 'bin', 'd8') # executable
-
-JAVA = '{{PREBUILT_JAVA}}' # executable
-
-TEMP_DIR = '/tmp'
-
-CRUNCH = os.path.expanduser(os.getenv('CRUNCH') or 'crunch') # executable
-
-#CLOSURE_COMPILER = '..' # define this to not use the bundled version
-
-########################################################################################################
-
-
-# Pick the JS engine to use for running the compiler. This engine must exist, or
-# nothing can be compiled.
-#
-# Recommendation: If you already have node installed, use that. Otherwise, build v8 or
-#                 spidermonkey from source. Any of these three is fine, as long as it's
-#                 a recent version (especially for v8 and spidermonkey).
-
-COMPILER_ENGINE = NODE_JS
-#COMPILER_ENGINE = V8_ENGINE
-#COMPILER_ENGINE = SPIDERMONKEY_ENGINE
-
-
-# All JS engines to use when running the automatic tests. Not all the engines in this list
-# must exist (if they don't, they will be skipped in the test runner).
-#
-# Recommendation: If you already have node installed, use that. If you can, also build
-#                 spidermonkey from source as well to get more test coverage (node can't
-#                 run all the tests due to node issue 1669). v8 is currently not recommended
-#                 here because of v8 issue 1822.
-
-JS_ENGINES = [NODE_JS] # add this if you have spidermonkey installed too, SPIDERMONKEY_ENGINE]
+# For testing only
+V8_ENGINE = os.path.join(WASM_INSTALL, 'bin', 'd8')
+JS_ENGINES = [NODE_JS]


### PR DESCRIPTION
These files are not used by the emsdk but only internally
when testing the resulting SDK.