### PR TITLE
Switch builders to use builder_group property instead of mastername.

### DIFF
--- a/cr-buildbucket.cfg
+++ b/cr-buildbucket.cfg
@@ -33,7 +33,7 @@ buckets {
         cipd_package: "infra/recipe_bundles/chromium.googlesource.com/chromium/tools/build"
         cipd_version: "refs/heads/master"
         name: "wasm_llvm"
-        properties: "mastername:client.wasm.llvm"
+        properties: "builder_group:client.wasm.llvm"
       }
     }
 


### PR DESCRIPTION
Bug: 1109276
Change-Id: I1d0d70d6680d0252c72700a4a03fc4c309eda63a