### PR TITLE
Build Binaryen with static libs when using LTO

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1081,6 +1081,7 @@ def Binaryen(build_dir):
 
     cmake_command = CMakeCommandNative([GetSrcDir('binaryen')], build_dir)
     if options.use_lto:
+        cmake_command.append('-DBUILD_STATIC_LIB=ON')
         cmake_command.append('-DBYN_ENABLE_LTO=ON')
 
     proc.check_call(cmake_command, cwd=build_dir, env=cc_env)


### PR DESCRIPTION
This bloats the tool install size by about 30MB but also improves
speed by about 17% (using the totally-scientific metric of timing
check.py on my desktop)