### PR TITLE
Limit which LLVM tools are built in release/LTO mode

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -73,7 +73,7 @@ LLVM_VERSION = '12.0.0'
 # Update this number each time you want to create a clobber build.  If the
 # clobber_version.txt file in the build dir doesn't match we remove ALL work
 # dirs.  This works like a simpler version of chromium's landmine feature.
-CLOBBER_BUILD_TAG = 21
+CLOBBER_BUILD_TAG = 22
 
 V8_BUILD_SUBDIR = os.path.join('out.gn', 'x64.release')
 

--- a/src/build.py
+++ b/src/build.py
@@ -904,7 +904,6 @@ def LLVM():
         '-DCLANG_ENABLE_STATIC_ANALYZER=OFF',
     ], build_dir)
 
-
     if not IsMac():
         # LLD isn't fully baked on mac yet.
         command.append('-DLLVM_ENABLE_LLD=ON')
@@ -916,11 +915,11 @@ def LLVM():
                    'llvm-objdump', 'llvm-ranlib', 'llvm-readobj', 'llvm-size',
                    'llvm-strings', 'llvm-symbolizer']
         ninja_targets = ('distribution', 'install-distribution')
-        targets.extend(['llc', 'opt']) # TODO: remove uses of these upstream
+        targets.extend(['llc', 'opt'])  # TODO: remove uses of these upstream
         command.extend(['-DLLVM_ENABLE_ASSERTIONS=OFF',
                         '-DLLVM_INCLUDE_TESTS=OFF',
-                        '-DLLVM_TOOLCHAIN_TOOLS='+';'.join(targets),
-                        '-DLLVM_DISTRIBUTION_COMPONENTS='+';'.join(targets),
+                        '-DLLVM_TOOLCHAIN_TOOLS=' + ';'.join(targets),
+                        '-DLLVM_DISTRIBUTION_COMPONENTS=' + ';'.join(targets),
                         '-DLLVM_ENABLE_LTO=Thin'])
 
     else:
@@ -930,9 +929,9 @@ def LLVM():
 
     proc.check_call(command, cwd=build_dir, env=cc_env)
     proc.check_call(['ninja', '-v', ninja_targets[0]] + jobs,
-                     cwd=build_dir, env=cc_env)
+                    cwd=build_dir, env=cc_env)
     proc.check_call(['ninja', ninja_targets[1]] + jobs,
-                     cwd=build_dir, env=cc_env)
+                    cwd=build_dir, env=cc_env)
     CopyLLVMTools(build_dir)
     install_bin = GetInstallDir('bin')
     for target in ('clang', 'clang++'):

--- a/src/build.py
+++ b/src/build.py
@@ -930,9 +930,9 @@ def LLVM():
     jobs = host_toolchains.NinjaJobs()
 
     proc.check_call(command, cwd=build_dir, env=cc_env)
-    proc.check_call(['ninja', '-v', ninja_targets[0] + jobs,
+    proc.check_call(['ninja', '-v', ninja_targets[0]] + jobs,
                      cwd=build_dir, env=cc_env)
-    proc.check_call(['ninja', nninja_targets[1] + jobs,
+    proc.check_call(['ninja', ninja_targets[1]] + jobs,
                      cwd=build_dir, env=cc_env)
     CopyLLVMTools(build_dir)
     install_bin = GetInstallDir('bin')

--- a/src/build.py
+++ b/src/build.py
@@ -925,7 +925,6 @@ def LLVM():
 
     else:
         command.extend(['-DLLVM_ENABLE_ASSERTIONS=ON'])
-        targets = []
 
     jobs = host_toolchains.NinjaJobs()
 


### PR DESCRIPTION
Reducing the number of link steps significantly reduces build time, and many of the built targets are not installed or used.
This uses the `LLVM_DISTRIBUTION_COMPONENTS` mechanism as documented in the [distribution guide](https://llvm.org/docs/BuildingADistribution.html).