### PR TITLE
Revert "Switch sysroot to ubuntu bionic (#675)"

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -77,8 +77,8 @@ CLOBBER_BUILD_TAG = 21
 
 V8_BUILD_SUBDIR = os.path.join('out.gn', 'x64.release')
 
-LINUX_SYSROOT = 'sysroot_ubuntu_bionic_amd64'
-LINUX_SYSROOT_URL = WASM_STORAGE_BASE + LINUX_SYSROOT + '_v1.tar.xz'
+LINUX_SYSROOT = 'sysroot_debian_stretch_amd64'
+LINUX_SYSROOT_URL = WASM_STORAGE_BASE + LINUX_SYSROOT + '_v2.tar.xz'
 
 options = None
 

--- a/src/create_sysroot.sh
+++ b/src/create_sysroot.sh
@@ -12,18 +12,17 @@
 
 set -o errexit
 
-SUITE=bionic
-DISTRO=ubuntu
-TARGET_DIR=sysroot_${DISTRO}_${SUITE}_amd64
-VERSION=1
+SUITE=stretch
+TARGET_DIR=sysroot_debian_${SUITE}_amd64
+VERSION=2
 
 mkdir $TARGET_DIR
 
 # Perform minimal installation
-debootstrap $SUITE $TARGET_DIR http://archive.ubuntu.com/ubuntu/
+debootstrap $SUITE $TARGET_DIR http://deb.debian.org/debian
 
 # Install additional packages
-chroot $TARGET_DIR apt-get install -y -q libstdc++-dev zlib1g-dev
+chroot $TARGET_DIR apt-get install -y -q libstdc++-6-dev zlib1g-dev
 
 # Convert absolute symlinks to relative
 find $TARGET_DIR -type l -lname '/*' -exec sh -c 'file="$0"; dir=$(dirname "$file"); target=$(readlink "$0"); prefix=$(dirname "$dir" | sed 's@[^/]*@\.\.@g'); newtarget="$prefix$target"; ln -snf $newtarget $file' {} \;
@@ -33,4 +32,4 @@ for d in dev proc tmp home run var boot media sys srv mnt; do
   rm -rf $TARGET_DIR/$d
 done
 
-tar cJf sysroot_${DISTRO}_${SUITE}_amd64_v${VERSION}.tar.xz -C $TARGET_DIR .
+tar cJf sysroot_debian_${SUITE}_amd64_v${VERSION}.tar.xz -C $TARGET_DIR .


### PR DESCRIPTION
This reverts commit b3c1fc5ade7dcfb495ad285e1374f6500b931513.

Turns own the resulting libm.so dependency is too recent
even to run out our own bots:

```
subprocess.check_call(`/b/s/w/ir/cache/vpython/75e09f/bin/python /b/s/w/ir/k/install/emscripten/embuilder.py build SYSTEM`, cwd=`/b/s/w/ir/cache/builder/emscripten-releases/waterfall/src`)
/b/s/w/ir/k/install/bin/clang: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /b/s/w/ir/k/install/bin/../lib/libLLVM-12git.so)
embuilder: error: '/b/s/w/ir/k/install/bin/clang --version' failed (1)
```