### PR TITLE
Suppress optional dependencies when installing native closure compiler

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1157,7 +1157,8 @@ def InstallEmscripten():
         native = 'google-closure-compiler-windows'
     elif IsLinux():
         native = 'google-closure-compiler-linux'
-    proc.check_call(['npm', 'install', '--no-optional', native], cwd=em_install_dir)
+    proc.check_call(['npm', 'install', '--no-optional', native],
+                    cwd=em_install_dir)
 
     version_file = GetSrcDir(EMSCRIPTEN_VERSION_FILE)
     if os.path.isfile(version_file):

--- a/src/build.py
+++ b/src/build.py
@@ -1157,7 +1157,7 @@ def InstallEmscripten():
         native = 'google-closure-compiler-windows'
     elif IsLinux():
         native = 'google-closure-compiler-linux'
-    proc.check_call(['npm', 'install', native], cwd=em_install_dir)
+    proc.check_call(['npm', 'install', '--no-optional', native], cwd=em_install_dir)
 
     version_file = GetSrcDir(EMSCRIPTEN_VERSION_FILE)
     if os.path.isfile(version_file):


### PR DESCRIPTION
Without this, the 'npm install' step installs a *second* copy
of the native google-closure-compiler-{os} package (as a dependency inside
the google-closure-compiler directory) in addition to the one installed
at the top level by the primary command.