### PR TITLE
Trigger LTO builds on locally-modified version file

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -547,7 +547,7 @@ def RevisionModifiesFile(f):
     # If the file is modified in the index or working tree, then return true.
     # This happens on trybots.
     status = proc.check_output(['git', 'status', '--porcelain', f],
-                               cwd=cwd).decode().strip()
+                               cwd=cwd).strip()
     changed = len(status) != 0
     s = status if changed else '(unchanged)'
     print('%s git status: %s' % (f, s))


### PR DESCRIPTION
Currently LTO builds are only triggered when the most recent commit modifies
the version file. But on try jobs, the files changed by the CL are not
committed; they are just modified in the index. So this change causes
LTO builds to also be triggered when the version file is modified
according to 'git status'.