### PR TITLE
Add a build.py flag to build with extra optimizations

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1062,7 +1062,6 @@ def Binaryen():
     cmake_command = CMakeCommandNative([GetSrcDir('binaryen')], out_dir)
     if options.extraopt:
         cmake_command.append('-DBYN_ENABLE_LTO=ON')
-        cmake_command.append('-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld')
     proc.check_call(cmake_command,
                     cwd=out_dir,
                     env=cc_env)

--- a/src/build.py
+++ b/src/build.py
@@ -764,11 +764,14 @@ def OverrideCMakeCompiler():
         return []
     cc = 'clang-cl' if IsWindows() else 'clang'
     cxx = 'clang-cl' if IsWindows() else 'clang++'
-    return [
+    tools = [
         '-DCMAKE_C_COMPILER=' + Executable(GetPrebuiltClang(cc)),
-        '-DCMAKE_CXX_COMPILER=' + Executable(GetPrebuiltClang(cxx))
+        '-DCMAKE_CXX_COMPILER=' + Executable(GetPrebuiltClang(cxx)),
     ]
+    if IsWindows():
+        tools.append('-DCMAKE_LINKER=' +  Executable(GetPrebuiltClang('lld-link')))
 
+    return tools
 
 def CMakeCommandBase():
     command = [PrebuiltCMakeBin(), '-G', 'Ninja']

--- a/src/build.py
+++ b/src/build.py
@@ -878,7 +878,7 @@ def LLVM():
     build_dir = os.path.join(work_dirs.GetBuild(), 'llvm-out')
     Mkdir(build_dir)
     cc_env = BuildEnv(build_dir, bin_subdir=True)
-    build_dylib = 'ON' if not IsWindows() and not options.extraopt else 'OFF'
+    build_dylib = 'ON' if not IsWindows() and not options.use_lto else 'OFF'
     command = CMakeCommandNative([
         GetLLVMSrcDir('llvm'),
         '-DCMAKE_CXX_FLAGS=-Wno-nonportable-include-path',
@@ -900,7 +900,7 @@ def LLVM():
         '-DLLVM_ENABLE_TERMINFO=%d' % (not IsLinux()),
     ], build_dir)
 
-    if options.extraopt:
+    if options.use_lto:
         command.extend(['-DLLVM_ENABLE_ASSERTIONS=OFF',
                         '-DLLVM_BUILD_TESTS=OFF',
                         '-DLLVM_INCLUDE_TESTS=OFF',
@@ -1060,7 +1060,7 @@ def Binaryen():
     cc_env = BuildEnv(out_dir, bin_subdir=True, runtime='Debug')
 
     cmake_command = CMakeCommandNative([GetSrcDir('binaryen')], out_dir)
-    if options.extraopt:
+    if options.use_lto:
         cmake_command.append('-DBYN_ENABLE_LTO=ON')
     proc.check_call(cmake_command,
                     cwd=out_dir,
@@ -1801,8 +1801,8 @@ def ParseArgs():
         '--clobber', dest='clobber', default=False, action='store_true',
         help="Delete working directories, forcing a clean build")
     parser.add_argument(
-        '--extraopt', dest='extraopt', default=False, action='store_true',
-        help='Extra optimization for host binaries')
+        '--use-lto', dest='use_lto', default=False, action='store_true',
+        help='Use extra optimization for host binaries')
 
     return parser.parse_args()
 

--- a/src/build.py
+++ b/src/build.py
@@ -899,7 +899,9 @@ def LLVM():
 
     if options.extraopt:
         command.extend(['-DLLVM_ENABLE_ASSERTIONS=OFF',
-                        '-DLLVM_ENABLE_LTO=Full',
+                        '-DLLVM_BUILD_TESTS=OFF',
+                        '-DLLVM_INCLUDE_TESTS=OFF',
+                        '-DLLVM_ENABLE_LTO=Thin',
                         '-DLLVM_ENABLE_LLD=ON'])
     else:
         command.extend(['-DLLVM_ENABLE_ASSERTIONS=ON'])

--- a/src/build.py
+++ b/src/build.py
@@ -769,9 +769,11 @@ def OverrideCMakeCompiler():
         '-DCMAKE_CXX_COMPILER=' + Executable(GetPrebuiltClang(cxx)),
     ]
     if IsWindows():
-        tools.append('-DCMAKE_LINKER=' +  Executable(GetPrebuiltClang('lld-link')))
+        tools.append('-DCMAKE_LINKER=' +
+                     Executable(GetPrebuiltClang('lld-link')))
 
     return tools
+
 
 def CMakeCommandBase():
     command = [PrebuiltCMakeBin(), '-G', 'Ninja']
@@ -908,7 +910,6 @@ def LLVM():
                         '-DLLVM_ENABLE_LLD=ON'])
     else:
         command.extend(['-DLLVM_ENABLE_ASSERTIONS=ON'])
-
 
     jobs = host_toolchains.NinjaJobs()
 


### PR DESCRIPTION
This enables ThinLTO for LLVM and Binaryen and disables assertions on LLVM. It's off by default.