### PR TITLE
Clobber the work dir of incremental builds on failure

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1415,7 +1415,7 @@ def ValidateLLVMTorture(indir, ext, opt):
 
 
 class Build(object):
-    def __init__(self, name_, runnable_, os_filter=None, is_default=True,
+    def __init__(self, name_, runnable_, os_filter=None,
                  incremental_build_dir=None, *args, **kwargs):
         self.name = name_
         self.runnable = runnable_
@@ -1433,11 +1433,11 @@ class Build(object):
                   (self.runnable.__name__, BuilderPlatformName()))
             return
 
+        # When using LTO we always want a clean build (the previous
+        # build was non-LTO)
+        if self.incremental_build_dir and options.use_lto:
+            RemoveIfBot(self.incremental_build_dir)
         try:
-            # When using LTO we always want a clean build (the previous
-            # build was non-LTO)
-            if self.incremental_build_dir and options.use_lto:
-                RemoveIfBot(self.incremental_build_dir)
             self.runnable(*self.args, **self.kwargs)
         except Exception:
             # If the build fails (even non-LTO), a possible cause is a build
@@ -1447,7 +1447,7 @@ class Build(object):
             raise
         finally:
             # When using LTO we want to always clean up afterward,
-            # (the next build will be non-LTO.
+            # (the next build will be non-LTO).
             if self.incremental_build_dir and options.use_lto:
                 RemoveIfBot(self.incremental_build_dir)
 

--- a/src/build.py
+++ b/src/build.py
@@ -1440,7 +1440,7 @@ class Build(object):
             if self.incremental_build_dir and options.use_lto:
                 ClobberOneDir(self.incremental_build_dir)
             self.runnable(*self.args, **self.kwargs)
-        except:
+        except Exception:
             # If the build fails (even non-LTO), a possible cause is a build
             # config change, so clobber the work dir for next time.
             if self.incremental_build_dir:
@@ -1496,14 +1496,17 @@ def AllBuilds():
     return [
         # Host tools
         Build('llvm', LLVM,
-              incremental_build_dir=os.path.join(work_dirs.GetBuild(), 'llvm-out')),
+              incremental_build_dir=os.path.join(
+                  work_dirs.GetBuild(), 'llvm-out')),
         Build('llvm-test-depends', LLVMTestDepends),
         Build('v8', V8, os_filter=Filter(exclude=['mac'])),
         Build('jsvu', Jsvu, os_filter=Filter(exclude=['windows'])),
         Build('wabt', Wabt,
-              incremental_build_dir=os.path.join(work_dirs.GetBuild(), 'wabt-out')),
+              incremental_build_dir=os.path.join(
+                  work_dirs.GetBuild(), 'wabt-out')),
         Build('binaryen', Binaryen,
-              incremental_build_dir=os.path.join(work_dirs.GetBuild(), 'binaryen-out')),
+              incremental_build_dir=os.path.join(
+                  work_dirs.GetBuild(), 'binaryen-out')),
         Build('emscripten-upstream', Emscripten),
         # Target libs
         # TODO: re-enable wasi on windows, see #517

--- a/src/build.py
+++ b/src/build.py
@@ -693,10 +693,9 @@ def AllSources():
     ]
 
 
-def ClobberOneDir(work_dir):
+def RemoveIfBot(work_dir):
     if buildbot.IsBot():
         Remove(work_dir)
-        Mkdir(work_dir)
 
 
 def Clobber():
@@ -728,7 +727,7 @@ def Clobber():
     else:
         dirs = work_dirs.GetAll()
     for work_dir in dirs:
-        ClobberOneDir(work_dir)
+        RemoveIfBot(work_dir)
     # Also clobber v8
     v8_dir = os.path.join(work_dirs.GetV8(), V8_BUILD_SUBDIR)
     Remove(v8_dir)
@@ -1438,19 +1437,19 @@ class Build(object):
             # When using LTO we always want a clean build (the previous
             # build was non-LTO)
             if self.incremental_build_dir and options.use_lto:
-                ClobberOneDir(self.incremental_build_dir)
+                RemoveIfBot(self.incremental_build_dir)
             self.runnable(*self.args, **self.kwargs)
         except Exception:
             # If the build fails (even non-LTO), a possible cause is a build
             # config change, so clobber the work dir for next time.
             if self.incremental_build_dir:
-                ClobberOneDir(self.incremental_build_dir)
+                RemoveIfBot(self.incremental_build_dir)
             raise
         finally:
             # When using LTO we want to always clean up afterward,
             # (the next build will be non-LTO.
             if self.incremental_build_dir and options.use_lto:
-                ClobberOneDir(self.incremental_build_dir)
+                RemoveIfBot(self.incremental_build_dir)
 
 
 def Summary():


### PR DESCRIPTION
Also clobber before and after LTO builds.

This is accomplished by hooking into the `Run` method that runs all build rules. 
Because of that, I also moved the specification of which directory is the build directory out of the body of each build function (so the build runner could access it)