### PR TITLE
Pass correct SDK path to build's setup_toolchain utility

### DIFF
--- a/src/host_toolchains.py
+++ b/src/host_toolchains.py
@@ -96,8 +96,8 @@ def SetUpVSEnv(outdir):
     # environment block
     runtime_dirs = os.pathsep.join(paths['runtime_dirs'])
     proc.check_call(SetupToolchain() +
-                    ['foo', paths['win_sdk'], runtime_dirs, 'win', 'x64',
-                     'environment.x64'],
+                    [paths['path'], paths['win_sdk'], runtime_dirs, 'win',
+                     'x64', 'environment.x64'],
                     cwd=outdir)
     return GetVSEnv(outdir)
 


### PR DESCRIPTION
When using Chrome's hermetic toolchain, we also use a build infra utility to
set up the environment variables that VS-compatible toolchains expect.
Until recently one of the arguments to that script was irrelevant for us,
but it recently became required (now the first argument points to the
root of the toolchain package, and the 2nd sdk_path must be a subdir).